### PR TITLE
Fix complexity description for iter_combinations

### DIFF
--- a/content/news/2022-01-08-bevy-0.6/index.md
+++ b/content/news/2022-01-08-bevy-0.6/index.md
@@ -704,7 +704,7 @@ fn system(query: Query<&Player>) {
 }
 ```
 
-This is especially useful for things like "checking for entities for collisions with all other entities". There is also an `iter_combinations_mut` variant. Just be careful ... the time complexity of this grows quickly (faster than exponentially!) as the number of entities in your combinations increases. With great power comes great responsibility!
+This is especially useful for things like "checking for entities for collisions with all other entities". There is also an `iter_combinations_mut` variant. Just be careful ... the time complexity of this grows exponentially as the number of entities in your combinations increases. With great power comes great responsibility!
 
 The new [iter_combinations example](https://github.com/bevyengine/bevy/blob/v0.6.0/examples/ecs/iter_combinations.rs) illustrates how to use this new API to calculate gravity between objects in a "solar system":
 


### PR DESCRIPTION
The newspost said it was super-exponential, but simple analysis shows that it should only be exponential.

The number of combinations is exponential at the size of the combination, so unless visiting each combination is super-exponential - the overall complexity should also be exponential. The bulk logic of visiting each combination is done in [`QueryCombinationIter::fetch_next_aliased_unchecked`](https://github.com/bevyengine/bevy/blob/v0.6.0/crates/bevy_ecs/src/query/iter.rs#L227), which seems polynomial. Not even exponential - definitely not super-exponential.