### PR TITLE
[Merged by Bors] - Use Zolas `resize_image` to limit News & Assets thumbnail sizes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ content/assets
 content/learn/errors
 content/examples
 static/assets/examples
+static/processed_images

--- a/templates/macros/assets.html
+++ b/templates/macros/assets.html
@@ -1,9 +1,11 @@
+{% import "macros/images.html" as image_macros %}
+
 {% macro card(post) %}
 <div class="card" id="{{ post.title | slugify }}">
     <a href="{{ post.extra.link }}">
         {% if post.extra.image %}
         <div class="card-image card-image-default">
-            <img src="{{ get_url(path=post.extra.image) }}" />
+            <img src="{{ image_macros::resize_image(path=post.extra.image, width=340, height=340) }}" />
         </div>
         {% endif %}
         <div class="card-text">

--- a/templates/macros/images.html
+++ b/templates/macros/images.html
@@ -1,0 +1,8 @@
+{% macro resize_image(path, width, height) -%}
+    {%- if path is ending_with(".svg") or path is ending_with(".gif") -%}
+        {{- path -}}
+    {%- else -%}
+        {%- set image = resize_image(path=path, width=width, height=height, op="fit") -%}
+        {{- image.url -}}
+    {%- endif -%}
+{%- endmacro card %}

--- a/templates/news.html
+++ b/templates/news.html
@@ -1,4 +1,6 @@
 {% extends "layouts/base.html" %}
+{% import "macros/images.html" as image_macros %}
+
 {% block content %}
 <div class="card-list padded-content">
   {% for page in section.pages %}
@@ -6,7 +8,7 @@
     {% if page.extra.image %}
     {% set image_parent = page.path | replace(from="_index.md", to="") %}
     <div class="card-image">
-      <img src="{{image_parent}}{{page.extra.image}}" class="centered-card-image" />
+      <img src="{{ image_macros::resize_image(path=image_parent ~ page.extra.image, width=580, height=326) }}" class="centered-card-image" />
     </div>
     {% else %}
     <div class="card-image">


### PR DESCRIPTION
- Add a new macro that wraps Zolas `resize_image`
- Use the macro on `News` & `Assets` templates to limit the maximum size of the thumbnails
- This saves few mb:
  - News, before: `9.57mb` 👉 after: `1.25mb`
  - Assets, before: `18.88mb` 👉 after: `17.34mb`. ⚠️ Almost `16mb` of those are GIFs.

closes #339