### PR TITLE
Help users discover the correct version of the official examples

### DIFF
--- a/content/learn/book/getting-started/_index.md
+++ b/content/learn/book/getting-started/_index.md
@@ -24,7 +24,14 @@ Note: the "fast compiles" setup is on the next page, so you might want to read t
     ```
     cd bevy
     ```
-3. Try the examples in the [examples folder](https://github.com/bevyengine/bevy/tree/main/examples)
+3. Switch to the correct Bevy version (as the default is the git main development branch)
+    ```
+    # use the latest Bevy release
+    git checkout latest
+    # or a specific version
+    git checkout v0.4.0
+    ```
+4. Try the examples in the [examples folder](https://github.com/bevyengine/bevy/tree/latest/examples)
     ```
     cargo run --example breakout
     ```

--- a/content/learn/book/getting-started/_index.md
+++ b/content/learn/book/getting-started/_index.md
@@ -31,7 +31,7 @@ Note: the "fast compiles" setup is on the next page, so you might want to read t
     # or a specific version
     git checkout v0.4.0
     ```
-4. Try the examples in the [examples folder](https://github.com/bevyengine/bevy/tree/latest/examples)
+4. Try the examples in the [examples folder](https://github.com/bevyengine/bevy/tree/latest/examples#examples)
     ```
     cargo run --example breakout
     ```

--- a/content/learn/book/next-steps/_index.md
+++ b/content/learn/book/next-steps/_index.md
@@ -8,8 +8,8 @@ page_template = "book-section.html"
 
 You have reached the end of The Bevy Book! And unfortunately, we haven't even scratched the surface of Bevy's features! Eventually this book will cover almost every facet of Bevy, but until then we recommend checking out:
 
-* **[The Bevy Examples](https://github.com/bevyengine/bevy/tree/main/examples#examples)**: We create an example for every major Bevy feature. This is currently the best way to learn Bevy's features and how to use them.
-* **[Breakout](https://github.com/bevyengine/bevy/blob/main/examples/game/breakout.rs)**: A small "breakout" clone that illustrates what a real Bevy game looks like.
+* **[The Bevy Examples](https://github.com/bevyengine/bevy/tree/latest/examples#examples)**: We create an example for every major Bevy feature. This is currently the best way to learn Bevy's features and how to use them.
+* **[Breakout](https://github.com/bevyengine/bevy/blob/latest/examples/game/breakout.rs)**: A small "breakout" clone that illustrates what a real Bevy game looks like.
 * **[Bevy API Docs](https://docs.rs/bevy)**: Bevy's Rust API documentation.
 * **[Awesome Bevy](https://github.com/bevyengine/awesome-bevy)**: List of projects by the Bevy community, including:
   * **[Learning Resources](https://github.com/bevyengine/awesome-bevy#learning)**: Tutorials, documentation, and examples.

--- a/templates/learn.html
+++ b/templates/learn.html
@@ -28,7 +28,7 @@
       </div>
     </div>
   </a>
-  <a class="card" href="https://github.com/bevyengine/bevy/tree/latest/examples">
+  <a class="card" href="https://github.com/bevyengine/bevy/tree/latest/examples#examples">
     <div class="card-image">
       <img src="/assets/github.svg" class="centered-card-image" alt="Github logo"/>
     </div>

--- a/templates/learn.html
+++ b/templates/learn.html
@@ -28,9 +28,22 @@
       </div>
     </div>
   </a>
-  <a class="card" href="https://github.com/bevyengine/awesome-bevy">
+  <a class="card" href="https://github.com/bevyengine/bevy/tree/latest/examples">
     <div class="card-image">
       <img src="/assets/github.svg" class="centered-card-image" alt="Github logo"/>
+    </div>
+    <div class="card-text">
+      <div class="card-title">
+        Official Examples
+      </div>
+      <div class="card-description">
+        Examples that show how to use the various features of Bevy.
+      </div>
+    </div>
+  </a>
+  <a class="card" href="https://github.com/bevyengine/awesome-bevy">
+    <div class="card-image">
+      <img src="/assets/bevy_icon_dark.svg" class="centered-card-image" alt="Bevy logo"/>
     </div>
     <div class="card-text">
       <div class="card-title">


### PR DESCRIPTION
1. Change all links to point to the `latest` branch (which is the release version, not `main`)
2. Explicitly instruct users to `git checkout` the correct version when they clone the repo to run the examples
  - I suspect this "getting started" book page was a big cause of misdirected/confused new users
  - See also: https://github.com/bevyengine/bevy/pull/1624 for a similar change to the README in the main repo
3. Add a card on the `Learn` page linking to the examples