### PR TITLE
Skip readme when generating error codes

### DIFF
--- a/generate-errors/Cargo.lock
+++ b/generate-errors/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13,6 +22,7 @@ name = "generate-errors"
 version = "0.1.0"
 dependencies = [
  "pulldown-cmark",
+ "regex",
  "serde",
  "toml",
 ]
@@ -51,6 +61,23 @@ checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "regex"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "serde"

--- a/generate-errors/Cargo.toml
+++ b/generate-errors/Cargo.toml
@@ -12,3 +12,4 @@ edition = "2018"
 pulldown-cmark = { version = "0.8", default-features = false }
 serde = { version = "1", features = [ "derive" ] }
 toml = "0.5"
+regex = "1.5"

--- a/generate-errors/src/lib.rs
+++ b/generate-errors/src/lib.rs
@@ -1,3 +1,4 @@
+use regex::Regex;
 use serde::Serialize;
 use std::fs::read_to_string;
 use std::{fs, io, path::PathBuf, str::FromStr};
@@ -35,27 +36,24 @@ impl From<&ErrorCode> for FrontMatterErrorCode {
 
 fn visit_dirs(dir: PathBuf, section: &mut Section) -> io::Result<()> {
     assert!(dir.is_dir(), "The path to the errors is not a directory");
+    let error_code_pattern = Regex::new(r"B[0-9]{4}\.md").unwrap();
     for entry in fs::read_dir(dir)? {
         let entry = entry?;
         let path = entry.path();
-        if path.file_name().unwrap() == "README.md" {
-            continue;
-        }
         if !path.is_dir() {
-            if path.extension().unwrap() != "md" {
+            let file_name = path
+                .file_name()
+                .unwrap()
+                .to_os_string()
+                .into_string()
+                .unwrap();
+            if !error_code_pattern.is_match(&file_name) {
                 continue;
             }
 
             let error_code = read_to_string(path.clone())?;
 
-            let code = path
-                .file_name()
-                .unwrap()
-                .to_os_string()
-                .into_string()
-                .unwrap()
-                .trim_end_matches(".md")
-                .to_owned();
+            let code = file_name.trim_end_matches(".md").to_owned();
             section.content.push(ErrorCode {
                 content: error_code
                     .trim_start_matches(&format!("# {}", code.clone()))
@@ -93,4 +91,22 @@ pub fn parse_errors(errors_dir: &str) -> io::Result<Section> {
         &mut errors_root_section,
     )?;
     Ok(errors_root_section)
+}
+
+#[cfg(test)]
+mod test_regex {
+    use regex::Regex;
+
+    #[test]
+    fn error_code_pattern() {
+        let error_code_pattern = Regex::new(r"B[0-9]{4}\.md").unwrap();
+        assert!(error_code_pattern.is_match("B0000.md"));
+        assert!(error_code_pattern.is_match("B9999.md"));
+
+        assert!(!error_code_pattern.is_match("E0000.md"));
+        assert!(!error_code_pattern.is_match("00000.md"));
+        assert!(!error_code_pattern.is_match("B0000.txt"));
+        assert!(!error_code_pattern.is_match("Cargo.toml"));
+        assert!(!error_code_pattern.is_match("README.md"));
+    }
 }

--- a/generate-errors/src/lib.rs
+++ b/generate-errors/src/lib.rs
@@ -34,17 +34,11 @@ impl From<&ErrorCode> for FrontMatterErrorCode {
 }
 
 fn visit_dirs(dir: PathBuf, section: &mut Section) -> io::Result<()> {
-    if !dir.is_dir() {
-        // Todo: after the 0.6 release, remove this if statement
-        // For now we will allow this to be able to point to the `latest` branch (0.5)
-        // which does not yet include error codes
-        return Ok(());
-    }
     assert!(dir.is_dir(), "The path to the errors is not a directory");
     for entry in fs::read_dir(dir)? {
         let entry = entry?;
         let path = entry.path();
-        if path.file_name().unwrap() == ".git" || path.file_name().unwrap() == ".github" {
+        if path.file_name().unwrap() == "README.md" {
             continue;
         }
         if !path.is_dir() {


### PR DESCRIPTION
After the readme was added, it started showing up on the website: https://bevyengine.org/learn/errors/#readme