### PR TITLE
[Merged by Bors] - Fix WorldQuery example in 0.7 release post

### DIFF
--- a/content/news/2022-04-15-bevy-0.7/index.md
+++ b/content/news/2022-04-15-bevy-0.7/index.md
@@ -477,6 +477,7 @@ Maybe you've gotten tired of typing the same components over and over. In **Bevy
 
 ```rust
 #[derive(WorldQuery)]
+#[world_query(mutable)]
 struct PlayerMovementQuery<'w> {
     transform: &'w mut Transform,
     velocity: &'w mut Velocity,


### PR DESCRIPTION
The example wouldn't compile by itself. As the [WorldQuery doc](https://docs.rs/bevy/latest/bevy/ecs/query/trait.WorldQuery.html#mutable-queries) shows, you must add a `world_query(mutable)` attribute for queries containing mutable elements to work, otherwise you will get a compilation error.
