### PR TITLE
Add Visual Studio 2019 build tools as windows

### DIFF
--- a/content/learn/book/getting-started/setup/_index.md
+++ b/content/learn/book/getting-started/setup/_index.md
@@ -20,7 +20,7 @@ Once this is done, you should have the ```rustc``` compiler and the ```cargo``` 
 
 ### Install OS dependencies
 * [Linux](https://github.com/bevyengine/bevy/blob/master/docs/linux_dependencies.md)
-* Windows: You should be good to go
+* Windows: Make sure to install [VS2019 build toos](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=16)
 * MacOS: No dependencies here
 
 ### Code Editor / IDE


### PR DESCRIPTION
This is a dependency as per: https://github.com/bevyengine/bevy/issues/939