### PR TITLE
Assets - description validation improvement

### DIFF
--- a/generate-assets/src/bin/generate.rs
+++ b/generate-assets/src/bin/generate.rs
@@ -40,7 +40,7 @@ impl From<&Asset> for FrontMatterAsset {
     fn from(asset: &Asset) -> Self {
         FrontMatterAsset {
             title: asset.name.clone(),
-            description: asset.description.clone().unwrap_or_default(),
+            description: asset.description.clone(),
             weight: asset.order.unwrap_or(0),
             extra: FrontMatterAssetExtra {
                 link: asset.link.clone(),

--- a/generate-assets/src/bin/validate.rs
+++ b/generate-assets/src/bin/validate.rs
@@ -21,7 +21,6 @@ trait AssetValidator {
 
 #[derive(Debug)]
 enum AssetError {
-    DescriptionMissing,
     DescriptionTooLong,
     DescriptionWithFormatting,
     ImageInvalidLink,
@@ -51,22 +50,17 @@ impl AssetValidator for AssetNode {
 impl AssetValidator for Asset {
     fn validate(&self) -> bool {
         let mut valid = true;
-        if let Some(description) = self.description.as_ref() {
-            if description.len() > 100 {
-                valid = false;
-                println!("{:50} - {:?}", self.name, AssetError::DescriptionTooLong);
-            }
-            if has_forbidden_formatting(description) {
-                valid = false;
-                println!(
-                    "{:50} - {:?}",
-                    self.name,
-                    AssetError::DescriptionWithFormatting
-                );
-            }
-        } else {
+        if self.description.len() > 100 {
             valid = false;
-            println!("{:50} - {:?}", self.name, AssetError::DescriptionMissing);
+            println!("{:50} - {:?}", self.name, AssetError::DescriptionTooLong);
+        }
+        if has_forbidden_formatting(&self.description) {
+            valid = false;
+            println!(
+                "{:50} - {:?}",
+                self.name,
+                AssetError::DescriptionWithFormatting
+            );
         }
         if let Some(image) = self.image.as_ref() {
             if image.starts_with('.')

--- a/generate-assets/src/lib.rs
+++ b/generate-assets/src/lib.rs
@@ -6,7 +6,7 @@ use std::{fs, io, path::PathBuf, str::FromStr};
 pub struct Asset {
     pub name: String,
     pub link: String,
-    pub description: Option<String>,
+    pub description: String,
     pub order: Option<usize>,
     pub image: Option<String>,
 


### PR DESCRIPTION
Now that all assets are fixed, description presence can be validated during parsing instead of later