### PR TITLE
Point to main branch of bevy for code validation

### DIFF
--- a/code-validation/Cargo.toml
+++ b/code-validation/Cargo.toml
@@ -4,4 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bevy = "0.6.0"
+# This should point to `main` when we are preparing for the next release,
+# but should be fixed at the latest release once it is published on crates.io
+# bevy = 0.6
+bevy = {git = "https://github.com/bevyengine/bevy"}


### PR DESCRIPTION
This allows us to verify that our code *will* work on 0.7, even if it currently doesn't on 0.6.

Obviously this should be revised shortly after each crates.io release.