### PR TITLE
Remove outdated paragraph (v0.6 fix)

### DIFF
--- a/content/learn/book/getting-started/ecs/_index.md
+++ b/content/learn/book/getting-started/ecs/_index.md
@@ -55,8 +55,6 @@ fn main() {
 }
 ```
 
-Note the `hello_world` function call. This is a "trait extension method" that converts the `hello_world` function into the {{rust_type(type="trait" crate="bevy_ecs" mod="system" no_mod=true name="System")}} type.
-
 The {{rust_type(type="struct" crate="bevy_app", name="App" method="add_system" no_struct=true)}} function adds the system to your App's {{rust_type(type="struct", crate="bevy_ecs", mod="schedule" no_mod=true name="Schedule")}}, but we'll cover that more later.
 
 Now run your App again using `cargo run`. You should see `hello world!` printed once in your terminal.


### PR DESCRIPTION
The `system()` call has been removed from the paragraph explaining it, but the whole sentence does not make sense anymore with `v0.6`.