### PR TITLE
Remove author section in Cargo.toml in _index.md

### DIFF
--- a/content/learn/book/getting-started/setup/_index.md
+++ b/content/learn/book/getting-started/setup/_index.md
@@ -63,7 +63,6 @@ fn main() {
 [package]
 name = "my_bevy_game"
 version = "0.1.0"
-authors = ["You <you@example.com>"]
 edition = "2018"
 
 [dependencies]
@@ -77,7 +76,6 @@ Bevy is [available as a library on crates.io](https://crates.io/crates/bevy), th
 [package]
 name = "my_bevy_game"
 version = "0.1.0"
-authors = ["You <you@example.com>"]
 edition = "2018"
 
 [dependencies]


### PR DESCRIPTION
The authors field is no longer included in Cargo.toml for new projects from Cargo 1.53 so it is removed from the setup guide.
"https://bevyengine.org/learn/book/getting-started/setup/"