### PR TITLE
Tweak error-prone Bevy fast-compiles advice

### DIFF
--- a/content/learn/book/getting-started/_index.md
+++ b/content/learn/book/getting-started/_index.md
@@ -41,6 +41,7 @@ Note: the "fast compiles" setup is on the next page, so you might want to read t
 
 Bevy is [available as a library on crates.io](https://crates.io/crates/bevy).
 
+
 Add the bevy crate to your project's Cargo.toml like this:
 
 ```toml
@@ -51,3 +52,16 @@ bevy = "0.6" # make sure this is the latest version
 This is the current `bevy` crate version:
 
 <a href="https://crates.io/crates/bevy"><img src="https://img.shields.io/crates/v/bevy.svg" style="height: 1.7rem;"/></a>
+
+**_NOTE:_** Bevy is currently being updated at a rapid pace. Taking a dependency on the git repo instead of the cargo crate will allow you to receive the latest updates as fast as possible. *However*, **there are often breaking changes made to APIs and behavior**. This means that it will be important to keep up with the latest developments with bevy. **This is not recommended for people who are just getting started with bevy.**
+```toml
+[dependencies]
+bevy = { git = "https://github.com/bevyengine/bevy" }
+```
+
+In general it's a good idea to lock in to a specific commit hash, which gives you control over when you take updates. You can find the [latest commit hash here](https://github.com/bevyengine/bevy/commits/main) (to the right of each commit).
+
+```toml
+[dependencies]
+bevy = { git = "https://github.com/bevyengine/bevy", rev = "25f62f7250a0d750068dc32533b9433f7985af98" }
+```

--- a/content/learn/book/getting-started/_index.md
+++ b/content/learn/book/getting-started/_index.md
@@ -41,7 +41,6 @@ Note: the "fast compiles" setup is on the next page, so you might want to read t
 
 Bevy is [available as a library on crates.io](https://crates.io/crates/bevy).
 
-
 Add the bevy crate to your project's Cargo.toml like this:
 
 ```toml
@@ -52,16 +51,3 @@ bevy = "0.6" # make sure this is the latest version
 This is the current `bevy` crate version:
 
 <a href="https://crates.io/crates/bevy"><img src="https://img.shields.io/crates/v/bevy.svg" style="height: 1.7rem;"/></a>
-
-**_NOTE:_** Bevy is currently being updated at a rapid pace. Taking a dependency on the git repo instead of the cargo crate will allow you to receive the latest updates as fast as possible. *However*, **there are often breaking changes made to APIs and behavior**. This means that it will be important to keep up with the latest developments with bevy. **This is not recommended for people who are just getting started with bevy.**
-```toml
-[dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy" }
-```
-
-In general it's a good idea to lock in to a specific commit hash, which gives you control over when you take updates. You can find the [latest commit hash here](https://github.com/bevyengine/bevy/commits/main) (to the right of each commit).
-
-```toml
-[dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", rev = "25f62f7250a0d750068dc32533b9433f7985af98" }
-```

--- a/content/learn/book/getting-started/setup/_index.md
+++ b/content/learn/book/getting-started/setup/_index.md
@@ -20,6 +20,7 @@ Install Rust by following the [Rust Getting Started Guide](https://www.rust-lang
 Once this is done, you should have the ```rustc``` compiler and the ```cargo``` build system installed in your path.
 
 ### Install OS dependencies
+
 * [Linux](https://github.com/bevyengine/bevy/blob/main/docs/linux_dependencies.md)
 * Windows: Make sure to install [VS2019 build tools](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=16)
 * MacOS: No dependencies here
@@ -34,7 +35,6 @@ The goal of this book is to learn Bevy, so it won't serve as a full Rust educati
 
 * [**The Rust Book**](https://doc.rust-lang.org/book/): the best place to learn Rust from scratch
 * [**Rust by Example**](https://doc.rust-lang.org/rust-by-example/): learn Rust by working through live coding examples
-
 
 ## Create a new Bevy Project
 
@@ -52,6 +52,7 @@ cd my_bevy_game
 Now run ```cargo run``` to build and run your project. You should see ```Hello, world!``` printed to your terminal. Open the ```my_bevy_game``` folder in your code editor of choice and take some time to look through the files.
 
 ```main.rs``` is the entry point of your program:
+
 ```rs
 fn main() {
     println!("Hello, world!");
@@ -91,44 +92,6 @@ If you are using [Cargo Workspaces](https://doc.rust-lang.org/book/ch14-03-cargo
 [workspace]
 resolver = "2" # Important! wgpu/Bevy needs this!
 ```
-
-### Enable Fast Compiles (Optional)
-
-Bevy can be built just fine using default configuration on stable Rust. However for maximally fast iterative compiles, we recommend the following configuration:
-
-* **Enable Bevy's Dynamic Linking Feature**: This is the most impactful compilation time decrease! If `bevy` is a dependency you can compile the binary with the "dynamic" feature flag (enables dynamic linking). Note that right now, this doesn't work on Windows.
-    ```sh
-    cargo run --features bevy/dynamic
-    ```
-    If you don't want to add the `--features bevy/dynamic` to each run, this flag can permanently be set via `Cargo.toml`:
-    ```toml
-    [dependencies]
-    bevy = { version = "0.6.0", features = ["dynamic"] }
-    ```
-    NOTE: Remember to revert this before releasing your game! Otherwise you will need to include `libbevy_dylib` alongside your game if you want it to run. If you remove the "dynamic" feature, your game executable can run standalone.
-
-* **LLD linker**: The Rust compiler spends a lot of time in the "link" step. LLD is _much faster_ at linking than the default Rust linker. To install LLD, find your OS below and run the given command:
-    * **Ubuntu**: `sudo apt-get install lld`
-    * **Arch**: `sudo pacman -S lld`
-    * **Windows**: Ensure you have the latest [cargo-binutils](https://github.com/rust-embedded/cargo-binutils)
-        ```sh
-        cargo install -f cargo-binutils
-        rustup component add llvm-tools-preview
-        ```
-    * **MacOS**: Modern LLD does not yet support MacOS, but we can use zld instead: `brew install michaeleisel/zld/zld`
-* **Nightly Rust Compiler**: This gives access to the latest performance improvements and "unstable" optimizations
-    
-    Create a ```rust-toolchain.toml``` file in the root of your project, next to ```Cargo.toml```.
-    ```toml
-    [toolchain]
-    channel = "nightly"
-    ```
-    For more information, see [The rustup book: Overrides](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file).
-* **Generic Sharing**: Allows crates to share monomorphized generic code instead of duplicating it. In some cases this allows us to "precompile" generic code so it doesn't affect iterative compiles. This is only available on nightly Rust.
-
-To enable fast compiles, install the nightly rust compiler and LLD. Then copy [this file](https://github.com/bevyengine/bevy/blob/main/.cargo/config_fast_builds) to `YOUR_WORKSPACE/.cargo/config.toml`. For the project in this guide, that would be `my_bevy_game/.cargo/config.toml`.
-
-If something went wrong, check out our [troubleshooting section](/learn/book/troubleshooting/) or [ask for help on our Discord](https://discord.com/invite/gMUk5Ph).
 
 ### Build Bevy
 


### PR DESCRIPTION
# Problem

Currently, the Bevy book encourages fussing with complex fast compilation setups.

Fast compile advice is very cool, but comes with a *large* numbers of caveats and often breaks in surprising ways: https://github.com/bevy-cheatbook/bevy-cheatbook/issues/135

It should not be introduced to beginners, even if it may be valuable to advanced users later.

## Solution

- remove advice to set up fast compiles

This advice can and should be added back later, in a more appropriate location with carefully vetted caveats.
