### PR TITLE
[Merged by Bors] - fix path to example bevymark and games

### DIFF
--- a/generate-wasm-examples/generate_wasm_examples.sh
+++ b/generate-wasm-examples/generate_wasm_examples.sh
@@ -72,5 +72,5 @@ add_category UI button text text_debug ui
 add_category audio audio
 add_category shader shader_instancing shader_material_glsl shader_material
 add_category ecs iter_combinations
-add_category Game breakout alien_cake_addict
+add_category Games breakout alien_cake_addict
 add_category stress_tests bevymark

--- a/generate-wasm-examples/generate_wasm_examples.sh
+++ b/generate-wasm-examples/generate_wasm_examples.sh
@@ -73,4 +73,4 @@ add_category audio audio
 add_category shader shader_instancing shader_material_glsl shader_material
 add_category ecs iter_combinations
 add_category Game breakout alien_cake_addict
-add_category Tools bevymark
+add_category stress_tests bevymark


### PR DESCRIPTION
When building examples for wasm, example bevymark and games fail as it has changed path in the Bevy repo.

This changes the path to the correct one