### PR TITLE
[Merged by Bors] - enable CI on bors branches

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -1,5 +1,5 @@
 status = [
-    "CI",
+    "build",
 ]
 
 use_squash_merge = true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,10 @@ name: CI
 
 on:
   pull_request:
+  push:
+    branches:    
+      - 'staging'
+      - 'trying'
 
 jobs:
   build:


### PR DESCRIPTION
bors is timeouting because CI is not triggering on its branches (`trying` and `staging`)
- enable CI on bors branches

bors needs the job name in its config
- change the workflow name to the job name