### PR TITLE
[Merged by Bors] - Make assets/examples grid responsive

### DIFF
--- a/sass/components/_item-grid.scss
+++ b/sass/components/_item-grid.scss
@@ -1,0 +1,5 @@
+.item-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(270px, 1fr));
+    gap: 16px;
+}

--- a/sass/pages/_assets.scss
+++ b/sass/pages/_assets.scss
@@ -1,14 +1,22 @@
 .assets {
     display: flex;
 
-    .card-list {
-        display: flex;
-        flex-wrap: wrap;
+    .asset-section {
+        font-size: 2.4rem;
+        margin: 0 0 20px;
+    }
+
+    .asset-subsection {
+        font-size: 1.9rem;
+        margin: 0 0 16px;
+    }
+
+    .item-grid {
+        margin-bottom: 52px;
     }
 
     .card {
-        width: 30%;
-        margin-right: $card-list-gap;
+        margin: 0;
         height: 8rem;
     }
 
@@ -33,6 +41,8 @@
     }
 
     .book-content {
+        margin-top: 16px;
+
         h3 {
             font-size: 1.9rem;
             font-weight: 700;

--- a/sass/site.scss
+++ b/sass/site.scss
@@ -18,10 +18,10 @@
 // - Repeating visual patterns: buttons, cards, menus…
 // - Components can be composed between them to create new components
 // - These should be self contained and shouldn't affect other styling
-@import "components/syntax-theme";
-@import "components/headerbar";
 @import "components/book-nav";
 @import "components/card";
+@import "components/headerbar";
+@import "components/syntax-theme";
 
 // Pages
 // - Page specific CSS

--- a/sass/site.scss
+++ b/sass/site.scss
@@ -21,6 +21,7 @@
 @import "components/book-nav";
 @import "components/card";
 @import "components/headerbar";
+@import "components/item-grid";
 @import "components/syntax-theme";
 
 // Pages

--- a/templates/assets.html
+++ b/templates/assets.html
@@ -39,7 +39,7 @@
         </h1>
 
         {% if section.pages %}
-        <div class="card-list padded-content">
+        <div class="item-grid">
             {% set pages = section.pages %}
             {% if section.extra.sort_order_reversed %}
             {% set pages = section.pages | reverse %}
@@ -60,7 +60,7 @@
         <h3 id="{{ section.title | slugify }}">
             {{ section.title }}<a class="anchor-link" href="#{{ section.title | slugify }}">#</a>
         </h3>
-        <div class="card-list padded-content">
+        <div class="item-grid">
             {% set pages = section.pages %}
             {% if section.extra.sort_order_reversed %}
             {% set pages = section.pages | reverse %}

--- a/templates/examples.html
+++ b/templates/examples.html
@@ -37,7 +37,7 @@
         </h1>
 
         {% if section.pages %}
-        <div class="card-list padded-content">
+        <div class="item-grid">
             {% set pages = section.pages %}
             {% if section.extra.sort_order_reversed %}
             {% set pages = section.pages | reverse %}


### PR DESCRIPTION
- Change layout to CSS `grid`. The grid decides how many columns to use depending on the window width (see `_item-grid.scss`)
- The grid is responsive and uses better the available space.

**🔴 BEFORE**

![image](https://user-images.githubusercontent.com/188612/161603684-40fac941-5036-40b5-88f7-cdca497ceee0.png)

<img width="343" alt="image" src="https://user-images.githubusercontent.com/188612/161603743-89078e27-b0d6-412b-8c32-6b9734f994cc.png">

**🟢 AFTER**

https://user-images.githubusercontent.com/188612/161604132-ac1f8931-095c-473c-9676-d6275fdd0ecf.mp4


