### PR TITLE
Update landing page to reflect relicense

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -170,7 +170,7 @@
                 An engine made by and for the developer community
                 <ul class="feature-sublist">
                     <li>100% free. Forever and always</li>
-                    <li>Open Source under the permissive MIT license</li>
+                    <li>Open Source under the permissive MIT or Apache 2.0 licenses</li>
                     <li>No contracts</li>
                     <li>No license fees</li>
                     <li>No sales cuts</li>


### PR DESCRIPTION
The current landing page only states MIT and fails to mention Apache 2.0. This PR fixes that.