### PR TITLE
Tweak color contrast and spacing for easier reading

### DIFF
--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -1,20 +1,21 @@
 html {
     overflow-y: scroll;
 }
+
 html, body {
     width: 100%;
     height: 100%;
     margin: 0 0 0 0;
     color: $default-color;
     font-family: 'Fira Sans', sans-serif;
-    background-color: #232326;
+    background-color: $background-color;
 }
+
 @media screen and (max-width: 650px) {
     html, body {
         font-size: 0.7rem;
     }
 }
-
 
 .container {
     max-width: 1200px;

--- a/sass/_features.scss
+++ b/sass/_features.scss
@@ -1,7 +1,6 @@
 .bevy-logo-header {
     display: block;
-    margin-left: auto;
-    margin-right: auto;
+    margin: 2em auto;
     width: 100%;
     max-width: 35rem;
 }
@@ -10,7 +9,7 @@
     text-align: center;
     margin-top: 1.5rem;
     font-size: 1.5rem;
-    font-weight: 500;
+    font-weight: 300;
 }
 
 .feature-list {
@@ -26,6 +25,12 @@
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
+    align-items: start;
+    margin: 0.5em auto;
+
+    &:nth-child(odd) .feature-image {
+        order: 2;
+    }
 }
 
 .feature-container-reverse {
@@ -33,12 +38,15 @@
 }
 
 .feature-title {
-    margin-top: 1.0rem;
-    margin-bottom: 0.3rem;
+    margin: 0.5em 0;
 }
 
 .feature-description {
-    font-size: 1.3rem;
+    font-weight: 300;
+}
+
+.feature-description strong {
+    font-weight: 500;
 }
 
 .feature-image {
@@ -54,7 +62,6 @@
 
 .feature-text {
     max-height: 18rem;
-    align-self: center;
 }
 
 .feature-image, .feature-text {
@@ -66,9 +73,7 @@
 }
 
 .feature-sublist {
-    margin-top: 0.5rem;
-    margin-bottom: 0.5rem;
-    margin-left: 0px;
+    margin: 1rem 0;
     padding-left: 2rem;
     font-size: 1.2rem;
 }

--- a/sass/_headerbar.scss
+++ b/sass/_headerbar.scss
@@ -2,7 +2,7 @@
     width: 100%;
     background-color: $headerbar-color;
     margin: 0;
-    box-shadow: 0px 0px 10px #333333;
+    box-shadow: 0px 0px 10px #111;
 }
 
 .headerbar {
@@ -37,44 +37,54 @@
     align-items: center;
 }
 
-.header-push {
-    margin-right: auto;
-}
-
 .header-item, .header-item:visited, .header-item:link {
-    font-weight: 500;
+    font-weight: 400;
     font-size: 1.4rem;
-    margin-left: 0.7rem;
+    margin: 0 0.5rem;
     color: $default-color;
     font-style: normal;
     text-decoration: none;
-}
 
-.header-item:active, .header-item:hover, .header-item-active {
-    color: $hover-color;
-    text-shadow: 0 0 1px $hover-shadow-color, 0 0 1px $hover-shadow-color;
-}
+    &.header-push {
+        margin-right: auto;
+    }
 
-$header-active-color: #b1d9ff;
-.header-item-active, .header-item-active:hover {
-    color: $header-active-color !important;
-    text-shadow: 0 0 1px $header-active-color, 0 0 1px $header-active-color;
+    &:active,
+    &:hover {
+        color: $hover-color;
+        text-shadow: 0 0 1px $hover-shadow-color, 0 0 1px $hover-shadow-color;
+    }
+
+    &.header-item-active,
+    &.header-item-active:hover {
+        color: $header-active-color;
+        text-shadow: 0 0 1px $header-active-shadow-color, 0 0 1px $header-active-shadow-color;
+        font-weight: 500;
+    }
 }
 
 .header-message {
     text-align: center;
     color: #797979;
-    font-size: 2.3rem;
+    font-size: 2rem;
+    font-weight: 300;
+    margin: 0 1rem;
+
+    h1 {
+        font-size: 2rem;
+        font-weight: 400;
+    }
 }
 
