### PR TITLE
examples: compute the slug directly in the category path

### DIFF
--- a/generate-wasm-examples/generate_wasm_examples.sh
+++ b/generate-wasm-examples/generate_wasm_examples.sh
@@ -19,9 +19,10 @@ add_category()
 {
     category=$1
     category_path=$2
+    category_slug=`echo $2 | tr '_' '-'`
     example_weight=0
 
-    mkdir ../../content/examples/$category_path
+    mkdir ../../content/examples/$category_slug
 
     # Remove first two arguments
     shift 2
@@ -31,10 +32,10 @@ add_category()
     for example in $@
     do
         echo "building $category / $example"
-        mkdir ../../content/examples/$category_path/$example
-        cp examples/$category_path/$example.rs ../../content/examples/$category_path/$example/
+        mkdir ../../content/examples/$category_slug/$example
+        cp examples/$category_path/$example.rs ../../content/examples/$category_slug/$example/
         cargo build --release --target wasm32-unknown-unknown --example $example
-        wasm-bindgen --out-dir ../../content/examples/$category_path/$example --no-typescript --target web target/wasm32-unknown-unknown/release/examples/$example.wasm
+        wasm-bindgen --out-dir ../../content/examples/$category_slug/$example --no-typescript --target web target/wasm32-unknown-unknown/release/examples/$example.wasm
         echo "+++
 title = \"$example\"
 template = \"example.html\"
@@ -42,7 +43,7 @@ weight = $example_weight
 
 [extra]
 header_message = \"Examples\"
-+++" > ../../content/examples/$category_path/$example/index.md
++++" > ../../content/examples/$category_slug/$example/index.md
 
         example_weight=$((example_weight+1))
     done
@@ -52,7 +53,7 @@ header_message = \"Examples\"
 title = \"$category\"
 sort_by = \"weight\"
 weight = $category_weight
-+++" > ../../content/examples/$category_path/_index.md
++++" > ../../content/examples/$category_slug/_index.md
 
     category_weight=$((category_weight+1))
 }


### PR DESCRIPTION
fix #351 

replaced `_` by `-` in the folder name for examples