### PR TITLE
Small fix to migration guide 0.4-0.5, where changed() is mentioned but should be is_changed()

### DIFF
--- a/content/learn/book/migration-guides/0.4-0.5/_index.md
+++ b/content/learn/book/migration-guides/0.4-0.5/_index.md
@@ -242,7 +242,7 @@ fn some_system(
 ) {
     // this system always runs
 
-    if !res.changed() { // or .added() or .mutated()
+    if !res.is_changed() { // or .is_added()
         return;
     }
 }


### PR DESCRIPTION
A small fix to documentation. (The migration guide mentions `changed()` which actually is `is_changed()` )