### PR TITLE
[Merged by Bors] - Remove advice to depend on `main`

### DIFF
--- a/content/learn/book/getting-started/_index.md
+++ b/content/learn/book/getting-started/_index.md
@@ -41,7 +41,6 @@ Note: the "fast compiles" setup is on the next page, so you might want to read t
 
 Bevy is [available as a library on crates.io](https://crates.io/crates/bevy).
 
-
 Add the bevy crate to your project's Cargo.toml like this:
 
 ```toml
@@ -52,16 +51,3 @@ bevy = "0.6" # make sure this is the latest version
 This is the current `bevy` crate version:
 
 <a href="https://crates.io/crates/bevy"><img src="https://img.shields.io/crates/v/bevy.svg" style="height: 1.7rem;"/></a>
-
-**_NOTE:_** Bevy is currently being updated at a rapid pace. Taking a dependency on the git repo instead of the cargo crate will allow you to receive the latest updates as fast as possible. *However*, **there are often breaking changes made to APIs and behavior**. This means that it will be important to keep up with the latest developments with bevy. **This is not recommended for people who are just getting started with bevy.**
-```toml
-[dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy" }
-```
-
-In general it's a good idea to lock in to a specific commit hash, which gives you control over when you take updates. You can find the [latest commit hash here](https://github.com/bevyengine/bevy/commits/main) (to the right of each commit).
-
-```toml
-[dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", rev = "25f62f7250a0d750068dc32533b9433f7985af98" }
-```


### PR DESCRIPTION
Relying directly on main breaks the ability to use vital ecosystem plugins, and exposes users to new bugs. It is no longer net useful due to the swap to train releases (and improved quality of the engine and ecosystem).