### PR TITLE
Book: improve discoverability of additional learning resources

### DIFF
--- a/content/learn/book/introduction/_index.md
+++ b/content/learn/book/introduction/_index.md
@@ -34,4 +34,6 @@ For a more in-depth introduction, check out the [Introducing Bevy](/news/introdu
 
 Bevy aims to be a general purpose game engine capable of handling any 2D or 3D workload. However Bevy is still in its infancy. <span class="warning">We are currently in the <i>prototyping</i> phase: important features are missing and APIs will change constantly.</span> If you are currently trying to pick an engine for your Next Big Project™, we recommend that you check out [Godot Engine](https://godotengine.org). It is currently much more feature-complete and stable. And it is also free, open-source, and [scriptable with Rust](https://github.com/GodotNativeTools/godot-rust)!
 
+This official book is still very incomplete. It will help you get started with the setup and learning the basics, but it does not yet cover most of Bevy's features. See the [Next Steps](/learn/book/next-steps/) page for links to other, more exhaustive, learning resources you can use.
+
 Phew! If you haven't been scared away yet, let's move on to learning some Bevy!

--- a/content/learn/book/next-steps/_index.md
+++ b/content/learn/book/next-steps/_index.md
@@ -11,5 +11,7 @@ You have reached the end of The Bevy Book! And unfortunately, we haven't even sc
 * **[The Bevy Examples](https://github.com/bevyengine/bevy/tree/main/examples#examples)**: We create an example for every major Bevy feature. This is currently the best way to learn Bevy's features and how to use them.
 * **[Breakout](https://github.com/bevyengine/bevy/blob/main/examples/game/breakout.rs)**: A small "breakout" clone that illustrates what a real Bevy game looks like.
 * **[Bevy API Docs](https://docs.rs/bevy)**: Bevy's Rust API documentation.
-* **[Awesome Bevy](https://github.com/bevyengine/awesome-bevy)**: List of community projects in Bevy, including plugins, games, and learning resources.
-  * **[Community-Made Learning Resources](https://github.com/bevyengine/awesome-bevy#learning)**: Tutorials, documentation, and examples made by the Bevy community.
+* **[Awesome Bevy](https://github.com/bevyengine/awesome-bevy)**: List of projects by the Bevy community, including:
+  * **[Learning Resources](https://github.com/bevyengine/awesome-bevy#learning)**: Tutorials, documentation, and examples.
+  * **[Plugins](https://github.com/bevyengine/awesome-bevy#plugins-and-crates)**: Extra functionality you can use in your projects.
+  * **[Games](https://github.com/bevyengine/awesome-bevy#games)**: Open-source games in various stages of development.

--- a/content/learn/book/next-steps/_index.md
+++ b/content/learn/book/next-steps/_index.md
@@ -11,3 +11,5 @@ You have reached the end of The Bevy Book! And unfortunately, we haven't even sc
 * **[The Bevy Examples](https://github.com/bevyengine/bevy/tree/main/examples#examples)**: We create an example for every major Bevy feature. This is currently the best way to learn Bevy's features and how to use them.
 * **[Breakout](https://github.com/bevyengine/bevy/blob/main/examples/game/breakout.rs)**: A small "breakout" clone that illustrates what a real Bevy game looks like.
 * **[Bevy API Docs](https://docs.rs/bevy)**: Bevy's Rust API documentation.
+* **[Awesome Bevy](https://github.com/bevyengine/awesome-bevy)**: List of community projects in Bevy, including plugins, games, and learning resources.
+  * **[Community-Made Learning Resources](https://github.com/bevyengine/awesome-bevy#learning)**: Tutorials, documentation, and examples made by the Bevy community.

--- a/templates/learn.html
+++ b/templates/learn.html
@@ -37,7 +37,7 @@
         Awesome Bevy
       </div>
       <div class="card-description">
-        Learn by example with an awesome-style list of cool Bevy projects.
+        Learn by example with an awesome-style list of cool Bevy projects. Read community-made tutorials and documentation.
       </div>
     </div>
   </a>


### PR DESCRIPTION
There are 2 changes to the Official Bevy Book that I want to make with this PR:

### 1. Add links to awesome-bevy and community learning resources (on the "Next Steps" page of the book)

I want people reading the official book to know where they can find community-made projects (awesome-bevy), and specifically to know about the existence of unofficial / community-made learning resources. (this is why I also added a separate link to the learning section of awesome-bevy)

### 2. Let people know in the introduction that the book is incomplete

I don't want people coming to the book to be discouraged by thinking that what's covered in the book is all there is.

I want to prominently direct them to also check out other resources early on, in the introduction, to manage expectations and make the book more useful.