### PR TITLE
getting-started/setup: s/config/config.toml

### DIFF
--- a/content/learn/book/getting-started/setup/_index.md
+++ b/content/learn/book/getting-started/setup/_index.md
@@ -94,7 +94,7 @@ Bevy can be built just fine using default configuration on stable Rust. However 
     * You can use `cargo +nightly ...` if you don't want to change the default to nightly.
 * **Generic Sharing**: Allows crates to share monomorphized generic code instead of duplicating it. In some cases this allows us to "precompile" generic code so it doesn't affect iterative compiles. This is only available on nightly Rust.
 
-To enable fast compiles, install the nightly rust compiler and LLD. Then copy [this file](https://github.com/bevyengine/bevy/blob/master/.cargo/config_fast_builds) to `YOUR_WORKSPACE/.cargo/config`. For the project in this guide, that would be `my_bevy_game/.cargo/config`.
+To enable fast compiles, install the nightly rust compiler and LLD. Then copy [this file](https://github.com/bevyengine/bevy/blob/master/.cargo/config_fast_builds) to `YOUR_WORKSPACE/.cargo/config.toml`. For the project in this guide, that would be `my_bevy_game/.cargo/config.toml`.
 
 ### Add Bevy to your project's Cargo.toml
 


### PR DESCRIPTION
When setting up a project for the first time, I found it confusing that the guide says to put the config in `.cargo/config`, while a comment in the [recommended config][1] says to put it in `.cargo/config.toml`. Apparently, `cargo` will look for the config in both places, but the [cargo documentation][2] recommends the path with the `.toml` extension included.

[1]: https://github.com/bevyengine/bevy/blob/master/.cargo/config_fast_builds
[2]: https://doc.rust-lang.org/cargo/reference/config.html