### PR TITLE
Show feature image next to text

### DIFF
--- a/sass/_features.scss
+++ b/sass/_features.scss
@@ -58,8 +58,8 @@
 }
 
 .feature-image, .feature-text {
-    min-width: 30rem;
-    max-width: 30rem;
+    min-width: 28rem;
+    max-width: 28rem;
     border-width: 1.8rem;
     border-style: solid;
     border-color: transparent;

--- a/sass/_features.scss
+++ b/sass/_features.scss
@@ -28,7 +28,7 @@
     justify-content: center;
 }
 
-.feature-container-reverse {
+.feature-container::nth-child(odd) {
     flex-wrap: wrap-reverse;
 }
 
@@ -57,7 +57,8 @@
     align-self: center;
 }
 
-.feature-image, .feature-text {
+.feature-image,
+.feature-text {
     min-width: 28rem;
     max-width: 28rem;
     border-width: 1.8rem;

--- a/templates/index.html
+++ b/templates/index.html
@@ -29,7 +29,6 @@
             <div class="feature-image">
                 <img src="assets/ecs.svg" class="feature-img" style="width: 100%; max-width: 90%; max-height: 90%;" alt="ECS code"/>
             </div>
-
         </div>
         <div class="feature-container feature-container-reverse">
             <div class="feature-image">
@@ -90,9 +89,9 @@
                     </ul>
                 </div>
             </div>
-        </div>
-        <div class="feature-image">
-            <img src="assets/platform-icons.svg" class="feature-img" alt="Microsoft, Apple, and Linux logos"/>
+            <div class="feature-image">
+                <img src="assets/platform-icons.svg" class="feature-img" alt="Microsoft, Apple, and Linux logos"/>
+            </div>
         </div>
         <div class="feature-container feature-container-reverse">
             <div class="feature-image">

--- a/templates/index.html
+++ b/templates/index.html
@@ -30,7 +30,7 @@
                 <img src="assets/ecs.svg" class="feature-img" style="width: 100%; max-width: 90%; max-height: 90%;" alt="ECS code"/>
             </div>
         </div>
-        <div class="feature-container feature-container-reverse">
+        <div class="feature-container">
             <div class="feature-image">
                 <img src="assets/sprite.png" class="feature-img" alt="Pixel art sprite of a person"/>
             </div>
@@ -61,7 +61,7 @@
                 <img src="assets/boat.png" class="feature-img" style="max-height: 95%; max-width: 95%;" alt="3D boat model"/>
             </div>
         </div>
-        <div class="feature-container feature-container-reverse">
+        <div class="feature-container">
             <div class="feature-image">
                 <img src="assets/render_graph.svg" class="feature-img" alt="Render graph"/>
             </div>
@@ -93,7 +93,7 @@
                 <img src="assets/platform-icons.svg" class="feature-img" alt="Microsoft, Apple, and Linux logos"/>
             </div>
         </div>
-        <div class="feature-container feature-container-reverse">
+        <div class="feature-container">
             <div class="feature-image">
                 <img src="assets/bevy_ui.svg" class="feature-img" alt="UI dialog window diagram"/>
             </div>
@@ -121,7 +121,7 @@
                 <img src="assets/scene.svg" class="feature-img" alt="2D scene of a square upon grass under the sun"/>
             </div>
         </div>
-        <div class="feature-container feature-container-reverse">
+        <div class="feature-container">
             <div class="feature-image">
                 <img src="assets/sound.svg" class="feature-img" alt="Music notes"/>
             </div>
@@ -148,7 +148,7 @@
                 <img src="assets/hot_reloading.svg" class="feature-img" alt="Hot reloading diagram"/>
             </div>
         </div>
-        <div class="feature-container feature-container-reverse">
+        <div class="feature-container">
             <div class="feature-image">
                 <img src="assets/progressbar.svg" class="feature-img" alt="Compile time progress bar"/>
             </div>


### PR DESCRIPTION
So that was pretty easy. Everything was already setup correctly except that the max-width was slightly too wide to allow flex to do it's thing and show the features side by side.

I also moved the image for the cross platform section inside the container.

![image](https://user-images.githubusercontent.com/8348954/160932178-b96cce0b-b487-4974-9a60-bf07fbf54652.png)


Closes #308