### PR TITLE
Future-proof github and docs links in 0.2, 0.3 and 0.4 announcement posts

### DIFF
--- a/content/news/2020-09-19-bevy-0.2/index.md
+++ b/content/news/2020-09-19-bevy-0.2/index.md
@@ -52,7 +52,7 @@ Those limitations haven't stopped @mrk-its from building the first WASM Bevy gam
 
 They use Bevy for game logic and cleverly work around the render limitations by passing ASCII art game state from [this Bevy system](https://github.com/mrk-its/bevy-robbo/blob/ascii/src/systems/js_render.rs) to [this JavaScript function](https://github.com/mrk-its/bevy-robbo/blob/ascii/wasm/render.js). 
 
-You can play around with some Bevy WASM examples by [following the instructions here](https://github.com/bevyengine/bevy/tree/master/examples#wasm).
+You can play around with some Bevy WASM examples by [following the instructions here](https://github.com/bevyengine/bevy/tree/v0.2.0/examples#wasm).
 
 ## Parallel Queries
 

--- a/content/news/2020-11-03-bevy-0.3/index.md
+++ b/content/news/2020-11-03-bevy-0.3/index.md
@@ -24,7 +24,7 @@ Here are some of the highlights from this release:
 
 <div class="release-feature-authors">authors: @enfipy, @PrototypeNM1, @endragor, @naithar</div>
 
-You can try out the [Bevy Android example](https://github.com/bevyengine/bevy/tree/master/examples/android) by following the [instructions here](https://github.com/bevyengine/bevy/blob/master/examples/README.md#android). While many things work, please note that this is _very hot_ off the presses. Some features will work and others probably won't. Now is a great time to dive in and help us close the gaps!
+You can try out the [Bevy Android example](https://github.com/bevyengine/bevy/tree/v0.3.0/examples/android) by following the [instructions here](https://github.com/bevyengine/bevy/blob/v0.3.0/examples/README.md#android). While many things work, please note that this is _very hot_ off the presses. Some features will work and others probably won't. Now is a great time to dive in and help us close the gaps!
 
 ![android](android.png)
 
@@ -47,7 +47,7 @@ Bevy can now run on iOS!
 
 <img src="ios.png" style="margin-left: -4rem; margin-bottom: -5rem; margin-top: -3rem" />
 
-You can try out the [Bevy iOS example](https://github.com/bevyengine/bevy/tree/master/examples/ios) by following the [instructions here](https://github.com/bevyengine/bevy/tree/master/examples#ios). This one is also hot off the presses: some features will work and others probably won't.
+You can try out the [Bevy iOS example](https://github.com/bevyengine/bevy/tree/v0.3.0/examples/ios) by following the [instructions here](https://github.com/bevyengine/bevy/tree/v0.3.0/examples#ios). This one is also hot off the presses: some features will work and others probably won't.
 
 This was another large group effort that spanned multiple projects:
 
@@ -340,7 +340,7 @@ To allow multiple concurrent reads of Queries (where it is safe), we added separ
 
 Bevy meshes used to require exactly three "vertex attributes": `position`, `normal`, and `uv`. This worked for most things, but there are a number of cases that require other attributes, such as "vertex colors" or "bone weights for animation". **Bevy 0.3** adds support for custom vertex attributes. Meshes can define whatever attributes they want and shaders can consume whatever attributes they want!
 
-[Here is an example](https://github.com/bevyengine/bevy/blob/master/examples/shader/mesh_custom_attribute.rs) that illustrates how to define a custom shader that consumes a mesh with an added "vertex color" attribute.
+[Here is an example](https://github.com/bevyengine/bevy/blob/v0.3.0/examples/shader/mesh_custom_attribute.rs) that illustrates how to define a custom shader that consumes a mesh with an added "vertex color" attribute.
 
 ![custom_vertex_attribute](custom_vertex_attribute.png)
 

--- a/content/news/2020-12-19-bevy-0.4/index.md
+++ b/content/news/2020-12-19-bevy-0.4/index.md
@@ -165,7 +165,7 @@ fn error_handler_system(In(result): In<Result<()>>, error_handler: Res<MyErrorHa
 }
 ```
 
-The {{rust_type(type="trait" crate="bevy_ecs" name="System" no_mod=true)}} trait now looks like this:
+The {{rust_type(type="trait" crate="bevy_ecs" version="0.4.0" name="System" no_mod=true)}} trait now looks like this:
 ```rust
 // Has no inputs and no outputs
 System<In = (), Out = ()>
@@ -196,7 +196,7 @@ app.add_system(my_system.system())
 
 #### Stage Trait
 
-Stages are now a trait. You can now implement your own {{rust_type(type="trait" crate="bevy_ecs" name="Stage" no_mod=true)}} types!
+Stages are now a trait. You can now implement your own {{rust_type(type="trait" crate="bevy_ecs" version="0.4.0" name="Stage" no_mod=true)}} types!
 
 ```rust
 struct MyStage;
@@ -209,7 +209,7 @@ impl Stage for MyStage {
 }
 ```
 
-#### Stage Type: {{rust_type(type="struct" crate="bevy_ecs" name="SystemStage" no_mod=true)}}
+#### Stage Type: {{rust_type(type="struct" crate="bevy_ecs" version="0.4.0" name="SystemStage" no_mod=true)}}
 
 This is basically a "normal" stage. You can add systems to it and you can decide how those systems will be executed (parallel, serial, or custom logic)
 
@@ -233,9 +233,9 @@ let custom_executor_stage =
         .with_system(b.system());
 ```
 
-#### Stage Type: {{rust_type(type="struct" crate="bevy_ecs" name="Schedule" no_mod=true)}}
+#### Stage Type: {{rust_type(type="struct" crate="bevy_ecs" version="0.4.0" name="Schedule" no_mod=true)}}
 
-You read that right! {{rust_type(type="struct" crate="bevy_ecs" name="Schedule" no_mod=true)}} now implements the {{rust_type(type="trait" crate="bevy_ecs" name="Stage" no_mod=true)}} trait, which means you can nest Schedules within other schedules: 
+You read that right! {{rust_type(type="struct" crate="bevy_ecs" version="0.4.0" name="Schedule" no_mod=true)}} now implements the {{rust_type(type="trait" crate="bevy_ecs" version="0.4.0" name="Stage" no_mod=true)}} trait, which means you can nest Schedules within other schedules:
 
 ```rust
 let schedule = Schedule::default()
@@ -252,7 +252,7 @@ let schedule = Schedule::default()
 
 #### Run Criteria
 
-You can add "run criteria" to any {{rust_type(type="struct" crate="bevy_ecs" name="SystemStage" no_mod=true)}} or {{rust_type(type="struct" crate="bevy_ecs" name="Schedule" no_mod=true)}}.
+You can add "run criteria" to any {{rust_type(type="struct" crate="bevy_ecs" version="0.4.0" name="SystemStage" no_mod=true)}} or {{rust_type(type="struct" crate="bevy_ecs" version="0.4.0" name="Schedule" no_mod=true)}}.
 
 ```rust
 // A "run criteria" is just a system that returns a `ShouldRun` result
@@ -296,7 +296,7 @@ Check out the excellent ["Fix Your Timestep!"](https://gafferongames.com/post/fi
 
 #### Typed Stage Builders
 
-Now that stages can be any type, we need a way for {{rust_type(type="trait" crate="bevy_app" name="Plugin" no_mod=true plural=true)}} to interact with arbitrary stage types:
+Now that stages can be any type, we need a way for {{rust_type(type="trait" crate="bevy_app" version="0.4.0" name="Plugin" no_mod=true plural=true)}} to interact with arbitrary stage types:
 
 ```rust
 app
@@ -368,7 +368,7 @@ You then add them to your app as a resource like this:
 app.add_resource(State::new(AppState::Loading))
 ```
 
-To run systems according to the current state, add a {{rust_type(type="struct" crate="bevy_ecs" name="StateStage" no_mod=true)}}:
+To run systems according to the current state, add a {{rust_type(type="struct" crate="bevy_ecs" version="0.4.0" name="StateStage" no_mod=true)}}:
 
 ```rust
 app.add_stage_after(stage::UPDATE, STAGE, StateStage::<AppState>::default())
@@ -533,9 +533,9 @@ When I was first building Bevy, I decided that the engine would benefit from suc
 
 They got the job done, but they were custom-tailored to Bevy's needs, were full of custom jargon (rather than reflecting Rust language constructs directly), didn't handle traits, and had a number of fundamental restrictions on how data could be accessed. 
 
-In this release we replaced the old `bevy_property` and `bevy_type_registry` crates with a new {{rust_mod(crate="bevy_reflect")}} crate. Bevy Reflect is intended to be a "generic" Rust reflection crate. I'm hoping it will be as useful for non-Bevy projects as it is for Bevy. We now use it for our Scene system, but in the future we will use it for animating Component fields and auto-generating Bevy Editor inspector widgets.
+In this release we replaced the old `bevy_property` and `bevy_type_registry` crates with a new {{rust_mod(crate="bevy_reflect" version="0.4.0")}} crate. Bevy Reflect is intended to be a "generic" Rust reflection crate. I'm hoping it will be as useful for non-Bevy projects as it is for Bevy. We now use it for our Scene system, but in the future we will use it for animating Component fields and auto-generating Bevy Editor inspector widgets.
 
-Bevy Reflect enables you to dynamically interact with Rust types by deriving the {{rust_type(type="trait" crate="bevy_reflect" name="Reflect" no_mod=true)}} trait:
+Bevy Reflect enables you to dynamically interact with Rust types by deriving the {{rust_type(type="trait" crate="bevy_reflect" version="0.4.0" name="Reflect" no_mod=true)}} trait:
 
 ```rust
 #[derive(Reflect)]
@@ -684,9 +684,9 @@ The Texture asset now has support for 3D textures. The new `array_texture.rs` ex
 
 <div class="release-feature-authors">authors: @superdump, @cart</div>
 
-Bevy finally has built in logging, which is now enabled by default via the new {{rust_type(type="struct" crate="bevy_log" name="LogPlugin" no_mod=true)}}. We evaluated various logging libraries and eventually landed on the new `tracing` crate. `tracing` is a structured logger that handles async / parallel logging well (perfect for an engine like Bevy), and enables profiling in addition to "normal" logging.
+Bevy finally has built in logging, which is now enabled by default via the new {{rust_type(type="struct" crate="bevy_log" version="0.4.0" name="LogPlugin" no_mod=true)}}. We evaluated various logging libraries and eventually landed on the new `tracing` crate. `tracing` is a structured logger that handles async / parallel logging well (perfect for an engine like Bevy), and enables profiling in addition to "normal" logging.
 
-The {{rust_type(type="struct" crate="bevy_log" name="LogPlugin" no_mod=true)}} configures each platform to log to the appropriate backend by default: the terminal on desktop, the console on web, and Android Logs / logcat on Android. We built a new Android `tracing` backend because one didn't exist yet.
+The {{rust_type(type="struct" crate="bevy_log" version="0.4.0" name="LogPlugin" no_mod=true)}} configures each platform to log to the appropriate backend by default: the terminal on desktop, the console on web, and Android Logs / logcat on Android. We built a new Android `tracing` backend because one didn't exist yet.
 
 
 ### Logging

--- a/templates/shortcodes/rust_mod.html
+++ b/templates/shortcodes/rust_mod.html
@@ -3,6 +3,10 @@
 {% set crate = "std" %}
 {% endif %}
 
+{% if not version %}
+{% set version = "std" %}
+{% endif %}
+
 {% if mod %}
 {% set mod_path = "/" ~ mod | replace(from="::", to="/") %}
 {% else %}
@@ -14,7 +18,7 @@
 {% set path = "stable/" ~ crate %}
 {% else %}
 {% set url = "https://docs.rs" %}
-{% set path = crate ~ "/latest/" ~ crate %}
+{% set path = crate ~ "/" ~ version ~ "/" ~ crate %}
 {% endif %}
 
 <a href="{{url}}/{{path}}{{mod_path}}/index.html"><code>{% if not no_crate and crate%}{{crate}}{% if not no_mod and mod%}::{{mod}}{% endif %}{% elif not no_mod and mod%}{{mod}}{% endif %}</code></a>


### PR DESCRIPTION
I don't think any of these were actually broken (yet) but it seems like a good bet that they will break at some point in the future.