### PR TITLE
Community: feature awesome-bevy

### DIFF
--- a/templates/community.html
+++ b/templates/community.html
@@ -82,5 +82,21 @@
             </div>
         </div>
     </a>
+    <a class="card" href="https://github.com/bevyengine/awesome-bevy">
+        <div class="card-image">
+            <img src="/assets/github.svg" class="centered-card-image community-icon" alt="Github logo"/>
+        </div>
+        <div class="card-text">
+            <div class="card-title">
+                Awesome Bevy
+            </div>
+            <div class="card-subtitle">
+                github.com/bevyengine/awesome-bevy
+            </div>
+            <div class="card-description">
+                List of community projects in Bevy, including plugins, games, books, and tutorials.
+            </div>
+        </div>
+    </a>
 </div>
 {% endblock content %}

--- a/templates/community.html
+++ b/templates/community.html
@@ -84,7 +84,7 @@
     </a>
     <a class="card" href="https://github.com/bevyengine/awesome-bevy">
         <div class="card-image">
-            <img src="/assets/github.svg" class="centered-card-image community-icon" alt="Github logo"/>
+            <img src="/assets/bevy_icon_dark.svg" class="centered-card-image community-icon" alt="Bevy logo"/>
         </div>
         <div class="card-text">
             <div class="card-title">


### PR DESCRIPTION
Add an "awesome-bevy" card to the "community" page.

I didn't know what logo to use, so I reused the github logo. I think it is a little ugly to have this duplication, so I hope we can come up with something else. Another suggestion: perhaps use the Bevy logo?

This should address #2 .