### PR TITLE
Fix dependency error

### DIFF
--- a/content/learn/book/getting-started/_index.md
+++ b/content/learn/book/getting-started/_index.md
@@ -55,7 +55,7 @@ This is the current `bevy` crate version:
 **_NOTE:_** Bevy is currently being updated at a rapid pace. Taking a dependency on the git repo instead of the cargo crate will allow you to receive the latest updates as fast as possible. *However*, **there are often breaking changes made to APIs and behavior**. This means that it will be important to keep up with the latest developments with bevy. **This is not recommended for people who are just getting started with bevy.**
 ```toml
 [dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy" }
+bevy = { git = "https://github.com/bevyengine/bevy", branch = "main" }
 ```
 
 In general it's a good idea to lock in to a specific commit hash, which gives you control over when you take updates. You can find the [latest commit hash here](https://github.com/bevyengine/bevy/commits/main) (to the right of each commit).


### PR DESCRIPTION
Cargo looks for a "master" branch, but bevy changed it's convention to "main" causing the following error:
```
error: failed to get `bevy` as a dependency of package `xxx`

Caused by:
  failed to load source for dependency `bevy`

Caused by:
  Unable to update https://github.com/bevyengine/bevy

Caused by:
  failed to find branch `master`

Caused by:
  cannot locate remote-tracking branch 'origin/master'; class=Reference (4); code=NotFound (-3)
```
This change suggested by @mockersf fixes that.