### PR TITLE
fix crevice example field name

### DIFF
--- a/content/news/2022-01-08-bevy-0.6/index.md
+++ b/content/news/2022-01-08-bevy-0.6/index.md
@@ -488,7 +488,7 @@ Coupling an `AsStd140` derive with our new `UniformVec<T>` type makes it easy to
 ```rust
 // WGSL shader
 struct Mesh {
-    model: mat4x4<f32>;
+    transform: mat4x4<f32>;
     inverse_transpose_model: mat4x4<f32>;
 };
 


### PR DESCRIPTION
I think field names of the rust struct directly match with the field names of the shader struct.