### PR TITLE
Fix variables in css calc

### DIFF
--- a/sass/_book-nav.scss
+++ b/sass/_book-nav.scss
@@ -3,7 +3,7 @@ $book-nav-width: 210px;
 
 @media screen and (max-width: 900px) {
     #show-book-nav:not(:checked) + .book-nav {
-        transform: translateX(calc(0px - $book-nav-width));
+        transform: translateX(calc(0px - #{$book-nav-width}));
     }
 
     #show-book-nav:checked + .book-nav + .book-content {
@@ -11,7 +11,7 @@ $book-nav-width: 210px;
     }
 
     .book-nav {
-        margin-right: calc(0px - $book-nav-width);
+        margin-right: calc(0px - #{$book-nav-width});
     }
 }
 


### PR DESCRIPTION
Currently the book nav is broken on mobile since the sass variables don't work in a css calc without [sass interpolation](https://sass-lang.com/documentation/interpolation). The pr fixes that.