### PR TITLE
Improve Ergonomics Example

### DIFF
--- a/content/news/2020-08-10-introducing-bevy/index.md
+++ b/content/news/2020-08-10-introducing-bevy/index.md
@@ -136,6 +136,7 @@ fn movement(mut position: Mut<Position>, velocity: &Velocity) {
 // the app entry point. hopefully you recognize it from the examples above!
 fn main() {
     App::build()
+        .add_default_plugins()
         .add_startup_system(setup.system())
         .add_system(movement.system())
         .run();


### PR DESCRIPTION
Add default plugins so `movement` system runs repeatedly.

`add_default_plugins()` was already introduced earlier, so it's not a new concept.  Without it, the `movement` system runs only once, which makes it hard to see the difference between `add_startup_system` and `add_system`.

If the extra line is still deemed too much or distracting, I'm happy to just close the pull request.