### PR TITLE
Fix the donate button in blog posts

### DIFF
--- a/content/news/2021-04-06-bevy-0.5/index.md
+++ b/content/news/2021-04-06-bevy-0.5/index.md
@@ -1143,7 +1143,7 @@ We also plan on breaking ground on the Bevy Editor as soon as we converge on a f
 
 [Sponsorships](https://github.com/sponsors/cart) help make full time work on Bevy sustainable. If you believe in Bevy's mission, consider [sponsoring @cart](https://github.com/sponsors/cart) ... every bit helps!
 
-<a class="header-item header-button header-button-donate" style="margin-left: 0px;" href="https://github.com/sponsors/cart">Donate <img src="/assets/heart.svg" class="header-button-donate-heart" alt="heart icon"/></a>
+<a class="button button--pink header__cta" href="https://github.com/sponsors/cart">Donate <img class="button__icon" src="/assets/heart.svg" alt="heart icon"/></a>
 
 ## Contributors
 

--- a/content/news/2022-01-08-bevy-0.6/index.md
+++ b/content/news/2022-01-08-bevy-0.6/index.md
@@ -1043,7 +1043,7 @@ To solve this problem @alice-i-cecile has [started working](https://github.com/b
 
 Sponsorships help make my full time work on Bevy sustainable. If you believe in Bevy's mission, consider sponsoring me (@cart) ... every bit helps!
 
-<a class="header-item header-button header-button-donate" style="margin-left: 0px;" href="https://github.com/sponsors/cart">Donate <img src="/assets/heart.svg" class="header-button-donate-heart" alt="heart icon"/></a>
+<a class="button button--pink header__cta" href="https://github.com/sponsors/cart">Donate <img class="button__icon" src="/assets/heart.svg" alt="heart icon"/></a>
 
 ## Contributors
 

--- a/content/news/2022-04-15-bevy-0.7/index.md
+++ b/content/news/2022-04-15-bevy-0.7/index.md
@@ -750,7 +750,7 @@ It has a built in "fly camera" and has tools to play animations and toggle light
 
 Sponsorships help make my full time work on Bevy sustainable. If you believe in Bevy's mission, consider sponsoring me (@cart) ... every bit helps!
 
-<a class="header-item header-button header-button-donate" style="margin-left: 0px;" href="https://github.com/sponsors/cart">Donate <img src="/assets/heart.svg" class="header-button-donate-heart" alt="heart icon"/></a>
+<a class="button button--pink header__cta" href="https://github.com/sponsors/cart">Donate <img class="button__icon" src="/assets/heart.svg" alt="heart icon"/></a>
 
 ## Contributors
 


### PR DESCRIPTION
Recent donate button style changes broke the donate button in blog posts. This aligns it with the new style. Might be worth abstracting this out with templates to avoid needing to keep everything in sync, but thats a problem for another day.