### PR TITLE
Change windows to include using binutils

### DIFF
--- a/content/learn/book/getting-started/setup/_index.md
+++ b/content/learn/book/getting-started/setup/_index.md
@@ -76,7 +76,11 @@ Bevy can be built just fine using default configuration on stable Rust. However 
 * **LLD linker**: The Rust compiler spends a lot of time in the "link" step. LLD is _much faster_ at linking than the default Rust linker. To install LLD, find your OS below and run the given command:
     * **Ubuntu**: `sudo apt-get install lld`
     * **Arch**: `sudo pacman -S lld`
-    * **Windows**: Go to next step, Bevy's cargo config uses the Rust bundled lld
+    * **Windows**: Ensure you have the latest [cargo-binutils](https://github.com/rust-embedded/cargo-binutils)
+        ```
+        cargo install -f cargo-binutils
+        rustup component add llvm-tools-preview
+        ```
     * **MacOS**: Modern LLD does not yet support MacOS, but we can use zld instead: `brew install michaeleisel/zld/zld`
 * **Nightly Rust Compiler**: This gives access to the latest performance improvements and "unstable" optimizations
     ```


### PR DESCRIPTION
 It was changed to use rust-lld instead, but it doesn't specify that you need to install cargo-binutils, as rust-lld is not shipped by default for most platforms. Cargo-binutils adds rust-lld, and llvm-tools-preview adds the actual lld executable to your toolchain.