### PR TITLE
fix code highlighting after zola 0.14

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,10 +7,6 @@ title = "Bevy Engine"
 # Whether to automatically compile all Sass files in the sass directory
 compile_sass = true
 
-# Whether to do syntax highlighting
-# Theme can be customised by setting the `highlight_theme` variable to a theme supported by Zola
-highlight_code = true
-
 # Whether to build a search index to be used later on by a JavaScript library
 build_search_index = true
 
@@ -21,6 +17,13 @@ highlight_theme = "charcoal"
 taxonomies = [
     {name = "news", feed = true},
 ]
+
+[markdown]
+# Whether to do syntax highlighting
+# Theme can be customised by setting the `highlight_theme` variable to a theme supported by Zola
+highlight_code = true
+highlight_theme = "base16-ocean-dark"
+
 
 [extra]
 # Put all your custom variables here

--- a/sass/site.scss
+++ b/sass/site.scss
@@ -9,7 +9,7 @@ $default-color: #ececec;
 $content-top-margin: 30px;
 $default-padding: 15px;
 $subtitle-color: #8f8f8f;
-$syntax-theme-background: #2b2c2f;
+$syntax-theme-background: #2b303b;
 $syntax-theme-background-hover: #414247;
 $default-image-background-color: #1b1b1b;
 $card-hover-background: #2f3033;


### PR DESCRIPTION
- move the config option to the correct section
- fix the background color