### PR TITLE
Remove whitespace from getting started command

### DIFF
--- a/content/learn/book/getting-started/_index.md
+++ b/content/learn/book/getting-started/_index.md
@@ -18,7 +18,7 @@ Note: the "fast compiles" setup is on the next page, so you might want to read t
 
 1. Clone the [Bevy repo](https://github.com/bevyengine/bevy):
     ```
-    git clone https://github.com/bevyengine/bevy    
+    git clone https://github.com/bevyengine/bevy
     ```
 2. Navigate to the new "bevy" folder
     ```


### PR DESCRIPTION
Not a big deal, but when you double click to copy the command and paste in your terminal, a bit of whitespace comes with it.