### PR TITLE
[Merged by Bors] - Remove "Features" option from header.

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -76,7 +76,6 @@
                     {% endif %}
                 </div>
                 <div class="header-item header-push"></div>
-                {{header_macros::header_item(name="Features", path="/", current_path=current_path)}}
                 {{header_macros::header_item(name="Learn", current_path=current_path)}}
                 {{header_macros::header_item(name="News", current_path=current_path)}}
                 {{header_macros::header_item(name="Community", current_path=current_path)}}


### PR DESCRIPTION
The features page is already accessible by clicking the bevy icon in the header. This makes the "Features" menu option redundant.
Removing it also frees up some space in the header.