### PR TITLE
do not remove msaa from examples

### DIFF
--- a/generate-wasm-examples/generate_wasm_examples.sh
+++ b/generate-wasm-examples/generate_wasm_examples.sh
@@ -14,9 +14,6 @@ sed -i.bak 's/width: 1280.,/width: 1024.,/' crates/bevy_window/src/window.rs
 # setting a canvas by default to help with integration
 sed -i.bak 's/canvas: None,/canvas: Some("#bevy".to_string()),/' crates/bevy_window/src/window.rs
 
-# disable msaa on any example that may set it
-sed -i.bak 's/Msaa { samples: 4 }/Msaa { samples: 1 }/' examples/*/*.rs
-
 
 add_category()
 {


### PR DESCRIPTION
This bug is fixed in wgpu, workaround is no longer needed

To merge after https://github.com/bevyengine/bevy/pull/3489

(also, next rebuild will have 3d examples working as bug in naga has been fixed and a patch has been released)