### PR TITLE
[Merged by Bors] - Remove underline from h3 headings

### DIFF
--- a/sass/pages/_book.scss
+++ b/sass/pages/_book.scss
@@ -18,6 +18,7 @@
     position: relative;
     width: 100%;
     min-width: 0;
+
     h1 {
         margin-top: $default-padding;
         font-size: 2.4rem;
@@ -32,7 +33,6 @@
     h3 {
         font-size: 1.4rem;
         font-weight: 500;
-        text-decoration: underline;
         margin-bottom: 15px;
     }
 


### PR DESCRIPTION
Closes #366.

My autoformatter also fixed the inconsistent style in the file. You can safely revert it if you want.