### PR TITLE
Change examples url

### DIFF
--- a/content/learn/book/next-steps/_index.md
+++ b/content/learn/book/next-steps/_index.md
@@ -8,6 +8,6 @@ page_template = "book-section.html"
 
 You have reached the end of The Bevy Book! And unfortunately, we haven't even scratched the surface of Bevy's features! Eventually this book will cover almost every facet of Bevy, but until then we recommend checking out:
 
-* **[The Bevy Examples](https://github.com/bevyengine/bevy/tree/master/examples)**: We create an example for every major Bevy feature. This is currently the best way to learn Bevy's features and how to use them. 
+* **[The Bevy Examples](https://github.com/bevyengine/bevy/tree/master/examples#examples)**: We create an example for every major Bevy feature. This is currently the best way to learn Bevy's features and how to use them. 
 * **[Breakout](https://github.com/bevyengine/bevy/blob/master/examples/game/breakout.rs)**: A small "breakout" clone that illustrates what a real Bevy game looks like.
 * **[Bevy API Docs](https://docs.rs/bevy)**: Bevy's Rust API documentation.


### PR DESCRIPTION
This changes the link

from https://github.com/bevyengine/bevy/tree/master/examples
to https://github.com/bevyengine/bevy/tree/master/examples#examples

so that the user sees the warning about differences in master and previous release examples immediately instead of being hidden beyond the scroll. An alternative would be to make the link point to 0.3, but this avoids letting the url become outdated.