### PR TITLE
[Merged by Bors] - Fix broken bevy assets gifs

### DIFF
--- a/templates/macros/images.html
+++ b/templates/macros/images.html
@@ -1,6 +1,6 @@
 {% macro resize_image(path, width, height) -%}
     {%- if path is ending_with(".svg") or path is ending_with(".gif") -%}
-        {{- path -}}
+        {{- get_url(path=path) -}}
     {%- else -%}
         {%- set image = resize_image(path=path, width=width, height=height, op="fit") -%}
         {{- image.url -}}


### PR DESCRIPTION
broken by #360 

fixes #374 

This seems like a pretty obvious mistake/fix.

To reproduce the issue locally, make sure you're viewing the assets page via a url with a trailing slash. The (incorrect) relative urls end up pointing at the right place if there is no trailing slash.