### PR TITLE
[Merged by Bors] - Clarify the config api migration

### DIFF
--- a/content/learn/book/migration-guides/0.6-0.7/_index.md
+++ b/content/learn/book/migration-guides/0.6-0.7/_index.md
@@ -208,7 +208,7 @@ fn camera_system(cameras: Query<&Camera, With<FirstPassCamera>>) {
 // 0.6
 struct Config(u32);
 
-fn local_config(local: Local<Config>) {
+fn local_is_42(local: Local<Config>) {
     assert_eq!(*local.0, 42);
 }
 
@@ -219,18 +219,15 @@ fn main() {
 }
 
 // 0.7
-struct Config(u32);
-
-fn local_config(local: u32) -> impl FnMut(ResMut<Config>) {
-    move |mut val: ResMut<Config>| {
-        val.0 = local;
-
+fn local_is_42(local: u32) -> impl FnMut() {
+    // This closure will be the system that will be executed
+    move || {
         assert_eq!(val.0, 42);
     }
 }
 
 fn main() {
-    App::new().add_system(local_config(42)).run();
+    App::new().add_system(local_is_42(42)).run();
 }
 ```
 

--- a/content/learn/book/migration-guides/0.6-0.7/_index.md
+++ b/content/learn/book/migration-guides/0.6-0.7/_index.md
@@ -222,7 +222,7 @@ fn main() {
 struct Config(u32);
 
 fn local_config(local: u32) -> impl FnMut(ResMut<Config>) {
-    move |mut val| {
+    move |mut val: ResMut<Config>| {
         val.0 = local;
 
         assert_eq!(val.0, 42);
@@ -230,9 +230,7 @@ fn local_config(local: u32) -> impl FnMut(ResMut<Config>) {
 }
 
 fn main() {
-        App::new()
-        .add_system(local_config(Config(42)))
-        .run();
+    App::new().add_system(local_config(42)).run();
 }
 ```
 

--- a/content/learn/book/migration-guides/0.6-0.7/_index.md
+++ b/content/learn/book/migration-guides/0.6-0.7/_index.md
@@ -222,7 +222,7 @@ fn main() {
 fn local_is_42(local: u32) -> impl FnMut() {
     // This closure will be the system that will be executed
     move || {
-        assert_eq!(val.0, 42);
+        assert_eq!(local, 42);
     }
 }
 


### PR DESCRIPTION
The 0.7 example of the migration guide for the config api had a few issues. It passed the wrong datatype and it wasn't cleared what the argument of the closer was.