### PR TITLE
World Metadata in systems must be references

### DIFF
--- a/content/news/2021-04-06-bevy-0.5/index.md
+++ b/content/news/2021-04-06-bevy-0.5/index.md
@@ -1013,7 +1013,7 @@ Component Bundles previously used the `XComponents` naming convention (ex: `Spri
 
 ```rust
 // you can access these new collections from normal systems, just like any other SystemParam
-fn system(archetypes: Archetypes, components: Components, bundles: Bundles, entities: Entities) {
+fn system(archetypes: &Archetypes, components: &Components, bundles: &Bundles, entities: &Entities) {
 }
 ```
 


### PR DESCRIPTION
The new World Metadata collections must be references to work inside systems.

https://github.com/bevyengine/bevy/blob/main/crates/bevy_ecs/src/system/system_param.rs#L890
https://github.com/bevyengine/bevy/blob/main/crates/bevy_ecs/src/system/system_param.rs#L922
https://github.com/bevyengine/bevy/blob/main/crates/bevy_ecs/src/system/system_param.rs#L954
https://github.com/bevyengine/bevy/blob/main/crates/bevy_ecs/src/system/system_param.rs#L986