### PR TITLE
Only 'build' for pull requests. Build AND deploy for pushes (merges) to master.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ name: CI
 #  or any pull request or pull request
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
@@ -15,25 +15,25 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref != 'refs/heads/master' # Only on PRs, see also build_and_deploy below
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: 'Build website'
-      uses: shalzz/zola-deploy-action@master
-      env:
-        PAGES_BRANCH: gh-pages
-        BUILD_DIR: .
-        BUILD_ONLY: true
-        TOKEN: ${{secrets.TOKEN}}
+      - name: "Build website"
+        uses: shalzz/zola-deploy-action@master
+        env:
+          PAGES_BRANCH: gh-pages
+          BUILD_DIR: .
+          BUILD_ONLY: true
+          TOKEN: fake-secret
 
   build_and_deploy:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master' # Only on a push to the master branch (like when PR's are merged)
     steps:
-    - uses: actions/checkout@master
+      - uses: actions/checkout@master
 
-    - name: 'Build and deploy website'
-      uses: shalzz/zola-deploy-action@master
-      env:
-        PAGES_BRANCH: gh-pages
-        BUILD_DIR: .
-        TOKEN: ${{ secrets.TOKEN }}
+      - name: "Build and deploy website"
+        uses: shalzz/zola-deploy-action@master
+        env:
+          PAGES_BRANCH: gh-pages
+          BUILD_DIR: .
+          TOKEN: ${{ secrets.TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,29 +2,37 @@
 
 name: CI
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
+# Controls when the action will run. Triggers the workflow on pushes to master
+#  or any pull request or pull request
 on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
+    if: github.ref != 'refs/heads/master' # Only on PRs, see also build_and_deploy below
     steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
 
-    # Runs a single command using the runners shell
     - name: shalzz/zola-deploy-action
       uses: shalzz/zola-deploy-action@master
       env:
         PAGES_BRANCH: gh-pages
+        BUILD_DIR: .
+        BUILD_ONLY: true
         TOKEN: ${{secrets.TOKEN}}
+
+  build_and_deploy:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master' # Only on a push to the master branch (like when PR's are merged)
+    steps:
+    - uses: actions/checkout@master
+    - name: 'Build and deploy'
+      uses: shalzz/zola-deploy-action@master
+      env:
+        PAGES_BRANCH: gh-pages
+        BUILD_DIR: .
+        TOKEN: ${{ secrets.TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: shalzz/zola-deploy-action
+    - name: 'Build'
       uses: shalzz/zola-deploy-action@master
       env:
         PAGES_BRANCH: gh-pages

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,7 @@ jobs:
         PAGES_BRANCH: gh-pages
         BUILD_DIR: .
         BUILD_ONLY: true
+        TOKEN: ${{secrets.TOKEN}}
 
   build_and_deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,6 @@ jobs:
         PAGES_BRANCH: gh-pages
         BUILD_DIR: .
         BUILD_ONLY: true
-        TOKEN: ${{secrets.TOKEN}}
 
   build_and_deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: 'Build'
+    - name: 'Build website'
       uses: shalzz/zola-deploy-action@master
       env:
         PAGES_BRANCH: gh-pages
@@ -30,7 +30,8 @@ jobs:
     if: github.ref == 'refs/heads/master' # Only on a push to the master branch (like when PR's are merged)
     steps:
     - uses: actions/checkout@master
-    - name: 'Build and deploy'
+
+    - name: 'Build and deploy website'
       uses: shalzz/zola-deploy-action@master
       env:
         PAGES_BRANCH: gh-pages


### PR DESCRIPTION
I noticed in https://github.com/bevyengine/bevy-website/pull/23 that the CI (luckily) failed to deploy the changed website to production.

Thrashing the web site with deployments from every commit of every pull request is _probably_ not what was intended, so this change makes it so that pull requests only attempt to _build_ the web site.  Later, when the pul request is merged to master then it will build _and_ deploy the web site.  Pushes straight to master will also build and deploy.