### PR TITLE
Highlight navbar items when active

### DIFF
--- a/templates/header-macros.html
+++ b/templates/header-macros.html
@@ -7,7 +7,7 @@
     {% set route = path %}
 {% endif %}
 {% set currently_home = path == home and lower_current_path == home %}
-<a href="{{route | lower}}" {% if lower_current_path is starting_with(name | lower) or currently_home %}class="header-item header-item-active" {% else %}class="header-item"{% endif %} >
+<a href="{{route | lower}}" {% if lower_current_path is starting_with("/"~name | lower) or currently_home %}class="header-item header-item-active" {% else %}class="header-item"{% endif %} >
     {{name}}
 </a>
 {% endmacro %}


### PR DESCRIPTION
Noticed that the active items on the navbar weren't getting highlighted (except `Features`), this PR fixes that.

The change,
- Concatenating a `/` to the `name` variable so that the `starting_with` comparison passes for valid items