### PR TITLE
Fix broken link to Wasm javascript function

### DIFF
--- a/content/news/2020-09-19-bevy-0.2/index.md
+++ b/content/news/2020-09-19-bevy-0.2/index.md
@@ -49,7 +49,7 @@ Those limitations haven't stopped @mrk-its from building the first WASM Bevy gam
 
 ![bevy-robbo](bevy-robbo.png)
 
-They use Bevy for game logic and cleverly work around the render limitations by passing ASCII art game state from [this Bevy system](https://github.com/mrk-its/bevy-robbo/blob/master/src/systems/js_render.rs) to [this JavaScript function](https://github.com/mrk-its/bevy-robbo/blob/master/wasm/render.js). 
+They use Bevy for game logic and cleverly work around the render limitations by passing ASCII art game state from [this Bevy system](https://github.com/mrk-its/bevy-robbo/blob/master/src/systems/js_render.rs) to [this JavaScript function](https://github.com/mrk-its/bevy-robbo/blob/master/assets/render.js). 
 
 You can play around with some Bevy WASM examples by [following the instructions here](https://github.com/bevyengine/bevy/tree/master/examples#wasm).
 


### PR DESCRIPTION
Point to the new location as of this commit:
https://github.com/mrk-its/bevy-robbo/commit/948587440919c9d05ababa488623d6c5e1f5785a