### PR TITLE
Recommend using the Rustup toolchain-file for nightly rust

### DIFF
--- a/content/learn/book/getting-started/setup/_index.md
+++ b/content/learn/book/getting-started/setup/_index.md
@@ -108,15 +108,13 @@ Bevy can be built just fine using default configuration on stable Rust. However 
         ```
     * **MacOS**: Modern LLD does not yet support MacOS, but we can use zld instead: `brew install michaeleisel/zld/zld`
 * **Nightly Rust Compiler**: This gives access to the latest performance improvements and "unstable" optimizations
-    ```sh
-    # Install the nightly toolchain
-    rustup toolchain install nightly
-    # Configure your current project to use nightly (run this command within the project)
-    rustup override set nightly
-    # OR configure cargo to use nightly for all projects -- switch back with `rustup default stable`
-    rustup default nightly
+    
+    Create a ```rust-toolchain``` file in the root of your project, next to ```Cargo.toml```.
+    ```toml
+    [toolchain]
+    channel = "nightly"
     ```
-    * You can use `cargo +nightly ...` if you don't want to change the default to nightly.
+    For more information, see [The rustup book: Overrides](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file).
 * **Generic Sharing**: Allows crates to share monomorphized generic code instead of duplicating it. In some cases this allows us to "precompile" generic code so it doesn't affect iterative compiles. This is only available on nightly Rust.
 
 To enable fast compiles, install the nightly rust compiler and LLD. Then copy [this file](https://github.com/bevyengine/bevy/blob/main/.cargo/config_fast_builds) to `YOUR_WORKSPACE/.cargo/config.toml`. For the project in this guide, that would be `my_bevy_game/.cargo/config.toml`.


### PR DESCRIPTION
Using a ```rust-toolchain``` file is much simpler to set up, compared to manual rustup overrides. Also, using the ```rust-toolchain``` file allows other people that download a repository to get going immediately without any manual configuration of their local toolchain.

Finally, in my opinion the toolchain version should be checked into source control anyway, since a codebase written with the nightly compiler in mind may not compile on stable rust. This makes the toolchain basically a build-dependency, and we obviously value checking in other build-dependencies via ```Cargo.toml```.

