### PR TITLE
fix broken docs.rs links

### DIFF
--- a/templates/shortcodes/rust_mod.html
+++ b/templates/shortcodes/rust_mod.html
@@ -4,7 +4,7 @@
 {% endif %}
 
 {% if not version %}
-{% set version = "std" %}
+{% set version = "latest" %}
 {% endif %}
 
 {% if mod %}

--- a/templates/shortcodes/rust_type.html
+++ b/templates/shortcodes/rust_type.html
@@ -3,7 +3,7 @@
 {% endif %}
 
 {% if not version %}
-{% set version = "std" %}
+{% set version = "latest" %}
 {% endif %}
 
 {% if not mod %}


### PR DESCRIPTION
When clicking on any documentation that is not `std` in the book, you get `The requested version does not exist.`
This is because docs.rs changed their url scheme from ```https://docs.rs/std/<crate>``` to  ```https://docs.rs/latest/<crate>``` in order to obtain the docs for the newest version.