### PR TITLE
removed explicit branch="main" in dependencies

### DIFF
--- a/content/learn/book/getting-started/_index.md
+++ b/content/learn/book/getting-started/_index.md
@@ -55,7 +55,7 @@ This is the current `bevy` crate version:
 **_NOTE:_** Bevy is currently being updated at a rapid pace. Taking a dependency on the git repo instead of the cargo crate will allow you to receive the latest updates as fast as possible. *However*, **there are often breaking changes made to APIs and behavior**. This means that it will be important to keep up with the latest developments with bevy. **This is not recommended for people who are just getting started with bevy.**
 ```toml
 [dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", branch = "main" }
+bevy = { git = "https://github.com/bevyengine/bevy" }
 ```
 
 In general it's a good idea to lock in to a specific commit hash, which gives you control over when you take updates. You can find the [latest commit hash here](https://github.com/bevyengine/bevy/commits/main) (to the right of each commit).


### PR DESCRIPTION
Support was added as of 1.53.0, I believe this is no longer needed.

https://blog.rust-lang.org/2021/06/17/Rust-1.53.0.html#head-branch-name-support-in-cargo

Closes #171 