### PR TITLE
Added lld warning

### DIFF
--- a/content/learn/book/getting-started/setup/_index.md
+++ b/content/learn/book/getting-started/setup/_index.md
@@ -96,6 +96,11 @@ Bevy can be built just fine using default configuration on stable Rust. However 
 
 To enable fast compiles, install the nightly rust compiler and LLD. Then copy [this file](https://github.com/bevyengine/bevy/blob/master/.cargo/config_fast_builds) to `YOUR_WORKSPACE/.cargo/config.toml`. For the project in this guide, that would be `my_bevy_game/.cargo/config.toml`.
 
+<h2 class="warning">Warning</h2>
+<div class="warning">
+While being much faster than the standard linker lld tends to produce bigger and slightly slower binaries, whether this tradeoff is worth it or not, it's up to you
+</div>
+
 ### Add Bevy to your project's Cargo.toml
 
 


### PR DESCRIPTION
Related to [bevyengin/bevy#1062](https://github.com/bevyengine/bevy/issues/1062)

Since lld comes with some tradeoff it seems oportune to add a warning (maybe it should say disclaimer?) in the setup section.
I also don't have proper benchmark about the slower speed so unless someone is able to provide those it might be better to just state the size tradeoff and prompt the user to run his own benchmarks.
Maybe enabling it just for debug builds would be better?