### PR TITLE
Update main page for bevy 0.6

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -53,7 +53,7 @@
                 <h2 class="feature-title">3D Renderer</h2>
                 A modern and flexible 3D renderer
                 <ul class="feature-sublist">
-                    <li><b>Features: </b>lights, cameras, meshes, textures, materials, gltf loading</li>
+                    <li><b>Features: </b>lights, shadows, cameras, meshes, textures, materials, gltf loading</li>
                     <li><b>Extensible: </b>custom shaders, materials, and render pipelines</li>
                     <li><b>Common Core: </b>built on top of Bevy's Render Graph</li>
                 </ul>
@@ -82,11 +82,11 @@
                 <div class="feature-description">
                     Support for all major desktop platforms:
                     <ul class="feature-sublist">
-                        <li>Windows, MacOS, Linux</li>
+                        <li>Windows, MacOS, Linux, Web</li>
                     </ul>
                     With more on the way:
                     <ul class="feature-sublist">
-                        <li>Android, iOS, Web</li>
+                        <li>Android, iOS</li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
Just adding "shadows" to the list of 3d renderer features, and promoting "Web" to a supported platform.

I think it would be great to update the 3d renderer image as well in a way that showcases the new renderer.