### PR TITLE
[Merged by Bors] - Make this section about the breaking part of the changeset

### DIFF
--- a/content/learn/book/migration-guides/0.6-0.7/_index.md
+++ b/content/learn/book/migration-guides/0.6-0.7/_index.md
@@ -262,19 +262,19 @@ commands.spawn_bundle(PerspectiveCameraBundle {
 
 ### [Implement init_resource for Commands and World](https://github.com/bevyengine/bevy/pull/3079)
 
-```rs
-#[derive(Default)]
-struct Scoreboard {
-    current_score: u32,
-    high_score: u32,
-}
+Methods that deal with inserting resources were reworked for consistency between the `Commands` and `Worlds` APIs.
 
+The breaking change is that `World::insert_non_send` was renamed to [`World::insert_non_send_resource`].
+
+```rs
 // 0.6
-commands.insert_resource(Scoreboard::default());
+world.insert_non_send(Score { score: 0 });
 
 // 0.7
-commands.init_resource::<Scoreboard>();
+world.insert_non_send_resource(Score { score: 0 });
 ```
+
+[`World::insert_non_send_resource`]: https://docs.rs/bevy/latest/bevy/ecs/world/struct.World.html#method.insert_non_send_resource
 
 ### [Infallible resource getters](https://github.com/bevyengine/bevy/pull/4047)
 


### PR DESCRIPTION
> DJMcBavy — Today at 9:38 AM
This section of the migration guide has got the wrong part of the change as breaking https://bevyengine.org/learn/book/migration-guides/0.6-0.7/#implement-init-resource-for-commands-and-world
The breakage is that init_non_send changed to init_non_send_resource (and possibly others?)

I couldn't find any other obvious breaking changes in that PR.