### PR TITLE
Add link to the awesome-bevy repo in Learn

### DIFF
--- a/templates/learn.html
+++ b/templates/learn.html
@@ -28,5 +28,18 @@
       </div>
     </div>
   </a>
+  <a class="card" href="https://github.com/bevyengine/awesome-bevy">
+    <div class="card-image">
+      <img src="/assets/github.svg" class="centered-card-image" />
+    </div>
+    <div class="card-text">
+      <div class="card-title">
+        Awesome Bevy
+      </div>
+      <div class="card-description">
+        Learn by example with an awesome-style list of cool Bevy projects.
+      </div>
+    </div>
+  </a>
 </div>
 {% endblock content %}


### PR DESCRIPTION
This adds a link to the [Awesome Bevy](https://github.com/bevyengine/awesome-bevy) repo, under Bevy Rust API Docs, in Learn.

Feel free to replace the card description with something else, currently it's:

> Learn by example with an awesome-style list of cool Bevy projects.