### PR TITLE
[Merged by Bors] - fix customFetch not found

### DIFF
--- a/generate-wasm-examples/generate_wasm_examples.sh
+++ b/generate-wasm-examples/generate_wasm_examples.sh
@@ -45,8 +45,8 @@ add_category()
           -e 's/function init(input) {/function init(customFetch, input) { customFetch = customFetch || fetch;/' \
           -e 's/input = fetch(/input = customFetch(/' \
           -e 's/getObject(arg0).fetch(/customFetch(/' \
-          -e 's/const imports = getImports();/const imports = getImports(customFetch);/'
-          -e 's/function getImports() {/function getImports(customFetch) {'
+          -e 's/const imports = getImports();/const imports = getImports(customFetch);/' \
+          -e 's/function getImports() {/function getImports(customFetch) {' \
           ../../content/examples/$category_slug/$example_slug/$example.js
 
         echo "+++

--- a/generate-wasm-examples/generate_wasm_examples.sh
+++ b/generate-wasm-examples/generate_wasm_examples.sh
@@ -45,6 +45,8 @@ add_category()
           -e 's/function init(input) {/function init(customFetch, input) { customFetch = customFetch || fetch;/' \
           -e 's/input = fetch(/input = customFetch(/' \
           -e 's/getObject(arg0).fetch(/customFetch(/' \
+          -e 's/const imports = getImports();/const imports = getImports(customFetch);/'
+          -e 's/function getImports() {/function getImports(customFetch) {'
           ../../content/examples/$category_slug/$example_slug/$example.js
 
         echo "+++

--- a/generate-wasm-examples/generate_wasm_examples.sh
+++ b/generate-wasm-examples/generate_wasm_examples.sh
@@ -46,7 +46,7 @@ add_category()
           -e 's/input = fetch(/input = customFetch(/' \
           -e 's/getObject(arg0).fetch(/customFetch(/' \
           -e 's/const imports = getImports();/const imports = getImports(customFetch);/' \
-          -e 's/function getImports() {/function getImports(customFetch) {' \
+          -e 's/function getImports() {/function getImports(customFetch) {/' \
           ../../content/examples/$category_slug/$example_slug/$example.js
 
         echo "+++


### PR DESCRIPTION
An update to wasm_bindgen changed how the file is generated.

This update adds customFetch to the new getImports function.

I didn't manage to reproduce it locally, but it does work when I do the change manually in the dev tools

fixes #384