### PR TITLE
[Merged by Bors] - Replace an unwrap in generate-assets with an expect

### DIFF
--- a/generate-assets/src/lib.rs
+++ b/generate-assets/src/lib.rs
@@ -85,7 +85,7 @@ fn visit_dirs(dir: PathBuf, section: &mut Section) -> io::Result<()> {
                 section.content.push(AssetNode::Section(new_section));
             } else {
                 if path.file_name().unwrap() == "_category.toml"
-                    || path.extension().unwrap() != "toml"
+                    || path.extension().expect("file to have an extension") != "toml"
                 {
                     continue;
                 }

--- a/generate-assets/src/lib.rs
+++ b/generate-assets/src/lib.rs
@@ -85,7 +85,7 @@ fn visit_dirs(dir: PathBuf, section: &mut Section) -> io::Result<()> {
                 section.content.push(AssetNode::Section(new_section));
             } else {
                 if path.file_name().unwrap() == "_category.toml"
-                    || path.extension().expect("file to have an extension") != "toml"
+                    || path.extension().expect("file must have an extension") != "toml"
                 {
                     continue;
                 }


### PR DESCRIPTION
Friend of mine just hit an error publishing to bevy-assets and the CI only had a Option::unwrap to report back.

This PR replaces the unwrapping of a file's extension with an expect that shows the file was missing an extension.