### PR TITLE
Added book nav toggle for mobile

### DIFF
--- a/sass/_book-nav.scss
+++ b/sass/_book-nav.scss
@@ -1,15 +1,24 @@
 $inactive-nav-color: #999999;
 
 @media screen and (max-width: 900px) {
+    #show-book-nav:not(:checked) + .book-nav {
+        transform: translateX(calc(0px - var(--book-nav-width)));
+    }
+
+    #show-book-nav:checked + .book-nav + .book-content {
+        transform: translateX(var(--book-nav-width));
+    }
+
     .book-nav {
-        display: none;
+        margin-right: calc(0px - var(--book-nav-width));
     }
 }
 
 .book-nav {
     margin-top: $content-padding;
-    min-width: 200px;
-    user-select: none; 
+    flex: 0 0 var(--book-nav-width);
+    user-select: none;
+    transition: transform 0.3s;
 }
 
 .book-nav-sections {
@@ -59,6 +68,10 @@ $inactive-nav-color: #999999;
 .book-nav-section-number {
     font-family: 'Fira Code', monospace;
     font-variant-ligatures: none;
-    font-size: 1rem; 
+    font-size: 1rem;
     margin-right: -0.2rem;
+}
+
+.book-content {
+    transition: transform 0.3s;
 }

--- a/sass/_headerbar.scss
+++ b/sass/_headerbar.scss
@@ -19,15 +19,20 @@
     height: 100%;
 }
 
-.header-logo, .header-logo-mobile {
+.header-logo, .header-logo-mobile, .toggle-nav-mobile {
     display: flex;
     height: 80%;
-    vertical-align: middle;
+    align-items: center;
 }
 
-.header-logo-mobile {
+.header-logo-mobile, .toggle-nav-mobile {
     height: 60%;
+    cursor: pointer;
     display: none;
+}
+
+.toggle-nav-mobile {
+    height: 100%;
 }
 
 .header-content {
@@ -103,7 +108,7 @@ $header-active-color: #b1d9ff;
 }
 
 @media screen and (max-width: 900px) {
-    .header-logo-mobile {
+    .header-logo-mobile, .toggle-nav-mobile {
         display: flex;
     }
 

--- a/sass/_variables.scss
+++ b/sass/_variables.scss
@@ -1,0 +1,3 @@
+:root {
+    --book-nav-width: 200px;
+}

--- a/sass/site.scss
+++ b/sass/site.scss
@@ -17,6 +17,7 @@ $card-hover-background: #2f3033;
 $media-max-width: 1000px;
 $border-radius: 10px;
 
+@import "variables";
 @import "headerbar";
 @import "community";
 @import "book";

--- a/templates/base.html
+++ b/templates/base.html
@@ -37,9 +37,21 @@
                 <a href="/" class="header-logo">
                     <img src="/assets/bevy_logo_dark.svg" class="logo" alt="bevy logo" />
                 </a>
-                <a href="/" class="header-logo-mobile">
-                    <img src="/assets/bevy_icon_dark.svg" class="logo" alt="bevy icon" />
-                </a>
+                {% if section and section.path is starting_with("/learn/book/") %}
+                    <label class="toggle-nav-mobile" for=show-book-nav>
+                        <svg alt="nav bars" width="24" height="24">
+                            <g fill="none" stroke="#ececec" stroke-width="2">
+                                <path d="m4 6h16" />
+                                <path d="m4 11h16" />
+                                <path d="m4 16h16" />
+                            </g>
+                        </svg>
+                    </label>
+                {% else %}
+                    <a href="/" class="header-logo-mobile">
+                        <img src="/assets/bevy_icon_dark.svg" class="logo" alt="bevy icon" />
+                    </a>
+                {% endif %}
                 <div class="header-item header-message">
                     {% if section and section.extra.header_message %}
                     {{section.extra.header_message}}

--- a/templates/book-section.html
+++ b/templates/book-section.html
@@ -6,6 +6,7 @@
 
 {% block content %}
 <div class="book-page">
+    <input type="checkbox" style="display: none" id="show-book-nav" />
     <nav class="book-nav" role="navigation">
         {% block menu %}
         {% set index = get_section(path="learn/book/_index.md") %}
@@ -43,7 +44,7 @@
             {% if result != "true" and result != "false" %}
                 {% set next_subsection_path = result %}
             {% endif %}
-        {% endif %} 
+        {% endif %}
         {% if next_subsection_path %}
             {% set next_section = get_section(path=next_subsection_path) %}
             <a id="book-pager-bar-next" href="{{next_section.permalink}}" class="book-pager-bar book-pager-bar-next">


### PR DESCRIPTION
Here's my solution to fix the book navigation not being visible on mobile. Basically what my changes do is if the url path starts with `/learn/book` it replaces the bevy mobile logo with bars to toggle the nav. When the bars are pressed or clicked the book-nav will slide in. Currently I've coded it so that the book-content will slide to the right when the book-nav is open, but if you'd prefer another solution, for example, maybe the book-nav should cover the content instead of it sliding to the right, just let me know. I can change the code to do that.

Closes #37