### PR TITLE
Fix Person Creation In Learn/Getting-Started/ECS

### DIFF
--- a/content/learn/book/getting-started/ecs/_index.md
+++ b/content/learn/book/getting-started/ecs/_index.md
@@ -78,9 +78,9 @@ We can then add `People` to our {{rust_type(type="struct" crate="bevy_ecs" name=
 ```rs
 fn add_people(mut commands: Commands) {
     commands
-        .spawn((Person, Name("Elaina Proctor".to_string())))
-        .spawn((Person, Name("Renzo Hume".to_string())))
-        .spawn((Person, Name("Zayna Nieves".to_string())));
+        .spawn((Person{}, Name("Elaina Proctor".to_string())))
+        .spawn((Person{}, Name("Renzo Hume".to_string())))
+        .spawn((Person{}, Name("Zayna Nieves".to_string())));
 }
 ```
 


### PR DESCRIPTION
Following the tutorial, After _index.md:115, we arrive at the following code:

```rust
use bevy::prelude::*;

struct Person{}

struct Name(String);

fn hello_world() {
    println!("Hello World");
}

fn add_people(mut commands: Commands) {
    commands
        .spawn((Person, Name("Elaina Proctor".to_string())))
        .spawn((Person, Name("Renzo Hume".to_string())))
        .spawn((Person, Name("Zanya Nieves".to_string())));
}

fn greet_people(_person: &Person, name: &Name) {
    println!("Hello {}", name.0);
}

fn main() {
    App::build()
        .add_startup_system(add_people.system())
        .add_system(hello_world.system())
        .add_system(greet_people.system())
        .run();
}
```

This will output `error[E0423]: expected value, found struct 'Person'` for the three lines related to spawn.

Properly instantiating the Person objects removes these errors and allows the code to compile.