### PR TITLE
[Merged by Bors] - Add Examples to nav and add "intro" text

### DIFF
--- a/sass/pages/_assets.scss
+++ b/sass/pages/_assets.scss
@@ -1,4 +1,9 @@
 .assets {
+    .assets-intro {
+        font-size: 1.2rem;
+        margin-bottom: 20px;
+    }
+
     .asset-section {
         font-size: 2.4rem;
         margin: 0 0 20px;
@@ -36,5 +41,6 @@
 
     a {
         text-decoration: none;
+        color: $link-color;
     }
 }

--- a/templates/examples.html
+++ b/templates/examples.html
@@ -13,6 +13,11 @@
 
 {% block page_content %}
 <div class="assets">
+    <div class="assets-intro">
+        These examples demonstrate how to use Bevy's features in a minimal, easy to understand way. Click an example below to run it in
+        your browser (using WASM + WebGL) and view the source code. You can also view these examples (and others) in the
+        <a href="https://github.com/bevyengine/bevy/tree/latest/examples#examples">Bevy repo</a>.
+    </div>
     {% for subsection in section.subsections %}
         {% set section = get_section(path=subsection) %}
 

--- a/templates/layouts/base.html
+++ b/templates/layouts/base.html
@@ -90,6 +90,7 @@
                                 {{header_macros::header_item(name="News", current_path=current_path)}}
                                 {{header_macros::header_item(name="Community", current_path=current_path)}}
                                 {{header_macros::header_item(name="Assets", current_path=current_path)}}
+                                {{header_macros::header_item(name="Examples", current_path=current_path)}}
                                 {# <li class="main-menu__entry">
                                     <a class="main-menu__link" href="https://merch.bevyengine.org">Merch</a>
                                 </li> #}


### PR DESCRIPTION
I think we've ironed out enough of the kinks to justify making the examples page more prominent. We've been sitting on a lot of value here for awhile :smile: 

For posterity: big thanks to @mockersf for putting together this feature in #225 and @doup for adding loading feedback in #355 and a bunch of other visual improvements.