### PR TITLE
[Merged by Bors] - make customFetch global

### DIFF
--- a/generate-wasm-examples/generate_wasm_examples.sh
+++ b/generate-wasm-examples/generate_wasm_examples.sh
@@ -42,7 +42,7 @@ add_category()
         # Patch generated JS to allow to inject custom `fetch` with loading feedback.
         # See: https://github.com/bevyengine/bevy-website/pull/355
         sed -i.bak \
-          -e 's/getObject(arg0).fetch(/window.customFetch(/' \
+          -e 's/getObject(arg0).fetch(/window.loadingBarFetch(/' \
           ../../content/examples/$category_slug/$example_slug/$example.js
 
         echo "+++

--- a/generate-wasm-examples/generate_wasm_examples.sh
+++ b/generate-wasm-examples/generate_wasm_examples.sh
@@ -42,11 +42,7 @@ add_category()
         # Patch generated JS to allow to inject custom `fetch` with loading feedback.
         # See: https://github.com/bevyengine/bevy-website/pull/355
         sed -i.bak \
-          -e 's/function init(input) {/function init(customFetch, input) { customFetch = customFetch || fetch;/' \
-          -e 's/input = fetch(/input = customFetch(/' \
-          -e 's/getObject(arg0).fetch(/customFetch(/' \
-          -e 's/const imports = getImports();/const imports = getImports(customFetch);/' \
-          -e 's/function getImports() {/function getImports(customFetch) {/' \
+          -e 's/getObject(arg0).fetch(/window.customFetch(/' \
           ../../content/examples/$category_slug/$example_slug/$example.js
 
         echo "+++

--- a/generate-wasm-examples/generate_wasm_examples.sh
+++ b/generate-wasm-examples/generate_wasm_examples.sh
@@ -43,6 +43,7 @@ add_category()
         # See: https://github.com/bevyengine/bevy-website/pull/355
         sed -i.bak \
           -e 's/getObject(arg0).fetch(/window.bevyLoadingBarFetch(/' \
+          -e 's/input = fetch(/input = window.bevyLoadingBarFetch(/' \
           ../../content/examples/$category_slug/$example_slug/$example.js
 
         echo "+++

--- a/generate-wasm-examples/generate_wasm_examples.sh
+++ b/generate-wasm-examples/generate_wasm_examples.sh
@@ -42,7 +42,7 @@ add_category()
         # Patch generated JS to allow to inject custom `fetch` with loading feedback.
         # See: https://github.com/bevyengine/bevy-website/pull/355
         sed -i.bak \
-          -e 's/getObject(arg0).fetch(/window.loadingBarFetch(/' \
+          -e 's/getObject(arg0).fetch(/window.bevyLoadingBarFetch(/' \
           ../../content/examples/$category_slug/$example_slug/$example.js
 
         echo "+++

--- a/templates/example.html
+++ b/templates/example.html
@@ -74,7 +74,7 @@
             }
         })
     }
-    window.bevyLoadingBarFetch = bevyLoadingBarFetch;
+    window.bevyLoadingBarFetch = loadingBarFetch;
     init();
 </script>
 {% endblock content %}

--- a/templates/example.html
+++ b/templates/example.html
@@ -74,7 +74,7 @@
             }
         })
     }
-
-    init(loadingBarFetch);
+    window.customFetch = loadingBarFetch;
+    init();
 </script>
 {% endblock content %}

--- a/templates/example.html
+++ b/templates/example.html
@@ -74,7 +74,7 @@
             }
         })
     }
-    window.customFetch = loadingBarFetch;
+    window.loadingBarFetch = loadingBarFetch;
     init();
 </script>
 {% endblock content %}

--- a/templates/example.html
+++ b/templates/example.html
@@ -74,7 +74,7 @@
             }
         })
     }
-    window.loadingBarFetch = loadingBarFetch;
+    window.bevyLoadingBarFetch = bevyLoadingBarFetch;
     init();
 </script>
 {% endblock content %}


### PR DESCRIPTION
To try and reduce the likelihood of this breaking again we can simply register customFetch globally and use it directly from the window. It still relies on wasm-bindgen not changing a specific line, but at least it's one line instead of 5.

I tested it locally and it works.

Obviously doing things globally isn't ideal, but I renamed it to be a bit more explicit.

I tried simply overriding `fetch` itself globally, but it broke everything.