### PR TITLE
Use example.com for illustrative email addresses

### DIFF
--- a/content/learn/book/getting-started/setup/_index.md
+++ b/content/learn/book/getting-started/setup/_index.md
@@ -63,7 +63,7 @@ fn main() {
 [package]
 name = "my_bevy_game"
 version = "0.1.0"
-authors = ["You <you@veryrealemail.com>"]
+authors = ["You <you@example.com>"]
 edition = "2018"
 
 [dependencies]
@@ -77,7 +77,7 @@ Bevy is [available as a library on crates.io](https://crates.io/crates/bevy), th
 [package]
 name = "my_bevy_game"
 version = "0.1.0"
-authors = ["You <you@veryrealemail.com>"]
+authors = ["You <you@example.com>"]
 edition = "2018"
 
 [dependencies]


### PR DESCRIPTION
The "veryrealemail.com" domain is actually owned by some individual (check the whois record). 

The [IANA has some reserved domains](https://www.iana.org/domains/reserved) for this purpose: example.com and example.org. Alternatively [RFC2606](https://datatracker.ietf.org/doc/html/rfc2606) also specifies an illustrative TLD, *.example*, that could also be appropriate: i.e. you@veryrealemail.example