### PR TITLE
Add anchor links to headers in the news section

### DIFF
--- a/content/news/_index.md
+++ b/content/news/_index.md
@@ -3,4 +3,5 @@ title = "Posts"
 sort_by = "date"
 template = "news.html"
 page_template = "news-page.html"
+insert_anchor_links = "right"
 +++

--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -39,3 +39,10 @@ a:focus {
 .warning {
     color: #c8c864;
 }
+
+.anchor-link, .anchor-link:focus, .anchor-link:hover, .anchor-link:active, .anchor-link:hover, .anchor-link:link, .anchor-link:visited {
+    margin-left: 0.3rem;
+    color: #505050;
+    text-shadow: none;
+    font-weight: 500;
+}

--- a/templates/anchor-link.html
+++ b/templates/anchor-link.html
@@ -1,0 +1,1 @@
+<a class="anchor-link" href="#{{id}}">#</a>


### PR DESCRIPTION
Fixes #125 by inserting a link via [Zola's anchor insertion](https://www.getzola.org/documentation/content/linking/#anchor-insertion). 

Screenshot:
![image](https://user-images.githubusercontent.com/8846211/113963450-378e9080-97ef-11eb-84f8-86adb8b03d25.png)
