### PR TITLE
Correct audio block on the landing page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -130,8 +130,8 @@
                 <h2 class="feature-title">Sound</h2>
                 Load audio files and play them on demand
                 <ul class="feature-sublist">
-                    <li>Load mp3 audio files as Assets</li>
-                    <li>Play audio files using the AudioOutput resource</li>
+                    <li>Load audio files as Assets</li>
+                    <li>Play audio Assets using the Audio resource</li>
                 </ul>
             </div>
         </div>
@@ -198,7 +198,7 @@
         <div class="sponsors-section">
             <a href="https://vertexstudio.co/"><img src="assets/vertex_studio.png" class="bronze-sponsor-image" alt="Vertex Studio logo"/></a>
             <a href="https://www.metabuild.io/"><img src="assets/metabuild.png" class="bronze-sponsor-image" alt="Metabuild Logo"/></a>
-            <a href="https://www.foresightmining.com/"><img src="assets/Foresight_Mining_Software_Corporation.png" class="bronze-sponsor-image" alt="Foresight Mining Software Corporation logo"/></a> 
+            <a href="https://www.foresightmining.com/"><img src="assets/Foresight_Mining_Software_Corporation.png" class="bronze-sponsor-image" alt="Foresight Mining Software Corporation logo"/></a>
         </div>
     </div>
 </div>


### PR DESCRIPTION
* `AudioOutput` is an internal, non-send resource; the user-facing resource to play audio on is `Audio`
* We can load multiple audio encodings, so I removed the `mp3` to make it more general
* Stray whitespace that my IDE removes on its own :bowtie: 