### PR TITLE
[Merged by Bors] - Update setup instructions for bevy 0.7

### DIFF
--- a/content/learn/book/getting-started/setup/_index.md
+++ b/content/learn/book/getting-started/setup/_index.md
@@ -80,7 +80,7 @@ version = "0.1.0"
 edition = "2021" # this needs to be 2021, or you need to set "resolver=2"
 
 [dependencies]
-bevy = "0.6" # make sure this is the latest version
+bevy = "0.7" # make sure this is the latest version
 ```
 
 ### Cargo Workspaces
@@ -103,7 +103,7 @@ Bevy can be built just fine using default configuration on stable Rust. However 
     If you don't want to add the `--features bevy/dynamic` to each run, this flag can permanently be set via `Cargo.toml`:
     ```toml
     [dependencies]
-    bevy = { version = "0.6.0", features = ["dynamic"] }
+    bevy = { version = "0.7.0", features = ["dynamic"] }
     ```
     NOTE: Remember to revert this before releasing your game! Otherwise you will need to include `libbevy_dylib` alongside your game if you want it to run. If you remove the "dynamic" feature, your game executable can run standalone.
 


### PR DESCRIPTION
Since bevy 0.7 is released, change the mentioned versions in the setup instructions from 0.6 to 0.7.