### PR TITLE
More migration guide

### DIFF
--- a/content/learn/book/migration-guides/0.4-0.5/_index.md
+++ b/content/learn/book/migration-guides/0.4-0.5/_index.md
@@ -24,35 +24,37 @@ fn foo(mut commands: Commands) {
 
 Systems using the old `commands: &mut Commands` syntax in 0.5 will fail to compile when calling `foo.system()`.
 
-This change was made because {{rust_type(type="struct" crate="bevy_ecs" version="0.5.0" name="Commands" no_mod=true)}}
-now holds an internal {{rust_type(type="struct" crate="bevy_ecs" version="0.5.0" name="World" no_mod=true)}}
+This change was made because {{rust_type(type="struct" crate="bevy_ecs" mod="system" version="0.5.0" name="Commands" no_mod=true)}}
+now holds an internal {{rust_type(type="struct" crate="bevy_ecs" mod="world" version="0.5.0" name="World" no_mod=true)}}
 reference to enable safe entity allocations.
 
-Note: The internal {{rust_type(type="struct" crate="bevy_ecs" version="0.5.0" name="World" no_mod=true)}} reference requires two lifetime parameters to pass Commands into a non-system function: ```commands: &'a mut Commands<'b>```
+Note: The internal {{rust_type(type="struct" crate="bevy_ecs" mod="world" version="0.5.0" name="World" no_mod=true)}} reference requires two lifetime parameters to pass Commands into a non-system function: `commands: &'a mut Commands<'b>`
 
-### Commands::insert() API is now used for a single component
+### Commands API
+
+The {{rust_type(type="struct" crate="bevy_ecs" version="0.5.0" mod="system" name="Commands" no_mod=true)}} API has been completely reworked for consistency with the {{rust_type(type="struct" crate="bevy_ecs" mod="world" version="0.5.0" name="World" no_mod=true)}} API.
 
 ```rust
 // 0.4
-// component
-commands.insert_one(entity, MyComponent)
-commands.insert(entity, (MyComponent,))
-// bundle
-commands.insert(entity, Bundle)
+commands
+    .spawn(SomeBundle)
+    .with(SomeComponent)
+    .spawn(SomeBundle); // this sort of chaining is no longer possible
 
+let entity = commands.spawn(SomeBundle).current_entity().unwrap();
+
+commands.despawn(entity);
 
 // 0.5
-// component
-commands.insert(entity, MyComponent)
-// bundle
-commands.insert_bundle(entity, MyBundle)
+    commands
+        .spawn()
+        .insert_bundle(SomeBundle)
+        .insert(Component);
+
+    let entity = commands.spawn().insert_bundle(SomeBundle).id();
+
+    commands.entity(entity).despawn();
 ```
-
-Instead of using `commands.insert_one()` for a single component, use `commands.insert()`.
-
-This means that `commands.insert()` will no longer accept a bundle as an argument. For bundles, use `commands.insert_bundle()`.
-
-This change helps to clarify the difference between components and bundles, and brings {{rust_type(type="struct" crate="bevy_ecs" version="0.5.0" name="Commands" no_mod=true)}} into alignment with other Bevy APIs. It also eliminates the confusion associated with calling `commands.insert()` on a tuple for the single-component case.
 
 ### Timer now uses Duration
 

--- a/content/learn/book/migration-guides/0.4-0.5/_index.md
+++ b/content/learn/book/migration-guides/0.4-0.5/_index.md
@@ -204,3 +204,26 @@ app.add_state(MyState::InitState)
 It is still possible to register the driver manually using
 `State::get_driver`, but this is not normally required.
 
+## ChangedRes removed
+
+This change was made to allow for more flexiblity and more consistent behavior with change detection for components.
+
+```rust
+// 0.4
+fn some_system(
+    res: ChangedRes<SomeResource>
+) {
+    // this system only runs if SomeResource has changed
+}
+
+// 0.5
+fn some_system(
+    res: Res<SomeResource> // or ResMut
+) {
+    // this system always runs
+
+    if !res.changed() { // or .added() or .mutated()
+        return;
+    }
+}
+```

--- a/content/learn/book/migration-guides/0.4-0.5/_index.md
+++ b/content/learn/book/migration-guides/0.4-0.5/_index.md
@@ -46,14 +46,14 @@ let entity = commands.spawn(SomeBundle).current_entity().unwrap();
 commands.despawn(entity);
 
 // 0.5
-    commands
-        .spawn()
-        .insert_bundle(SomeBundle)
-        .insert(Component);
+commands
+    .spawn()
+    .insert_bundle(SomeBundle)
+    .insert(Component);
 
-    let entity = commands.spawn().insert_bundle(SomeBundle).id();
+let entity = commands.spawn().insert_bundle(SomeBundle).id();
 
-    commands.entity(entity).despawn();
+commands.entity(entity).despawn();
 ```
 
 ### Timer now uses Duration


### PR DESCRIPTION
The previous section talking about `insert` method of `Commands` was written pre-`EntityBuilder` and seemed wrong.

Also, the links to `Commands` and `World` docs were broken.

Here's a very minimal section about the new Commands API that touches on the most important stuff, probably.

And also a ChangedRes section that I found half-written in my local repo.