### PR TITLE
Add SpriteBundle section to 0.5 -> 0.6 migration guide

### DIFF
--- a/content/learn/book/migration-guides/0.5-0.6/_index.md
+++ b/content/learn/book/migration-guides/0.5-0.6/_index.md
@@ -11,6 +11,7 @@ long_title = "Migration Guide: 0.5 to 0.6"
 ### Rust 2021 now required
 
 Bevy has been updated to use Rust 2021. This means we can take advantage of the new Cargo feature resolver by default (which both Bevy and the new wgpu version require). Make sure you update your crates to Rust 2021 or you will need to manually enable the new feature resolver with `resolver = "2" in your Cargo.toml.
+
 ```toml
 [package]
 name = "your_app"
@@ -18,7 +19,7 @@ version = "0.1.0"
 edition = "2021"
 ```
 
-Note that "virtual Cargo workspaces" still need to manually define `resolver = "2"`, even in Rust 2021. [Refer to the Rust 2021 documentation](https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html#details) for details. 
+Note that "virtual Cargo workspaces" still need to manually define `resolver = "2"`, even in Rust 2021. [Refer to the Rust 2021 documentation](https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html#details) for details.
 
 ```toml
 [workspace]
@@ -229,6 +230,7 @@ struct SystemParamDerive<'w, 's> {
 ```
 
 ### QuerySet declare "QueryState" instead of "Query"
+
 <!-- Adapt for ParamSet instead, if https://github.com/bevyengine/bevy/pull/2765 is merged -->
 
 Due to the [System Param Lifetime Split](#system-param-lifetime-split), {{rust_type(type="struct" crate="bevy_ecs" mod="system" name="QuerySet" version="0.6.0" no_mod=true plural=true)}} now need to specify their Queries with {{rust_type(type="struct" crate="bevy_ecs" mod="query" version="0.6.0" name="QueryState" no_mod=true)}} instead of {{rust_type(type="struct" crate="bevy_ecs" mod="system" version="0.6.0" name="Query" no_mod=true)}}.
@@ -254,9 +256,11 @@ The {{rust_type(type="struct" crate="bevy_input" mod="" version="0.5.0" name="In
 The {{rust_type(type="struct" crate="bevy_ecs" mod="system" version="0.5.0" name="SystemState" no_mod=true)}} struct, which stores the metadata of a System, was renamed to {{rust_type(type="struct" crate="bevy_ecs" mod="system" version="0.6.0" name="SystemMeta" no_mod=true)}}.
 
 This was done to accommodate the new {{rust_type(type="struct" crate="bevy_ecs" mod="system" version="0.6.0" name="SystemState" no_mod=true)}} which allows easier cached access to {{rust_type(type="trait" crate="bevy_ecs" mod="system" version="0.6.0" name="SystemParam" no_mod=true plural=true)}} outside of a regular System.
+
 <!-- TODO: Link to entry for SystemState in the release blog post. -->
 
 ### Vector casting functions are now named to match return type
+
 The casting functions for {{rust_type(type="struct" crate="bevy" mod="math" version="0.6.0" name="IVec2" no_mod=true)}}, {{rust_type(type="struct" crate="bevy" mod="math" version="0.6.0" name="DVec2" no_mod=true)}}, {{rust_type(type="struct" crate="bevy" mod="math" version="0.6.0" name="UVec2" no_mod=true)}}, {{rust_type(type="struct" crate="bevy" mod="math" version="0.6.0" name="Vec2" no_mod=true)}} have all been changed from being named after their inner elements' cast target to what the entire "Vec" is being casted into. This affects all the different dimensions of the math vectors (i.e., {{rust_type(type="struct" crate="bevy" mod="math" version="0.6.0" name="Vec2" no_mod=true)}}, {{rust_type(type="struct" crate="bevy" mod="math" version="0.6.0" name="Vec3" no_mod=true)}} and {{rust_type(type="struct" crate="bevy" mod="math" version="0.6.0" name="Vec4" no_mod=true)}}).
 
 ```rust
@@ -270,6 +274,5 @@ let xyz: IVec3 = xyz.as_ivec3();
 ```
 
 ### StandardMaterial's "roughness" is renamed to "perceptual_roughness"
+
 The {{rust_type(type="struct" crate="bevy_pbr" mod="" version="0.6.0" name="StandardMaterial" no_mod=true)}} field `roughness` was renamed to `perceptual_roughness`.
-
-

--- a/content/learn/book/migration-guides/0.5-0.6/_index.md
+++ b/content/learn/book/migration-guides/0.5-0.6/_index.md
@@ -279,7 +279,7 @@ The {{rust_type(type="struct" crate="bevy_pbr" mod="" version="0.6.0" name="Stan
 
 ### SpriteBundle and Sprite
 
-{{rust_type(type="struct" crate="bevy_sprite" mod="" version="0.6.0" name="SpriteBundle" no_mod=true)}} now uses a texture handle rather than a material and {{rust_type(type="struct" crate="bevy_sprite" mod="" version="0.6.0" name="Sprite" no_mod=true)}} has a `color` for tint. {{rust_type(type="struct" crate="bevy_sprite" mod="" version="0.6.0" name="Sprite" no_mod=true)}} had its `resize_mode` field replaced with a `custom_size`. The following example shows how to spawn a tinted sprite at a particular size. For simpler cases, check out the updated [sprite](https://github.com/bevyengine/bevy/blob/v0.6.0/examples/2d/sprite.rs) and [rect](https://github.com/bevyengine/bevy/blob/v0.6.0/examples/2d/rect.rs) examples.
+The {{rust_type(type="struct" crate="bevy_sprite" mod="" version="0.6.0" name="SpriteBundle" no_mod=true)}} now uses a `texture` handle rather than a `material`. The `color` field of the material is now directly available inside of the {{rust_type(type="struct" crate="bevy_sprite" mod="" version="0.6.0" name="Sprite" no_mod=true)}} struct, which also had its `resize_mode` field replaced with a `custom_size`. The following example shows how to spawn a tinted sprite at a particular size. For simpler cases, check out the updated [sprite](https://github.com/bevyengine/bevy/blob/v0.6.0/examples/2d/sprite.rs) and [rect](https://github.com/bevyengine/bevy/blob/v0.6.0/examples/2d/rect.rs) examples.
 
 ```rust
 // 0.5

--- a/content/learn/book/migration-guides/0.5-0.6/_index.md
+++ b/content/learn/book/migration-guides/0.5-0.6/_index.md
@@ -279,7 +279,7 @@ The {{rust_type(type="struct" crate="bevy_pbr" mod="" version="0.6.0" name="Stan
 
 ### SpriteBundle and Sprite
 
-{{rust_type(type="struct" crate="bevy_sprite" mod="" version="0.6.0" name="SpriteBundle" no_mod=true)}} now uses texture handle rather than a material and {{rust_type(type="struct" crate="bevy_sprite" mod="" version="0.6.0" name="Sprite" no_mod=true)}} has a `color` for tint. {{rust_type(type="struct" crate="bevy_sprite" mod="" version="0.6.0" name="Sprite" no_mod=true)}} had its `resize_mode` field replaced with a `custom_size`. The following example shows how to spawn a tinted sprite at a particular size. For simpler cases, check out the updated [sprite](https://github.com/bevyengine/bevy/blob/v0.6.0/examples/2d/sprite.rs) and [rect](https://github.com/bevyengine/bevy/blob/v0.6.0/examples/2d/rect.rs) examples.
+{{rust_type(type="struct" crate="bevy_sprite" mod="" version="0.6.0" name="SpriteBundle" no_mod=true)}} now uses a texture handle rather than a material and {{rust_type(type="struct" crate="bevy_sprite" mod="" version="0.6.0" name="Sprite" no_mod=true)}} has a `color` for tint. {{rust_type(type="struct" crate="bevy_sprite" mod="" version="0.6.0" name="Sprite" no_mod=true)}} had its `resize_mode` field replaced with a `custom_size`. The following example shows how to spawn a tinted sprite at a particular size. For simpler cases, check out the updated [sprite](https://github.com/bevyengine/bevy/blob/v0.6.0/examples/2d/sprite.rs) and [rect](https://github.com/bevyengine/bevy/blob/v0.6.0/examples/2d/rect.rs) examples.
 
 ```rust
 // 0.5

--- a/content/learn/book/migration-guides/0.5-0.6/_index.md
+++ b/content/learn/book/migration-guides/0.5-0.6/_index.md
@@ -276,3 +276,34 @@ let xyz: IVec3 = xyz.as_ivec3();
 ### StandardMaterial's "roughness" is renamed to "perceptual_roughness"
 
 The {{rust_type(type="struct" crate="bevy_pbr" mod="" version="0.6.0" name="StandardMaterial" no_mod=true)}} field `roughness` was renamed to `perceptual_roughness`.
+
+### SpriteBundle and Sprite
+
+{{rust_type(type="struct" crate="bevy_sprite" mod="" version="0.6.0" name="SpriteBundle" no_mod=true)}} now uses texture handle rather than a material and {{rust_type(type="struct" crate="bevy_sprite" mod="" version="0.6.0" name="Sprite" no_mod=true)}} has a `color` for tint. {{rust_type(type="struct" crate="bevy_sprite" mod="" version="0.6.0" name="Sprite" no_mod=true)}} had its `resize_mode` field replaced with a `custom_size`. The following example shows how to spawn a tinted sprite at a particular size. For simpler cases, check out the updated [sprite](https://github.com/bevyengine/bevy/blob/v0.6.0/examples/2d/sprite.rs) and [rect](https://github.com/bevyengine/bevy/blob/v0.6.0/examples/2d/rect.rs) examples.
+
+```rust
+// 0.5
+SpriteBundle {
+    sprite: Sprite {
+        size: Vec2::new(256.0, 256.0),
+        resize_mode: SpriteResizeMode::Manual,
+        ..Default::default()
+    },
+    material: materials.add(ColorMaterial {
+        color: Color::RED,
+        texture: Some(asset_server.load("branding/icon.png")),
+    }),
+    ..Default::default()
+}
+
+// 0.6
+SpriteBundle {
+    sprite: Sprite {
+        custom_size: Some(Vec2::new(256.0, 256.0)),
+        color: Color::RED,
+        ..Default::default()
+    },
+    texture: asset_server.load("branding/icon.png"),
+    ..Default::default()
+}
+```


### PR DESCRIPTION
Let me know if there are any strong opinions about how I laid this out. I thought about showing the "simple examples" and then linking off to `contributors.rs` for the "advanced" stuff, but it seemed a bit harder to dig the relevant info out of that example.