### PR TITLE
Start 0.5 -> 0.6 Migration guide

### DIFF
--- a/content/learn/book/migration-guides/0.5-0.6/_index.md
+++ b/content/learn/book/migration-guides/0.5-0.6/_index.md
@@ -48,3 +48,38 @@ fn main() {
         .run();
 }
 ```
+
+### "Light" and "LightBundle" are now "PointLight" and "PointLightBundle"
+
+```rust
+// 0.5
+commands.spawn_bundle(LightBundle {
+    light: Light {
+        color: Color::rgb(1.0, 1.0, 1.0),
+        depth: 0.1..50.0,
+        fov: f32::to_radians(60.0),
+        intensity: 200.0,
+        range: 20.0,
+    }
+    ..Default::default()
+});
+
+// 0.6
+commands.spawn_bundle(PointLightBundle {
+    light: PointLight {
+        color: Color::rgb(1.0, 1.0, 1.0),
+        intensity: 200.0,
+        range: 20.0,
+    }
+    ..Default::default()
+});
+```
+
+The {{rust_type(type="struct" crate="bevy_pbr" mod="" version="0.5.0" name="Light" no_mod=true)}} and {{rust_type(type="struct" crate="bevy_pbr" mod="" version="0.5.0" name="LightBundle" no_mod=true)}} were renamed to {{rust_type(type="struct" crate="bevy_pbr" mod="" version="0.6.0" name="PointLight" no_mod=true)}} and {{rust_type(type="struct" crate="bevy_pbr" mod="" version="0.6.0" name="PointLightBundle" no_mod=true)}} to more clearly communicate the behavior of the Light Source.
+At the same time the `fov` and `depth` fields were removed from the {{rust_type(type="struct" crate="bevy_pbr" mod="" version="0.6.0" name="PointLight" no_mod=true)}} as they were unused.
+
+<!-- TODO: Remove this comment if https://github.com/bevyengine/bevy/pull/2367 is merged.
+
+In addition the {{rust_type(type="struct" crate="bevy_pbr" mod="" version="0.6.0" name="DirectionalLight" no_mod=true)}} and {{rust_type(type="struct" crate="bevy_pbr" mod="" version="0.6.0" name="DirectionalLightBundle" no_mod=true)}} were introduced with `0.6`.
+
+-->

--- a/content/learn/book/migration-guides/0.5-0.6/_index.md
+++ b/content/learn/book/migration-guides/0.5-0.6/_index.md
@@ -145,6 +145,49 @@ In addition the {{rust_type(type="struct" crate="bevy_pbr" mod="" version="0.6.0
 
 -->
 
+### System Param Lifetime Split
+
+The Lifetime of {{rust_type(type="trait" crate="bevy_ecs" mod="system" version="0.5.0" name="SystemParam" no_mod=true)}} was split in two separate Lifetimes.
+
+```rust
+// 0.5
+type SystemParamAlias<'a> = (Res<'a, AssetServer>, Query<'a, &'static Transform>, Local<'a, i32>);
+
+#[derive(SystemParam)]
+struct SystemParamDerive<'a> {
+    res: Res<'a, AssetServer>,
+    query: Query<'a, &Transform>,
+    local: Local<'a, i32>,
+}
+
+// 0.6
+type SystemParamAlias<'w, 's> = (Res<'w, AssetServer>, Query<'w, 's, &'static Transform>, Local<'s, i32>);
+
+#[derive(SystemParam)]
+struct SystemParamDerive<'w, 's> {
+    res: Res<'w, AssetServer>,
+    query: Query<'w, 's, &'static Transform>,
+    local: Local<'s, i32>,
+}
+```
+
+### QuerySet declare "QueryState" instead of "Query"
+<!-- Adapt for ParamSet instead, if https://github.com/bevyengine/bevy/pull/2765 is merged -->
+
+Due to the [System Param Lifetime Split](#system-param-lifetime-split), {{rust_type(type="struct" crate="bevy_ecs" mod="system" name="QuerySet" version="0.6.0" no_mod=true plural=true)}} now need to specify their Queries with {{rust_type(type="struct" crate="bevy_ecs" mod="query" version="0.6.0" name="QuerySet" no_mod=true)}} instead of {{rust_type(type="struct" crate="bevy_ecs" mod="system" version="0.6.0" name="Query" no_mod=true)}}.
+
+```rust
+// 0.5
+fn query_set(mut queries: QuerySet<(Query<&mut Transform>, Query<&Transform>)>) {
+
+}
+
+// 0.6
+fn query_set(mut queries: QuerySet<(QueryState<&mut Transform>, QueryState<&Transform>)>) {
+
+}
+```
+
 ### "SystemState" is now "SystemMeta"
 
 The {{rust_type(type="struct" crate="bevy_ecs" mod="system" version="0.5.0" name="SystemState" no_mod=true)}} struct, which stores the metadata of a System, was renamed to {{rust_type(type="struct" crate="bevy_ecs" mod="system" version="0.6.0" name="SystemMeta" no_mod=true)}}.

--- a/content/learn/book/migration-guides/0.5-0.6/_index.md
+++ b/content/learn/book/migration-guides/0.5-0.6/_index.md
@@ -8,6 +8,41 @@ page_template = "book-section.html"
 long_title = "Migration Guide: 0.5 to 0.6"
 +++
 
+### "AppBuilder" was merged into "App"
+
+All functions of {{rust_type(type="struct" crate="bevy_app" mod="" version="0.5.0" name="AppBuilder" no_mod=true)}} were merged into {{rust_type(type="struct" crate="bevy_app" mod="" version="0.6.0" name="App" no_mod=true)}}.
+
+In practice this means that you start constructing an {{rust_type(type="struct" crate="bevy_app" mod="" version="0.6.0" name="App" no_mod=true)}} by calling {{rust_type(type="struct" crate="bevy_app" mod="" version="0.6.0" name="App" no_mod=true method="new")}} instead of {{rust_type(type="struct" crate="bevy_app" mod="" version="0.5.0" name="App" no_mod=true method="build")}} and {{rust_type(type="trait" crate="bevy_app" mod="" version="0.5.0" name="Plugin" no_mod=true method="build")}} takes a {{rust_type(type="struct" crate="bevy_app" mod="" version="0.6.0" name="App" no_mod=true)}} instead of a {{rust_type(type="struct" crate="bevy_app" mod="" version="0.5.0" name="AppBuilder" no_mod=true)}}
+
+```rs
+// 0.5
+fn main() {
+    App::build()
+        .add_plugin(SomePlugin)
+        .run();
+}
+
+impl Plugin for SomePlugin {
+    fn build(&self, app: &mut AppBuilder) {
+
+    }
+}
+
+// 0.6
+fn main() {
+    App::new()
+        .add_plugin(SomePlugin)
+        .run();
+}
+
+impl Plugin for SomePlugin {
+    fn build(&self, app: &mut App) {
+
+    }
+}
+
+```
+
 ### Calling ".system()" on a system is now optional
 
 ```rust
@@ -21,7 +56,7 @@ fn main() {
 
 // 0.6
 fn main() {
-    App::build()
+    App::new()
         .add_system(first_system)
         .add_system(second_system.system())
         .run();
@@ -42,7 +77,7 @@ fn main() {
 
 // 0.6
 fn main() {
-    App::build()
+    App::new()
         .add_system(first_system.label("FirstSystem"))
         .add_system(second_system.after("FirstSystem"))
         .run();

--- a/content/learn/book/migration-guides/0.5-0.6/_index.md
+++ b/content/learn/book/migration-guides/0.5-0.6/_index.md
@@ -49,6 +49,31 @@ fn main() {
 }
 ```
 
+### ".single()" and ".single_mut()" are now infallible
+
+The functions {{rust_type(type="struct" crate="bevy_ecs" mod="system" version="0.6.0" name="Query" no_mod=true method="single")}} and {{rust_type(type="struct" crate="bevy_ecs" mod="system" version="0.6.0" name="Query" no_mod=true method="single_mut")}} no longer return a {{rust_type(type="enum", crate="std" mod="result", name="Result", no_mod=true)}} and Panic instead, if not exactly one Entity was found.
+
+If you need the old behavior you can use the fallible {{rust_type(type="struct" crate="bevy_ecs" mod="system" version="0.6.0" name="Query" no_mod=true method="get_single")}} and {{rust_type(type="struct" crate="bevy_ecs" mod="system" version="0.6.0" name="Query" no_mod=true method="get_single_mut")}} instead.
+
+```rs
+// 0.5
+fn player_system(query: Query<&Transform, With<Player>>) {
+    let player_position = query.single().unwrap();
+    // do something with player_position
+}
+
+// 0.6
+fn player_system_infallible(query: Query<&Transform, With<Player>>) {
+    let player_position = query.single();
+    // do something with player_position
+}
+
+fn player_system_fallible(query: Query<&Transform, With<Player>>) {
+    let player_position = query.get_single().unwrap();
+    // do something with player_position
+}
+```
+
 ### "Light" and "LightBundle" are now "PointLight" and "PointLightBundle"
 
 ```rust

--- a/content/learn/book/migration-guides/0.5-0.6/_index.md
+++ b/content/learn/book/migration-guides/0.5-0.6/_index.md
@@ -84,40 +84,9 @@ In addition the {{rust_type(type="struct" crate="bevy_pbr" mod="" version="0.6.0
 
 -->
 
-### New SystemState and rename old SystemState to SystemMeta
+### "SystemState" is now "SystemMeta"
 
-To get easier cached access to a {{rust_type(type="trait" crate="bevy_ecs" mod="system" version="0.6.0" name="SystemParam" no_mod=true)}} outside of a system, a new {{rust_type(type="struct" crate="bevy_ecs" mod="system" version="0.6.0" name="SystemState" no_mod=true)}} was introduced.
+The {{rust_type(type="struct" crate="bevy_ecs" mod="system" version="0.5.0" name="SystemState" no_mod=true)}} struct, which stores the metadata of a System, was renamed to {{rust_type(type="struct" crate="bevy_ecs" mod="system" version="0.6.0" name="SystemMeta" no_mod=true)}}.
 
-<!-- Adapted from https://github.com/bevyengine/bevy/pull/2283 -->
-```rust
-#[derive(Eq, PartialEq, Debug)]
-struct A(usize);
-
-#[derive(Eq, PartialEq, Debug)]
-struct B(usize);
-
-let mut world = World::default();
-world.insert_resource(A(42));
-world.spawn().insert(B(7));
-
-// we get nice lifetime elision when declaring the type on the left hand side
-let mut system_state: SystemState<(Commands, Res<A>, Query<&B>)> = SystemState::new(&mut world);
-{
-  let (mut commands, res, query) = system_state.get(&world);
-
-  assert_eq!(*res, A(42), "returned resource matches initial value");
-  assert_eq!(
-      *query.single().unwrap(),
-      B(7),
-      "returned component matches initial value"
-  );
-
-  commands.insert_resource(3.14);
-}
-// It is the user's responsibility to call SystemState::apply(world) for parameters that queue up work
-system_state.apply(&mut world);
-```
-
-See the original [PR](https://github.com/bevyengine/bevy/pull/2283) for a larger usage example.
-
-The preexisting {{rust_type(type="struct" crate="bevy_ecs" mod="system" version="0.5.0" name="SystemState" no_mod=true)}} in `0.5` was renamed to {{rust_type(type="struct" crate="bevy_ecs" mod="system" version="0.6.0" name="SystemMeta" no_mod=true)}}.
+This was done to accomedate the new {{rust_type(type="struct" crate="bevy_ecs" mod="system" version="0.6.0" name="SystemState" no_mod=true)}} which allows easier cached access to {{rust_type(type="trait" crate="bevy_ecs" mod="system" version="0.6.0" name="SystemParam" no_mod=true plural=true)}} outside of a regular System.
+<!-- TODO: Link to entry for SystemState in the release blog post. -->

--- a/content/learn/book/migration-guides/0.5-0.6/_index.md
+++ b/content/learn/book/migration-guides/0.5-0.6/_index.md
@@ -227,6 +227,10 @@ fn query_set(mut queries: QuerySet<(QueryState<&mut Transform>, QueryState<&Tran
 }
 ```
 
+### "Input\<T\>.update()" is renamed to "Input\<T\>.clear()"
+
+The {{rust_type(type="struct" crate="bevy_input" mod="" version="0.5.0" name="Input" no_mod=true method="update")}} function was renamed to {{rust_type(type="struct" crate="bevy_input" mod="" version="0.6.0" name="Input" no_mod=true method="clear")}}.
+
 ### "SystemState" is now "SystemMeta"
 
 The {{rust_type(type="struct" crate="bevy_ecs" mod="system" version="0.5.0" name="SystemState" no_mod=true)}} struct, which stores the metadata of a System, was renamed to {{rust_type(type="struct" crate="bevy_ecs" mod="system" version="0.6.0" name="SystemMeta" no_mod=true)}}.

--- a/content/learn/book/migration-guides/0.5-0.6/_index.md
+++ b/content/learn/book/migration-guides/0.5-0.6/_index.md
@@ -60,7 +60,7 @@ commands.spawn_bundle(LightBundle {
         fov: f32::to_radians(60.0),
         intensity: 200.0,
         range: 20.0,
-    }
+    },
     ..Default::default()
 });
 
@@ -70,7 +70,7 @@ commands.spawn_bundle(PointLightBundle {
         color: Color::rgb(1.0, 1.0, 1.0),
         intensity: 200.0,
         range: 20.0,
-    }
+    },
     ..Default::default()
 });
 ```

--- a/content/learn/book/migration-guides/0.5-0.6/_index.md
+++ b/content/learn/book/migration-guides/0.5-0.6/_index.md
@@ -1,0 +1,9 @@
++++
+title = "0.5 to 0.6"
+weight = 1
+sort_by = "weight"
+template = "book-section.html"
+page_template = "book-section.html"
+[extra]
+long_title = "Migration Guide: 0.5 to 0.6"
++++

--- a/content/learn/book/migration-guides/0.5-0.6/_index.md
+++ b/content/learn/book/migration-guides/0.5-0.6/_index.md
@@ -45,6 +45,8 @@ impl Plugin for SomePlugin {
 
 ### Calling ".system()" on a system is now optional
 
+When adding a system to Bevy it is no longer necessary to call `.system()` beforehand.
+
 ```rust
 // 0.5
 fn main() {
@@ -63,8 +65,7 @@ fn main() {
 }
 ```
 
-When adding a system to Bevy it is no longer necessary to call `.system()` beforehand.
-System Configuration Functions like `.label()` or `.config()` can now also be directly called on a system.
+System configuration Functions like `.label()` or `.config()` can now also be directly called on a system.
 
 ```rust
 // 0.5
@@ -148,5 +149,5 @@ In addition the {{rust_type(type="struct" crate="bevy_pbr" mod="" version="0.6.0
 
 The {{rust_type(type="struct" crate="bevy_ecs" mod="system" version="0.5.0" name="SystemState" no_mod=true)}} struct, which stores the metadata of a System, was renamed to {{rust_type(type="struct" crate="bevy_ecs" mod="system" version="0.6.0" name="SystemMeta" no_mod=true)}}.
 
-This was done to accomedate the new {{rust_type(type="struct" crate="bevy_ecs" mod="system" version="0.6.0" name="SystemState" no_mod=true)}} which allows easier cached access to {{rust_type(type="trait" crate="bevy_ecs" mod="system" version="0.6.0" name="SystemParam" no_mod=true plural=true)}} outside of a regular System.
+This was done to accommodate the new {{rust_type(type="struct" crate="bevy_ecs" mod="system" version="0.6.0" name="SystemState" no_mod=true)}} which allows easier cached access to {{rust_type(type="trait" crate="bevy_ecs" mod="system" version="0.6.0" name="SystemParam" no_mod=true plural=true)}} outside of a regular System.
 <!-- TODO: Link to entry for SystemState in the release blog post. -->

--- a/content/learn/book/migration-guides/0.5-0.6/_index.md
+++ b/content/learn/book/migration-guides/0.5-0.6/_index.md
@@ -42,7 +42,7 @@ impl Plugin for SomePlugin {
 }
 ```
 
-### The "Component" Trait does now need to be derived
+### The "Component" trait now needs to be derived
 
 Bevy no longer has a blanket implementation for the {{rust_type(type="trait" crate="bevy_ecs" mod="component" version="0.6.0" name="Component" no_mod=true)}} trait.
 Instead you need to derive (or manualy implement) the trait for every Type that needs it.

--- a/content/learn/book/migration-guides/0.5-0.6/_index.md
+++ b/content/learn/book/migration-guides/0.5-0.6/_index.md
@@ -7,3 +7,44 @@ page_template = "book-section.html"
 [extra]
 long_title = "Migration Guide: 0.5 to 0.6"
 +++
+
+### Calling ".system()" on a system is now optional
+
+```rust
+// 0.5
+fn main() {
+    App::build()
+        .add_system(first_system.system())
+        .add_system(second_system.system())
+        .run();
+}
+
+// 0.6
+fn main() {
+    App::build()
+        .add_system(first_system)
+        .add_system(second_system.system())
+        .run();
+}
+```
+
+When adding a system to Bevy it is no longer necessary to call `.system()` beforehand.
+Functions like `.label()` or `.config()` can now also be directly called on a system.
+
+```rust
+// 0.5
+fn main() {
+    App::build()
+        .add_system(first_system.system().label("FirstSystem"))
+        .add_system(second_system.system().after("FirstSystem"))
+        .run();
+}
+
+// 0.6
+fn main() {
+    App::build()
+        .add_system(first_system.label("FirstSystem"))
+        .add_system(second_system.after("FirstSystem"))
+        .run();
+}
+```

--- a/content/learn/book/migration-guides/0.5-0.6/_index.md
+++ b/content/learn/book/migration-guides/0.5-0.6/_index.md
@@ -29,7 +29,7 @@ fn main() {
 ```
 
 When adding a system to Bevy it is no longer necessary to call `.system()` beforehand.
-Functions like `.label()` or `.config()` can now also be directly called on a system.
+System Configuration Functions like `.label()` or `.config()` can now also be directly called on a system.
 
 ```rust
 // 0.5
@@ -83,3 +83,55 @@ At the same time the `fov` and `depth` fields were removed from the {{rust_type(
 In addition the {{rust_type(type="struct" crate="bevy_pbr" mod="" version="0.6.0" name="DirectionalLight" no_mod=true)}} and {{rust_type(type="struct" crate="bevy_pbr" mod="" version="0.6.0" name="DirectionalLightBundle" no_mod=true)}} were introduced with `0.6`.
 
 -->
+
+### New SystemState and rename old SystemState to SystemMeta
+
+To get easier cached access to a {{rust_type(type="trait" crate="bevy_ecs" mod="system" version="0.6.0" name="SystemParam" no_mod=true)}} outside of a system, a new {{rust_type(type="struct" crate="bevy_ecs" mod="system" version="0.6.0" name="SystemState" no_mod=true)}} was introduced.
+
+<!-- Directly taken from https://github.com/bevyengine/bevy/pull/2283 -->
+```rust
+#[derive(Eq, PartialEq, Debug)]
+struct A(usize);
+
+#[derive(Eq, PartialEq, Debug)]
+struct B(usize);
+
+let mut world = World::default();
+world.insert_resource(A(42));
+world.spawn().insert(B(7));
+
+// we get nice lifetime elision when declaring the type on the left hand side
+let mut system_state: SystemState<(Res<A>, Query<&B>)> = SystemState::new(&mut world);
+let (a, query) = system_state.get(&world);
+assert_eq!(*a, A(42), "returned resource matches initial value");
+assert_eq!(
+    *query.single().unwrap(),
+    B(7),
+    "returned component matches initial value"
+);
+
+// mutable system params require unique world access
+let mut system_state: SystemState<(ResMut<A>, Query<&mut B>)> = SystemState::new(&mut world);
+let (a, query) = system_state.get_mut(&mut world);
+
+// static lifetimes are required when declaring inside of structs
+struct SomeContainer {
+  state: SystemState<(Res<'static, A>, Res<'static, B>)>
+}
+
+// this can be shortened using type aliases, which will be useful for complex param tuples
+type MyParams<'a> = (Res<'a, A>, Res<'a, B>);
+struct SomeContainer {
+  state: SystemState<MyParams<'static>>
+}
+
+// It is the user's responsibility to call SystemState::apply(world) for parameters that queue up work
+let mut system_state: SystemState<(Commands, Query<&B>)> = SystemState::new(&mut world);
+{
+  let (mut commands, query) = system_state.get(&world);
+  commands.insert_resource(3.14);
+}
+system_state.apply(&mut world);
+```
+
+The preexisting {{rust_type(type="struct" crate="bevy_ecs" mod="system" version="0.5.0" name="SystemState" no_mod=true)}} in `0.5` was renamed to {{rust_type(type="struct" crate="bevy_ecs" mod="system" version="0.6.0" name="SystemMeta" no_mod=true)}}.

--- a/content/learn/book/migration-guides/0.5-0.6/_index.md
+++ b/content/learn/book/migration-guides/0.5-0.6/_index.md
@@ -40,7 +40,46 @@ impl Plugin for SomePlugin {
 
     }
 }
+```
 
+### The "Component" Trait does now need to be derived
+
+Bevy no longer has a blanket implementation for the {{rust_type(type="trait" crate="bevy_ecs" mod="component" version="0.6.0" name="Component" no_mod=true)}} trait.
+Instead you need to derive (or manualy implement) the trait for every Type that needs it.
+
+```rust
+// 0.5
+struct MyComponent;
+
+// 0.6
+#[derive(Component)]
+struct MyComponent;
+```
+
+In order to use foreign types as components, wrap them using the newtype pattern.
+
+```rust
+#[derive(Component)]
+struct Cooldown(std::time::Duration);
+```
+
+### Setting the Component Storage is now done in "Component" Trait
+
+The change to deriving {{rust_type(type="trait" crate="bevy_ecs" mod="component" version="0.6.0" name="Component" no_mod=true)}}, enabled setting the Component Storage at compiletime instead of runtime.
+
+```rust
+// 0.5
+appbuilder
+    .world
+    .register_component(ComponentDescriptor::new::<MyComponent>(
+        StorageType::SparseSet,
+    ))
+    .unwrap();
+
+// 0.6
+#[derive(Component)]
+#[component(storage = "SparseSet")]
+struct MyComponent;
 ```
 
 ### Calling ".system()" on a system is now optional


### PR DESCRIPTION
This PR starts a new Migration guide, with the following changes:

1. bevyengine/bevy#2531
2. Optional `.system()` from bevyengine/bevy#2398, bevyengine/bevy#2403, bevyengine/bevy#2422 and bevyengine/bevy#2431,
3. bevyengine/bevy#2793
4. bevyengine/bevy#1778
5. bevyengine/bevy#2605
6. bevyengine/bevy#2283
7. bevyengine/bevy#2254
8. bevyengine/bevy#1781

Ignored Changes:
1. bevyengine/bevy#1959: Changes might be obsoleted/lumped in with the render rework
2. bevyengine/bevy#2623: The PR has the `S-Needs-Migration-Guide` Label, but the feature was already broken in `0.5` and originally fixed in bevyengine/bevy#2024
3. bevyengine/bevy#2606: The change is small and the old `.add_plugin(bevy::app::ScheduleRunnerPlugin {})` syntax still compiles in `0.6`.

I started this, before noticing that #134 already exists. 