### PR TITLE
Add links to news sections

### DIFF
--- a/content/news/2021-04-06-bevy-0.5/index.md
+++ b/content/news/2021-04-06-bevy-0.5/index.md
@@ -23,7 +23,7 @@ Here are some of the highlights from this release:
 
 <!-- more -->
 
-## Physically Based Rendering (PBR)
+{{ heading(text="Physically Based Rendering (PBR)") }}
 
 <div class="release-feature-authors">authors: @StarArawn, @mtsr, @mockersf, @IngmarBitter, @Josh015, @norgate, @cart</div>
 
@@ -35,9 +35,9 @@ The new PBR example helps visualize these new material properties:
 
 ![pbr](pbr.png)
 
-## GLTF Improvements
+{{ heading(text="GLTF Improvements") }}
 
-### PBR Textures
+{{ heading(text="PBR Textures", size=3) }}
 
 <div class="release-feature-authors">authors: @mtsr, @mockersf</div>
 

--- a/content/news/_index.md
+++ b/content/news/_index.md
@@ -3,4 +3,5 @@ title = "Posts"
 sort_by = "date"
 template = "news.html"
 page_template = "news-page.html"
+insert_anchor_links = "right"
 +++

--- a/templates/shortcodes/heading.html
+++ b/templates/shortcodes/heading.html
@@ -1,0 +1,11 @@
+<a href="#{{text | slugify}}" id="{{text | slugify}}">
+    {% if size %}
+    <h{{size}}>
+        {{text}}
+    </h{{size}}>
+    {% else %}
+    <h2>
+        {{text}}
+    </h2>
+    {% endif %}
+</a>


### PR DESCRIPTION
Fixes #125 by inserting a link via [Zola's anchor insertion](https://www.getzola.org/documentation/content/linking/#anchor-insertion). 

Screenshot:
![image](https://user-images.githubusercontent.com/8846211/113963450-378e9080-97ef-11eb-84f8-86adb8b03d25.png)
