### PR TITLE
Point people at the latest release in quick start section

### DIFF
--- a/content/learn/book/getting-started/_index.md
+++ b/content/learn/book/getting-started/_index.md
@@ -18,13 +18,13 @@ Note: the "fast compiles" setup is on the next page, so you might want to read t
 
 1. Clone the [Bevy repo](https://github.com/bevyengine/bevy):
     ```
-    git clone https://github.com/bevyengine/bevy
+    git clone https://github.com/bevyengine/bevy --branch latest
     ```
 2. Navigate to the new "bevy" folder
     ```
     cd bevy
     ```
-3. Try the examples in the [examples folder](https://github.com/bevyengine/bevy/tree/main/examples)
+3. Try the examples in the [examples folder](https://github.com/bevyengine/bevy/tree/latest/examples)
     ```
     cargo run --example breakout
     ```


### PR DESCRIPTION
Hopefully preventing one source of master/release examples confusion.

It wasn't entirely obvious to me what to do with the links/clone url in this section, but it didn't seem like a great situation to point a brand new user directly at the "main" examples, but then tell them to use 0.4.