### PR TITLE
external file code block: initial implementation

### DIFF
--- a/templates/shortcodes/file_code_block.html
+++ b/templates/shortcodes/file_code_block.html
@@ -1,0 +1,6 @@
+{% if not lang %}
+    {% set lang = "" %}
+{% endif %}
+{% set data = "```" ~ lang ~ "
+" ~ load_data(path=path) ~ "```" %}
+{{data | markdown(inline=true) | safe}}


### PR DESCRIPTION
Adds the ability to embed external files as code blocks in markdown text. This opens up the doors to validating these files using other tooling (such as `cargo build` for rust).

The syntax is:
```
{{file_code_block(path="templates/base.html" lang="html")}}
```

More context in #143 