-.header-button {
-    background-color: #799bbb;
+.header-button, .header-button:visited, .header-button:link {
+    color: $header-button-color;
+    background-color: $header-button-background-color;
     border-style: solid;
-    border-color: #576f86;
+    border-color: $header-button-border-color;
     border-width: 3px;
-    padding: 0.4rem;
     border-radius: 10px;
-    font-size: 1.2rem !important;
+    font-size: 1.2rem;
+    padding: 0.5rem 1rem;
 }
 
 @media screen and (max-width: 450px) {

--- a/sass/site.scss
+++ b/sass/site.scss
@@ -1,11 +1,16 @@
 @charset "utf-8";
 
-
-$headerbar-color: #1e1e22;
+$background-color: #161619;
+$headerbar-color: #212125;
+$header-active-color: #b1d9ff;
+$header-active-shadow-color: transparentize($header-active-color, 0.5);
+$header-button-color: white;
+$header-button-background-color: darken(desaturate(#799bbb, 0%), 15%);
+$header-button-border-color: lighten(#799bbb, 20%);
 $hover-color: #ececec;
-$hover-shadow-color: #d6d6d6;
+$hover-shadow-color: transparentize($hover-color, 0.5);
 $link-color: #7c90ff;
-$link-hover-shadow-color: #6c82ff;
+$link-hover-shadow-color: transparentize($link-color, 0.5);
 $default-color: #ececec;
 $content-top-margin: 30px;
 $default-padding: 15px;

--- a/templates/base.html
+++ b/templates/base.html
@@ -15,7 +15,7 @@
 {% set path = ""%}
 {% endif %}
 
-<html lang="en">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en" >
     <head>
         <meta charset="UTF-8">
         <meta name='viewport' content="width=device-width, initial-scale=1" />
@@ -40,6 +40,7 @@
                     <img src="/assets/bevy_icon_dark.svg" class="logo" alt="bevy icon" />
                 </a>
                 <div class="header-item header-message">
+                    <h1>
                     {% if section and section.extra.header_message %}
                     {{section.extra.header_message}}
                     {% elif page and page.extra.header_message %}
@@ -53,6 +54,7 @@
                     {% else %}
                         Features
                     {% endif %}
+                    </h1>
                 </div>
                 <div class="header-item header-push"></div>
                 {{header_macros::header_item(name="Features", path="/", current_path=current_path)}}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,186 +1,209 @@
 {% extends "base.html" %}
 
 {% block content %}
-<div class="padded-content container">
-    <img src="/assets/bevy_logo_dark.svg" class="bevy-logo-header" />
+<div class="padded-content container" role="main">
+    <img src="/assets/bevy_logo_dark.svg" alt="The Bevy project logo" class="bevy-logo-header" />
     <div class="bevy-description">
-        A refreshingly simple data-driven game engine built in Rust
-        <br />
-        Free and Open Source Forever!
+        A refreshingly simple data-driven game engine built in Rust.
+        <p><strong>Free and Open Source Forever!</strong></p>
     </div>
     <div class="feature-list">
         <div class="feature-container">
+            <div class="feature-image">
+                <img src="assets/ecs.svg" alt="Example system code" class="feature-img" style="margin-left: 10%; margin-right: auto;" />
+            </div>
             <div class="feature-text">
                 <h2 class="feature-title">Data Driven</h2>
                 <div class="feature-description">
                     All engine and game logic uses Bevy ECS, a custom Entity Component System
                     <ul class="feature-sublist">
-                        <li><b>Fast:</b> Massively Parallel and Cache-Friendly. The fastest ECS according to some
-                            benchmarks</li>
-                        <li><b>Simple:</b> Components are Rust structs, Systems are Rust functions</li>
-                        <li><b>Capable:</b> Queries, Global Resources, Local Resources, Change Detection, Lock-Free
-                            Parallel Scheduler</li>
+                        <li><strong>Fast:</strong> Massively Parallel and Cache-Friendly. The fastest ECS according to
+                            some benchmarks.</li>
+                        <li><strong>Simple:</strong> Components are Rust structs, Systems are Rust functions</li>
+                        <li><strong>Capable:</strong> Queries, Global Resources, Local Resources, Change Detection,
+                            Lock-Free Parallel Scheduler</li>
                     </ul>
                 </div>
             </div>
-            <div class="feature-image">
-                <img src="assets/ecs.svg" class="feature-img" style="margin-left: 10%; margin-right: auto;" />
-            </div>
-
         </div>
         <div class="feature-container feature-container-reverse">
             <div class="feature-image">
-                <img src="assets/sprite.png" class="feature-img" />
+                <img src="assets/sprite.png" alt="A 2D character sprite" class="feature-img" />
             </div>
             <div class="feature-text">
                 <h2 class="feature-title">2D Renderer</h2>
                 <div class="feature-description">
                     Render real-time 2D graphics for games and apps
                     <ul class="feature-sublist">
-                        <li><b>Features: </b>sprite sheets, dynamic texture atlases, cameras, textures, and materials
-                        </li>
-                        <li><b>Extensible: </b>custom shaders, materials, and render pipelines</li>
-                        <li><b>Common Core: </b>builds on top of Bevy's Render Graph</li>
+                        <li><strong>Features:</strong> sprite sheets, dynamic texture atlases, cameras, textures, and
+                            materials</li>
+                        <li><strong>Extensible:</strong> custom shaders, materials, and render pipelines</li>
+                        <li><strong>Common Core:</strong> Builds on top of Bevy's Render Graph</li>
                     </ul>
                 </div>
             </div>
         </div>
         <div class="feature-container">
+            <div class="feature-image">
+                <img src="assets/boat.png" alt="A 3D rendering of a boat" class="feature-img" style="max-height: 95%; max-width: 95%;" />
+            </div>
             <div class="feature-text">
                 <h2 class="feature-title">3D Renderer</h2>
-                A modern and flexible 3D renderer
-                <ul class="feature-sublist">
-                    <li><b>Features: </b>lights, cameras, meshes, textures, materials, gltf loading</li>
-                    <li><b>Extensible: </b>custom shaders, materials, and render pipelines</li>
-                    <li><b>Common Core: </b>built on top of Bevy's Render Graph</li>
-                </ul>
-            </div>
-            <div class="feature-image">
-                <img src="assets/boat.png" class="feature-img" style="max-height: 95%; max-width: 95%;" />
+                <div class="feature-description">
+                    A modern and flexible 3D renderer
+                    <ul class="feature-sublist">
+                        <li><strong>Features:</strong> lights, cameras, meshes, textures, materials, GLTF loading</li>
+                        <li><strong>Extensible:</strong> custom shaders, materials, and render pipelines</li>
+                        <li><strong>Common Core:</strong> Built on top of Bevy's Render Graph</li>
+                    </ul>
+                </div>
             </div>
         </div>
         <div class="feature-container feature-container-reverse">
             <div class="feature-image">
-                <img src="assets/render_graph.svg" class="feature-img" />
+                <img src="assets/render_graph.svg" alt="A conceptual illustration of a rendering graph"
+                     class="feature-img" />
             </div>
             <div class="feature-text">
                 <h2 class="feature-title">Render Graph</h2>
-                Compose custom render pipelines using a graph structure
-                <ul class="feature-sublist">
-                    <li><b>Parallel: </b> Render Graphs are automatically rendered in parallel</li>
-                    <li><b>Modular: </b> Build composable and reusable render logic using Render Graph nodes </li>
-                    <li><b>Backend Agnostic: </b> Not tied to a specific graphics api</li>
-                </ul>
+                <div class="feature-description">
+                    Compose custom render pipelines using a graph structure
+                    <ul class="feature-sublist">
+                        <li><strong>Parallel:</strong> Render Graphs are automatically rendered in parallel</li>
+                        <li><strong>Modular:</strong> Build composable and reusable render logic using Render Graph
+                            nodes</li>
+                        <li><strong>Backend Agnostic:</strong> Not tied to a specific graphics API</li>
+                    </ul>
+                </div>
             </div>
         </div>
         <div class="feature-container">
+            <div class="feature-image">
+                <img src="assets/platform-icons.svg" alt="Windows, macOS and Linux logos" class="feature-img" />
+            </div>
             <div class="feature-text">
                 <h2 class="feature-title">Cross Platform</h2>
                 <div class="feature-description">
                     Support for all major desktop platforms:
                     <ul class="feature-sublist">
-                        <li>Windows, MacOS, Linux</li>
+                        <li>Windows</li>
+                        <li>MacOS</li>
+                        <li>Linux</li>
                     </ul>
                     With more on the way:
                     <ul class="feature-sublist">
-                        <li>Android, iOS, Web</li>
+                        <li>Android</li>
+                        <li>iOS</li>
+                        <li>Web</li>
                     </ul>
                 </div>
             </div>
         </div>
-        <div class="feature-image">
-            <img src="assets/platform-icons.svg" class="feature-img" />
-        </div>
         <div class="feature-container feature-container-reverse">
             <div class="feature-image">
-                <img src="assets/bevy_ui.svg" class="feature-img" />
+                <img src="assets/bevy_ui.svg" alt="An illustration of a user interface" class="feature-img" />
             </div>
             <div class="feature-text">
                 <h2 class="feature-title">Bevy UI</h2>
-                A custom ECS-driven UI framework built specifically for Bevy
-                <ul class="feature-sublist">
-                    <li>Built directly on top of Bevy's ECS, Renderer, and Scene plugins</li>
-                    <li>Compose UIs dynamically in code or declaratively using the Bevy Scene format</li>
-                    <li>Use a familiar "flex box" model to layout your UIs</li>
-                </ul>
+                <div class="feature-description">
+                    A custom ECS-driven UI framework built specifically for Bevy
+                    <ul class="feature-sublist">
+                        <li>Built directly on top of Bevy's ECS, Renderer, and Scene plugins</li>
+                        <li>Compose UIs dynamically in code or declaratively using the Bevy Scene format</li>
+                        <li>Use a familiar "flex box" model to layout your UIs</li>
+                    </ul>
+                </div>
             </div>
         </div>
         <div class="feature-container">
+            <div class="feature-image">
+                <img src="assets/scene.svg" alt="An illustration of a video game scene" class="feature-img" />
+            </div>
             <div class="feature-text">
                 <h2 class="feature-title">Scenes</h2>
-                Create, save, and load ECS worlds using Bevy's Scene system
-                <ul class="feature-sublist">
-                    <li><b>Loading</b>: Loading scenes preserves entity IDs (useful for save games)</li>
-                    <li><b>Instancing</b>: Instancing creates linked duplicates of scenes with new entity IDs</li>
-                    <li><b>Hot Reloading</b>: Changes to scene files are automatically applied to running apps</li>
-                </ul>
-            </div>
-            <div class="feature-image">
-                <img src="assets/scene.svg" class="feature-img" />
+                <div class="feature-description">
+                    Create, save, and load ECS worlds using Bevy's Scene system
+                    <ul class="feature-sublist">
+                        <li><strong>Loading</strong>: Loading scenes preserves entity IDs (useful for save games)</li>
+                        <li><strong>Instancing</strong>: Instancing creates linked duplicates of scenes with new entity
+                            IDs</li>
+                        <li><strong>Hot Reloading</strong>: Changes to scene files are automatically applied to running
+                            apps</li>
+                    </ul>
+                </div>
             </div>
         </div>
         <div class="feature-container feature-container-reverse">
             <div class="feature-image">
-                <img src="assets/sound.svg" class="feature-img" />
+                <img src="assets/sound.svg" alt="Musical notes" class="feature-img" />
             </div>
             <div class="feature-text">
                 <h2 class="feature-title">Sound</h2>
-                Load audio files and play them on demand
-                <ul class="feature-sublist">
-                    <li>Load mp3 audio files as Assets</li>
-                    <li>Play audio files using the AudioOutput resource</li>
-                </ul>
+                <div class="feature-description">
+                    Load audio files and play them on demand
+                    <ul class="feature-sublist">
+                        <li>Load mp3 audio files as Assets</li>
+                        <li>Play audio files using the AudioOutput resource</li>
+                    </ul>
+                </div>
             </div>
         </div>
         <div class="feature-container">
+            <div class="feature-image">
+                <img src="assets/hot_reloading.svg" alt="An illustration depicting easy hot reloading of assets"
+                     class="feature-img" />
+            </div>
             <div class="feature-text">
                 <h2 class="feature-title">Hot Reloading</h2>
-                Get instant feedback on your changes without app restarts or recompiles
-                <ul class="feature-sublist">
-                    <li>Asset changes are immediately reflected in running Bevy apps</li>
-                    <li>You can currently hot-reload scenes, textures, and meshes</li>
-                    <li>Any asset type can be integrated</li>
-                </ul>
-            </div>
-            <div class="feature-image">
-                <img src="assets/hot_reloading.svg" class="feature-img" />
+                <div class="feature-description">
+                    Get instant feedback on your changes without app restarts or recompiles
+                    <ul class="feature-sublist">
+                        <li>Asset changes are immediately reflected in running Bevy apps</li>
+                        <li>You can currently hot-reload scenes, textures, and meshes</li>
+                        <li>Any asset type can be integrated</li>
+                    </ul>
+                </div>
             </div>
         </div>
         <div class="feature-container feature-container-reverse">
             <div class="feature-image">
-                <img src="assets/progressbar.svg" class="feature-img" />
+                <img src="assets/progressbar.svg" alt="A progress bar nearing completion" class="feature-img" />
             </div>
             <div class="feature-text">
                 <h2 class="feature-title">Productive Compile Times</h2>
-                Game development is an iterative process. You can't afford to wait for compiles
-                <ul class="feature-sublist">
-                    <li>With Bevy you can expect 0.8-3.0 seconds with the "fast compiles" configuration</li>
-                    <li>Compare that to other popular Rust game engines, which can take over 30 seconds to compile a
-                        single
-                        newline insertion!</li>
-                </ul>
+                <div class="feature-description">
+                    Game development is an iterative process. You can't afford to wait for compiles
+                    <ul class="feature-sublist">
+                        <li>With Bevy you can expect 0.8-3.0 seconds with the "fast compiles" configuration</li>
+                        <li>Compare that to other popular Rust game engines, which can take over 30 seconds to compile a
+                            single newline insertion!</li>
+                    </ul>
+                </div>
             </div>
         </div>
         <div class="feature-container">
+            <div class="feature-image">
+                <img src="assets/opensource.svg" alt="An emblem depicting this project as Open Source Software"
+                     class="feature-img" />
+            </div>
             <div class="feature-text">
                 <h2 class="feature-title">Free and Open Source</h2>
-                An engine made by and for the developer community
-                <ul class="feature-sublist">
-                    <li>100% free. Forever and always</li>
-                    <li>Open Source under the permissive MIT license</li>
-                    <li>No contracts</li>
-                    <li>No license fees</li>
-                    <li>No sales cuts</li>
-                </ul>
-            </div>
-            <div class="feature-image">
-                <img src="assets/opensource.svg" class="feature-img" />
+                <div class="feature-description">
+                    An engine made by and for the developer community
+                    <ul class="feature-sublist">
+                        <li>100% free. Forever and always</li>
+                        <li>Open Source under the permissive MIT license</li>
+                        <li>No contracts</li>
+                        <li>No license fees</li>
+                        <li>No sales cuts</li>
+                    </ul>
+                </div>
             </div>
         </div>
     </div>
     <div class="media-content features-whats-next">
         Ready to start building Bevy apps? Get started fast with <a href="learn/book/introduction/">The Bevy Book!</a>
     </div>
-    <img src="/assets/bevy_logo_dark.svg" class="bevy-logo-header" />
+    <img src="/assets/bevy_logo_dark.svg" alt="The Bevy project logo" class="bevy-logo-header" />
 </div>
 {% endblock content %}


### PR DESCRIPTION
Thought I'd put a little bit of time tonight into tweaking the landing page for a little bit of visual clarity/accessibility improvements. I tried to stay true to the spirit of the existing site. Let me know if you want me to undo something. Some things included:

- While the contrast of background+text passed a11y checkers like WAVE, I personally found it a little bit difficult on the eyes due to the combination of contrast + font weights, so I adjusted both.
- Adjusted contrast of the "Get Started" button. I'm not that happy with where it landed aesthetically. it at least passes a11y tests now
- Attempted to make spacing of elements a little bit more rhythmically consistent, because I have a compulsion
- Added alt tags to images for screen reading

Tackles a little bit of #3, there are still some small tweaks that can help with a11y checks -- easiest thing to do is just put the site into a [tool like this](https://wave.webaim.org/) and work through them. This PR knocks a few out.

Before
![before](https://user-images.githubusercontent.com/2466322/89975009-29827300-dc54-11ea-857e-5a275f15acee.png)

After
![after](https://user-images.githubusercontent.com/2466322/89975019-2c7d6380-dc54-11ea-9466-6ef52df58d11.png)
