### PR TITLE
[Merged by Bors] - Switch to using .path instead of .permalink. This makes links relative.

### DIFF
--- a/templates/book-macros.html
+++ b/templates/book-macros.html
@@ -1,7 +1,7 @@
 {% macro book_nav_section(section_path, section_number) %}
 {% set section = get_section(path=section_path) %}
 <li class="book-nav-section">
-    <a href="{{ section.permalink }}" {% if current_path == section.path %}class="book-nav-section-title-active book-nav-section-title" {% else %}class="book-nav-section-title"{% endif %}>
+    <a href="{{ section.path }}" {% if current_path == section.path %}class="book-nav-section-title-active book-nav-section-title" {% else %}class="book-nav-section-title"{% endif %}>
         <strong class="book-nav-section-number">{{ section_number }}.</strong>
         {{ section.title | lower }}
     </a>

--- a/templates/book-section.html
+++ b/templates/book-section.html
@@ -40,7 +40,7 @@
         {% for p in all_sections %}
             {% set section_obj = get_section(path=p) %}
             {% if found_current %}
-                <a id="book-pager-bar-next" href="{{section_obj.permalink}}" class="book-pager-bar book-pager-bar-next">
+                <a id="book-pager-bar-next" href="{{section_obj.path}}" class="book-pager-bar book-pager-bar-next">
                     <div class="book-pager-bar-icon book-pager-bar-icon-next">
                     <img src="/assets/pager_next.svg" class="book-pager-image book-pager-image-right" />
                     </div>
@@ -51,7 +51,7 @@
             {% if current_path == section_obj.path %}
              {% set_global found_current = true %}
              {% if previous_section %}
-                <a id="book-pager-bar-previous" href="{{previous_section.permalink}}" class="book-pager-bar book-pager-bar-previous">
+                <a id="book-pager-bar-previous" href="{{previous_section.path}}" class="book-pager-bar book-pager-bar-previous">
                     <div class="book-pager-bar-icon book-pager-bar-icon-previous">
                         <img src="/assets/pager_previous.svg" class="book-pager-image book-pager-image-left" />
                     </div>

--- a/templates/news.html
+++ b/templates/news.html
@@ -2,9 +2,9 @@
 {% block content %}
 <div class="card-list padded-content">
   {% for page in section.pages %}
-  <a class="card" href="{{ page.permalink }}">
+  <a class="card" href="{{ page.path }}">
     {% if page.extra.image %}
-    {% set image_parent = page.permalink | replace(from="_index.md", to="") %}
+    {% set image_parent = page.path | replace(from="_index.md", to="") %}
     <div class="card-image">
       <img src="{{image_parent}}{{page.extra.image}}" class="centered-card-image" />
     </div>


### PR DESCRIPTION
When testing Vercel integration it was discovered that some links (like the news feed) would link to the production website instead of the preview site. This is because all permalinks in zola use the `base_url` from the config file, which is hardcoded.

You can also check this locally by running `zola serve` and using the url `localhost:1111` in your browser. Clicking on a news post will redirect you to `127.0.0.1:1111` because `127.0.0.1` is the `base_url` in development.

This PR switches from using `.permalink` to `.path` which makes these links relative.