### PR TITLE
Migration guide for next version (0.6?)

### DIFF
--- a/content/learn/book/migration-guides/0.5-0.6/_index.md
+++ b/content/learn/book/migration-guides/0.5-0.6/_index.md
@@ -1,0 +1,10 @@
++++
+title = "0.5 to 0.6"
+weight = 1
+sort_by = "weight"
+template = "book-section.html"
+page_template = "book-section.html"
+[extra]
+long_title = "Migration Guide: 0.5 to 0.6"
++++
+

--- a/content/learn/book/migration-guides/0.5-0.6/_index.md
+++ b/content/learn/book/migration-guides/0.5-0.6/_index.md
@@ -8,3 +8,31 @@ page_template = "book-section.html"
 long_title = "Migration Guide: 0.5 to 0.6"
 +++
 
+### `Light` and `LightBundle` are now `PointLight` and `PointLightBundle`
+
+```rust
+// 0.5
+commands.spawn_bundle(LightBundle {
+    light: Light {
+        color: Color::YELLOW,
+        fov: f32::to_radians(60.0),
+        depth: 0.1..50.0,
+        intensity: 200.0,
+        range: 20.0,
+    },
+    ..Default::default()
+});
+
+// 0.6
+commands.spawn_bundle(PointLightBundle {
+    point_light: PointLight {
+        color: Color::YELLOW,
+        intensity: 200.0,
+        range: 20.0,
+    },
+    ..Default::default()
+});
+```
+
+Cleanup on the {{rust_type(type="struct" crate="bevy_pbr" mod="light" version="0.5.0" name="PointLight" no_mod=true)}},
+removing unused fields `fov` and `depth`.


### PR DESCRIPTION
Starting the next migration guide now that there aren't yet a lot of changes

Using https://github.com/bevyengine/bevy/compare/v0.5.0...main, I noticed only one change that needed an entry

current Bevy commit: https://github.com/bevyengine/bevy/commit/ad43f52bd2dd331a2b9208821c6c89f4851ec1b5

If someone want write access to my fork to add entries as they come or fix my English please ask, and add a comment with latest Bevy commit you've looked at