### PR TITLE
[Merged by Bors] - Specify file on `main.rs` mention

### DIFF
--- a/content/learn/book/getting-started/ecs/_index.md
+++ b/content/learn/book/getting-started/ecs/_index.md
@@ -64,7 +64,7 @@ Now run your App again using `cargo run`. You should see `hello world!` printed 
 
 Greeting the whole world is great, but what if we want to greet specific people? In ECS, you would generally model people as entities with a set of components that define them. Let's start simple with a `Person` component.
 
-Add this struct to `main.rs`:
+Add this struct to your `main.rs` file:
 
 ```rs
 #[derive(Component)]


### PR DESCRIPTION
This is a small change, but in walking through the Bevy book with some students I'm teaching this summer, they misunderstood this and thought it should be added to the main function instead.

It's definitely more to reduce confusion and ambiguity for newer Rust developers and might be a bit annoyingly verbose for others. Not sure.