### PR TITLE
Add Visible -> Visibility to migration guide

### DIFF
--- a/content/learn/book/migration-guides/0.5-0.6/_index.md
+++ b/content/learn/book/migration-guides/0.5-0.6/_index.md
@@ -307,3 +307,38 @@ SpriteBundle {
     ..Default::default()
 }
 ```
+
+### Visible is now Visibility 
+The {{rust_type(type="struct" crate="bevy" mod="render::draw" version="0.5.0" name="Visible" no_mod=true)}} struct, which is used in a number of components to set visibility, was renamed to {{rust_type(type="struct" crate="bevy" mod="render::view" version="0.6.0" name="Visibility" no_mod=true)}}. Additionally, the field `is_transparent` was removed from the struct. For 3D, transparency can be set using the `alpha_mode` field on a material. Transparency is now automatically enabled for all objects in 2D. 
+
+```rust
+// 0.5
+let material_handle = materials.add(StandardMaterial {
+    base_color_texture: Some(texture.clone()),
+    ..Default::default()
+});
+
+commands.spawn_bundle(PbrBundle {
+    material: material_handle,
+    visible: Visible {
+        is_visible: true,
+        is_transparent: true,
+    },
+    ..Default::default()
+});
+
+// 0.6
+let material_handle = materials.add(StandardMaterial {
+    base_color_texture: Some(texture.clone()),
+    alpha_mode: AlphaMode::Blend,
+    ..Default::default()
+});
+
+commands.spawn_bundle(PbrBundle {
+    material: material_handle,
+    visibility: Visibility {
+        is_visible: true,
+    },
+    ..Default::default()
+});
+```


### PR DESCRIPTION
This adds a note on the changes with Visibility. I'm open to suggestions on the is_transparent text