### PR TITLE
Update the bevy version number in the cargo snippets

### DIFF
--- a/content/learn/book/getting-started/_index.md
+++ b/content/learn/book/getting-started/_index.md
@@ -38,7 +38,7 @@ Add the bevy crate to your project's Cargo.toml like this:
 
 ```toml
 [dependencies]
-bevy = "0.1.2" # make sure this is the latest version
+bevy = "0.3" # make sure this is the latest version
 ```
 
 This is the current `bevy` crate version:

--- a/content/learn/book/getting-started/setup/_index.md
+++ b/content/learn/book/getting-started/setup/_index.md
@@ -109,7 +109,7 @@ authors = ["You <you@veryrealemail.com>"]
 edition = "2018"
 
 [dependencies]
-bevy = "0.2.1" # make sure this is the latest version
+bevy = "0.3" # make sure this is the latest version
 ```
 
 Run ```cargo run``` again. The Bevy dependencies should start building. This will take some time as you are essentially building an engine from scratch. You will only need to do a full rebuild once. Every build after this one will be fast!


### PR DESCRIPTION
Since the example code in the book uses features new in Bevy 0.3 (plugin groups), I updated the cargo snippets to 0.3 to make it easier for new users.