### PR TITLE
Speed up new user documentation

### DIFF
--- a/content/learn/book/getting-started/_index.md
+++ b/content/learn/book/getting-started/_index.md
@@ -9,7 +9,7 @@ insert_anchor_links = "right"
 
 ## Quick Start
 
-Assuming that Rust is installed, install dependencies for either [Linux](https://github.com/bevyengine/bevy/blob/main/docs/linux_dependencies.md) or [Windows](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=16)
+Assuming that [Rust](https://www.rust-lang.org/learn/get-started) is installed, install dependencies for either [Linux](https://github.com/bevyengine/bevy/blob/main/docs/linux_dependencies.md) or [Windows](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=16)
 
 The setup for "fast compiles" is on the next page, with notable less compute time.
 

--- a/content/learn/book/getting-started/_index.md
+++ b/content/learn/book/getting-started/_index.md
@@ -7,13 +7,11 @@ page_template = "book-section.html"
 insert_anchor_links = "right"
 +++
 
-This section will help you get started on your Bevy journey as quickly as possible. It will walk you through setting up your development environment and writing a simple Bevy app.
-
 ## Quick Start
 
-If you want to dive in immediately and you already have a working Rust setup, feel free to follow this "quick start" guide. Otherwise, move on to the next page.
+Assuming that Rust is installed, install dependencies for either [Linux](https://github.com/bevyengine/bevy/blob/main/docs/linux_dependencies.md) or [Windows](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=16)
 
-Note: the "fast compiles" setup is on the next page, so you might want to read that section first.
+The setup for "fast compiles" is on the next page, with notable less compute time.
 
 ### Try the Examples
 

--- a/content/learn/book/getting-started/setup/_index.md
+++ b/content/learn/book/getting-started/setup/_index.md
@@ -9,21 +9,6 @@ insert_anchor_links = "right"
 
 I know you are itching to start making games, but we need to do a _small_ amount of setup first.
 
-## Rust Setup
-
-All Bevy app and engine code is written in Rust. This means that before we begin, we need to set up our Rust development environment.
-
-### Installing Rust
-
-Install Rust by following the [Rust Getting Started Guide](https://www.rust-lang.org/learn/get-started).
-
-Once this is done, you should have the ```rustc``` compiler and the ```cargo``` build system installed in your path.
-
-### Install OS dependencies
-* [Linux](https://github.com/bevyengine/bevy/blob/main/docs/linux_dependencies.md)
-* Windows: Make sure to install [VS2019 build tools](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=16)
-* MacOS: No dependencies here
-
 ### Code Editor / IDE
 
 You can use any code editor you want, but we highly recommend one that has a [Rust Analyzer](https://github.com/rust-analyzer/rust-analyzer) plugin. Rust Analyzer is still in development, but it already provides top-tier autocomplete and code intelligence. [Visual Studio Code](https://code.visualstudio.com/) has an officially supported [Rust Analyzer Extension](https://marketplace.visualstudio.com/items?itemName=matklad.rust-analyzer).


### PR DESCRIPTION
Originally the user would have to find the dependencies on a secondary page, it makes no sense to tell someone to compile an example before you install the dependencies.