### PR TITLE
Add more vertical negative space to navbar logo

### DIFF
--- a/sass/_headerbar.scss
+++ b/sass/_headerbar.scss
@@ -16,7 +16,7 @@
 }
 
 .logo {
-    height: 100%;
+    height: 75%;
 }
 
 .header-logo, .header-logo-mobile, .toggle-nav-mobile {
@@ -69,7 +69,7 @@ $header-active-color: #b1d9ff;
 .header-message {
     text-align: center;
     color: #797979;
-    font-size: 2.3rem;
+    font-size: 1.725rem;
 }
 
 .header-button {


### PR DESCRIPTION
The logo currently fills up too much vertical space on the navbar. This PR shrinks it and the `header-message` by 25% to provide more vertical negative space.