### PR TITLE
permutations -> combinations

### DIFF
--- a/content/news/2022-01-08-bevy-0.6/index.md
+++ b/content/news/2022-01-08-bevy-0.6/index.md
@@ -690,7 +690,7 @@ We plan on exposing more control over scheduling, running, and working with sub-
 
 <div class="release-feature-authors">authors: @Frizi</div>
 
-You can now iterate all permutations of N entities for a given query:
+You can now iterate all combinations of N entities for a given query:
 
 ```rust
 fn system(query: Query<&Player>) {


### PR DESCRIPTION
Use `combinations` for consistency. See also [the discussion on wording](https://github.com/bevyengine/bevy/pull/1763#issuecomment-808781977).

Resolves this [reddit complaint](https://www.reddit.com/r/rust/comments/rz612l/comment/hru3tkk/?utm_source=reddit&utm_medium=web2x&context=3)

