### PR TITLE
Add note about cargo workspaces

### DIFF
--- a/content/learn/book/getting-started/setup/_index.md
+++ b/content/learn/book/getting-started/setup/_index.md
@@ -81,6 +81,15 @@ edition = "2021" # this needs to be 2021, or you need to set "resolver=2"
 [dependencies]
 bevy = "0.6" # make sure this is the latest version
 ```
+
+### Cargo Workspaces
+If you are using [Cargo Workspaces](https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html), you will also need to add the resolver to your Cargo.toml file in the root directory:
+
+```toml
+[workspace]
+resolver = "2" # Important! wgpu/Bevy needs this!
+```
+
 ### Enable Fast Compiles (Optional)
 
 Bevy can be built just fine using default configuration on stable Rust. However for maximally fast iterative compiles, we recommend the following configuration:


### PR DESCRIPTION
It's noted in the [Bevy 0.6 release notes](https://bevyengine.org/news/bevy-0-6/#rust-2021), but I missed it.

This adds it to the getting started guide as well.