### PR TITLE
[Merged by Bors] - Add link to Bevy Cheatbook to Next Steps

### DIFF
--- a/content/learn/book/next-steps/_index.md
+++ b/content/learn/book/next-steps/_index.md
@@ -16,3 +16,4 @@ You have reached the end of The Bevy Book! And unfortunately, we haven't even sc
   * **[Learning Resources](https://bevyengine.org/assets/#learning)**: Tutorials, documentation, and examples.
   * **[Plugins](https://bevyengine.org/assets/#assets)**: Extra functionality you can use in your projects.
   * **[Games](https://bevyengine.org/assets/#apps)**: Open-source games in various stages of development.
+* **[Bevy Cheatbook](https://bevy-cheatbook.github.io/)**: An in-depth, opinionated, unofficial guide to Bevy's API and ecosystem.


### PR DESCRIPTION
Adding this link is a long-standing debate. To summarize:

- the Bevy Cheatbook is by far the most useful unofficial learning resource
   - it is consistently high quality and up to date
   - it is more comprehensive than any resource other than docs.rs or perhaps the examples
   - there are no other learning resources in this tier (yet)
- the community vocally recommends the Cheatbook to all newcomers
- the Cheatbook is deliberately unofficial and opinionated: in particular, it is not afraid to say that some APIs aren't yet ready, or endorse specific vetted plugins
- Next Steps is the natural place for this link, given the current book layout
- eventually, we would like Bevy Assets / its successor to be sorted by some measure of popularity  / objective quality, but that is not yet ready

My proposal:

1. We add this link, clearly disclaiming that it is unofficial and opinionated.
2. When Bevy Assets has a more useful sorting mechanism / showcase mechanism, remove this link in favor of highlighting the Cheatbook there.
3. If Bevy Cheatbook falls out of date or has serious quality issues that are unresolved, we remove this link.
4. If another comparable learning resource emerges, we add that link as well, and accelerate work on the Bevy Assets solution.
