### PR TITLE
[Merged by Bors] - Generate extra metadata from external sources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,8 @@ on:
   pull_request:
   push:
     branches:
-      - "staging"
-      - "trying"
+      - 'staging'
+      - 'trying'
 
 jobs:
   generate-assets:
@@ -23,9 +23,20 @@ jobs:
             generate-assets/target/
           key: ${{ runner.os }}-generate-assets-${{ hashFiles('generate-assets/Cargo.toml') }}
 
+      - name: Get cache key
+        id: cache-key
+        run: echo "::set-output name=key::$(date +'%Y-%m-%d')"
+
+      - name: Get crates.io datadump from cache
+        uses: actions/cache@v2
+        with:
+          path: generate-assets/data
+          key: ${{ runner.os }}-${{ steps.cache-key.outputs.key }}
+
       - name: "Build Bevy Assets"
         run: >
           cd generate-assets &&
+          export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} &&
           ./generate_assets.sh
 
       - uses: actions/upload-artifact@master

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,16 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+
+      - name: Cache multiple crates.io datadump
+        uses: actions/cache@v2
+        with:
+          path: generate-assets/data
+          key: ${{ runner.os }}-${{ steps.date.outputs.date }}
+
       - name: "Build Bevy Assets"
         run: cd generate-assets && ./generate_assets.sh
 

--- a/README.md
+++ b/README.md
@@ -15,3 +15,8 @@ To check out any local changes you've made:
 3. Start the Zola server with `zola serve`.
 
 A local server should start and you should be able to access a local version of the website from there.
+
+## Assets generation
+
+Assets are generated using data from /generate/assets and crates.io using their [datadump](https://crates.io/data-access) trough [cratesio-dbdump-lookup](https://github.com/alyti/cratesio-dbdump-lookup).
+Please notice when unpacked, the crates.io dump fills about 500 mb.

--- a/generate-assets/.gitignore
+++ b/generate-assets/.gitignore
@@ -1,2 +1,4 @@
 target
 assets
+data/
+.env

--- a/generate-assets/Cargo.lock
+++ b/generate-assets/Cargo.lock
@@ -3,6 +3,23 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12,19 +29,434 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
+
+[[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "bytes"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+
+[[package]]
+name = "bzip2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6afcd980b5f3a45017c57e57a2fcccbb351cc43a356ce117ef760ef8052b89b0"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
+name = "cached-path"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f1c56d30236522ab3393a08746b138d4e16372001f42d29c88d513aeb8ab7ef"
+dependencies = [
+ "flate2",
+ "fs2",
+ "glob",
+ "indicatif",
+ "log",
+ "rand",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tar",
+ "tempfile",
+ "thiserror",
+ "zip",
+ "zip-extensions",
+]
+
+[[package]]
+name = "cargo_toml"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5809dd3e6444651fd1cdd3dbec71eca438c439a0fcc8081674a14da0afe50185"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "toml",
+]
+
+[[package]]
+name = "cc"
+version = "1.0.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chunked_transfer"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
+
+[[package]]
+name = "console"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28b32d32ca44b70c3e4acd7db1babf555fa026e385fb95f18028f88848b3c31"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "terminal_size",
+ "winapi",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cratesio-dbdump-csvtab"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf3ee3626c01052b15282249e2c9c81bee3de1c60baa818f95c8e4ee4197ea2"
+dependencies = [
+ "cached-path",
+ "flate2",
+ "rusqlite",
+ "tar",
+ "thiserror",
+]
+
+[[package]]
+name = "cratesio-dbdump-lookup"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0e240e659ad18b47646482ab1c67d1c0ea5deb0d1dfdbd8c839c389a105136b"
+dependencies = [
+ "rusqlite",
+ "serde",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "csv"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa 0.4.8",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fastrand"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e94a7bbaa59354bc20dd75b67f23e2797b4490e9d6928203fb105c79e448c86c"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "windows-sys",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+
+[[package]]
+name = "futures-io"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
+
+[[package]]
+name = "futures-task"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+
+[[package]]
+name = "futures-util"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "generate-assets"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "base64",
+ "cargo_toml",
+ "cratesio-dbdump-csvtab",
+ "cratesio-dbdump-lookup",
+ "dotenv",
  "rand",
  "regex",
  "serde",
  "toml",
+ "ureq",
+ "url",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -35,20 +467,386 @@ checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.95"
+name = "glob"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "789da6d93f1b866ffe175afc5322a4d76c038605a1c3319bb57b06967ca98a36"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
+name = "h2"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashlink"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7249a3129cbc1ffccd74857f81464a323a152173cdb134e0fd81bc803b29facf"
+dependencies = [
+ "hashbrown 0.11.2",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "http"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa 1.0.2",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "496ce29bb5a52785b44e0f7ca2847ae0bb839c9bd28f69acac9b99d461c0c04c"
+
+[[package]]
+name = "httpdate"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "hyper"
+version = "0.14.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa 1.0.2",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
+dependencies = [
+ "console",
+ "lazy_static",
+ "number_prefix",
+ "regex",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
+
+[[package]]
+name = "itoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
+name = "itoa"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+
+[[package]]
+name = "js-sys"
+version = "0.3.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3fac17f7123a73ca62df411b1bf727ccc805daa070338fda671c86dac1bdc27"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "libc"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290b64917f8b0cb885d9de0f9959fe1f775d7fa12f1da2db9001c1c8ab60f89d"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "log"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "matches"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+
+[[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
+name = "once_cell"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+
+[[package]]
+name = "openssl"
+version = "0.10.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "618febf65336490dfcf20b73f885f5651a0c89c64c2d4a8c3662585a70bf5bd0"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "ppv-lite86"
@@ -58,11 +856,11 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.27"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
+checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -115,6 +913,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,25 +933,170 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
-name = "serde"
-version = "1.0.126"
+name = "remove_dir_all"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c4b1eaf239b47034fb450ee9cdedd7d0226571689d8823030c4b6c2cb407152"
+dependencies = [
+ "bitflags",
+ "csv",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "lazy_static",
+ "libsqlite3-sys",
+ "memchr",
+ "smallvec",
+]
+
+[[package]]
+name = "rustls"
+version = "0.20.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aab8ee6c7097ed6057f43c187a62418d0c05a4bd5f18b3571db50ee0f9ce033"
+dependencies = [
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+
+[[package]]
+name = "schannel"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
+dependencies = [
+ "lazy_static",
+ "windows-sys",
+]
+
+[[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.139"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0171ebb889e45aa68b44aee0859b3eede84c6f5f5c228e6f140c0b2a0a46cad6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.126"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
+checksum = "dc1d3230c1de7932af58ad8ffbe1d784bd55efd5a9d84ac24f69c72d83543dfb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -152,14 +1104,198 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn"
-version = "1.0.72"
+name = "serde_json"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
+checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
+dependencies = [
+ "itoa 1.0.2",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa 1.0.2",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
+
+[[package]]
+name = "smallvec"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
+
+[[package]]
+name = "socket2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "syn"
+version = "1.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
+name = "tokio"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57aec3cfa4c296db7255446efb4928a6be304b431a806216105542a67b6ca82e"
+dependencies = [
+ "autocfg",
+ "bytes",
+ "libc",
+ "memchr",
+ "mio",
+ "num_cpus",
+ "once_cell",
+ "pin-project-lite",
+ "socket2",
+ "winapi",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc463cd8deddc3770d20f9852143d50bf6094e640b485cb2e189a2099085ff45"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -172,13 +1308,344 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.2"
+name = "tower-service"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+
+[[package]]
+name = "tracing"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
+name = "typenum"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c61ba63f9235225a22310255a29b806b907c9b8c964bcbd0a2c70f3f2deea7"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "ureq"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97acb4c28a254fd7a4aeec976c46a7fa404eac4d7c134b30c75144846d7cb8f"
+dependencies = [
+ "base64",
+ "chunked_transfer",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki",
+ "webpki-roots",
+]
+
+[[package]]
+name = "url"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
+ "log",
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c53b543413a17a202f4be280a7e5c62a1c69345f5de525ee64f8cfdbc954994"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5491a68ab4500fa6b4d726bd67408630c3dbe9c4fe7bda16d5c82a1fd8c7340a"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de9a9cec1733468a8c657e57fa2413d2ae2c0129b95e87c5b72b8ace4d13f31f"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c441e177922bc58f1e12c022624b6216378e5febc2f0533e41ba443d505b80aa"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d94ac45fcf608c1f45ef53e748d35660f168490c10b23704c7779ab8f5c3048"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a89911bd99e5f3659ec4acf9c4d93b0a90fe4a2a11f15328472058edc5261be"
+
+[[package]]
+name = "web-sys"
+version = "0.3.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fed94beee57daf8dd7d51f2b15dc2bcde92d7a72304cdf662a4371008b71b90"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1c760f0d366a6c24a02ed7816e23e691f5d92291f94d15e836006fd11b04daf"
+dependencies = [
+ "webpki",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "xattr"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "zip"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93ab48844d61251bb3835145c521d88aa4031d7139e8485990f60ca911fa0815"
+dependencies = [
+ "byteorder",
+ "bzip2",
+ "crc32fast",
+ "flate2",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "zip-extensions"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64c3c977bc3434ce2d4bcea8ad3c644672de0f2c402b72b9171ca80a8885d14"
+dependencies = [
+ "zip",
+]

--- a/generate-assets/Cargo.toml
+++ b/generate-assets/Cargo.toml
@@ -12,6 +12,14 @@ edition = "2018"
 
 [dependencies]
 toml = "0.5"
-serde = { version = "1", features = [ "derive" ] }
+serde = { version = "1", features = ["derive"] }
 rand = "0.8"
 regex = "1"
+cargo_toml = "0.11.5"
+url = "2.2.2"
+anyhow = "1.0.58"
+base64 = "0.13.0"
+cratesio-dbdump-lookup = "0.1.1"
+cratesio-dbdump-csvtab = "0.2.2"
+ureq = { version = "2.5.0", features = ["json"] }
+dotenv = "0.15.0"

--- a/generate-assets/generate_assets.sh
+++ b/generate-assets/generate_assets.sh
@@ -2,4 +2,4 @@
 
 git clone --depth=1 https://github.com/bevyengine/bevy-assets assets
 
-cargo run --bin generate -- assets ../content
+cargo run --release --bin generate -- assets ../content

--- a/generate-assets/src/bin/generate.rs
+++ b/generate-assets/src/bin/generate.rs
@@ -6,15 +6,48 @@ use std::{
     path::Path,
 };
 
-use generate_assets::*;
+use generate_assets::{github_client::GithubClient, gitlab_client::GitlabClient, *};
 
-fn main() -> io::Result<()> {
+fn main() -> anyhow::Result<()> {
+    // Don't fail if file is not present, like in CI, just ignore it
+    let _ = dotenv::dotenv();
+
     let asset_dir = std::env::args().nth(1).unwrap();
     let content_dir = std::env::args().nth(2).unwrap();
-    let _ = fs::create_dir(content_dir.clone());
-    let asset_root_section = parse_assets(&asset_dir)?;
 
-    asset_root_section.write(Path::new(&content_dir), Path::new(""), 0)?;
+    let db = prepare_crates_db()?;
+
+    let github_client = {
+        // This should be configured in CI, but it's not mandatory if running locally
+        if let Ok(token) = std::env::var("GITHUB_TOKEN") {
+            Some(GithubClient::new(token))
+        } else {
+            println!("GITHUB_TOKEN not found, github links will be skipped");
+            None
+        }
+    };
+
+    let gitlab_client = {
+        // This should be configured in CI, but it's not mandatory if running locally
+        if let Ok(token) = std::env::var("GITLAB_TOKEN") {
+            Some(GitlabClient::new(token))
+        } else {
+            println!("GITLAB_TOKEN not found, gitlab links will be skipped");
+            Some(GitlabClient::new(String::from("")))
+        }
+    };
+
+    let _ = fs::create_dir(content_dir.clone());
+    let asset_root_section = parse_assets(
+        &asset_dir,
+        Some(&db),
+        github_client.as_ref(),
+        gitlab_client.as_ref(),
+    )?;
+
+    asset_root_section
+        .write(Path::new(&content_dir), Path::new(""), 0)
+        .expect("Failed to write assets section");
     Ok(())
 }
 
@@ -34,6 +67,8 @@ struct FrontMatterAsset {
 struct FrontMatterAssetExtra {
     link: String,
     image: Option<String>,
+    licenses: Option<Vec<String>>,
+    bevy_versions: Option<Vec<String>>,
 }
 
 impl From<&Asset> for FrontMatterAsset {
@@ -45,6 +80,8 @@ impl From<&Asset> for FrontMatterAsset {
             extra: FrontMatterAssetExtra {
                 link: asset.link.clone(),
                 image: asset.image.clone(),
+                licenses: asset.licenses.clone(),
+                bevy_versions: asset.bevy_versions.clone(),
             },
         }
     }
@@ -96,7 +133,8 @@ impl FrontMatterWriter for Asset {
                 toml::to_string(&frontmatter).unwrap(),
             )
             .as_bytes(),
-        )?;
+        )
+        .unwrap_or_else(|err| panic!("Failed to write at {:?}\n{}", formatted_path, err));
 
         Ok(())
     }
@@ -151,14 +189,18 @@ impl FrontMatterWriter for Section {
     fn write(&self, root_path: &Path, current_path: &Path, weight: usize) -> io::Result<()> {
         let section_path = current_path.join(self.name.to_ascii_lowercase());
         let path = root_path.join(&section_path);
-        fs::create_dir(path.clone())?;
+        if !path.exists() {
+            fs::create_dir(path.clone())
+                .unwrap_or_else(|_| panic!("Failed to create dir {:?}", path));
+        }
 
         let mut frontmatter = FrontMatterSection::from(self);
         if self.order.is_none() {
             frontmatter.weight = weight;
         }
 
-        let mut file = File::create(path.join("_index.md"))?;
+        let mut file = File::create(path.join("_index.md"))
+            .unwrap_or_else(|_| panic!("Failed to create _index.md at {:?}", path));
         file.write_all(
             format!(
                 r#"+++

--- a/generate-assets/src/bin/validate.rs
+++ b/generate-assets/src/bin/validate.rs
@@ -4,7 +4,7 @@ use generate_assets::*;
 
 fn main() -> Result<(), ()> {
     let asset_dir = std::env::args().nth(1).unwrap();
-    if let Ok(asset_root_section) = parse_assets(&asset_dir) {
+    if let Ok(asset_root_section) = parse_assets(&asset_dir, None, None, None) {
         if asset_root_section.validate() {
             Ok(())
         } else {
@@ -76,7 +76,7 @@ impl AssetValidator for Asset {
             }
         }
 
-        return valid;
+        valid
     }
 }
 
@@ -92,5 +92,5 @@ fn has_forbidden_formatting(string: &str) -> bool {
         return true;
     }
 
-    return false;
+    false
 }

--- a/generate-assets/src/github_client.rs
+++ b/generate-assets/src/github_client.rs
@@ -1,0 +1,77 @@
+use anyhow::bail;
+use serde::Deserialize;
+
+const BASE_URL: &str = "https://api.github.com";
+
+#[derive(Deserialize)]
+struct GithubContentResponse {
+    encoding: String,
+    content: String,
+}
+
+#[derive(Deserialize)]
+struct GithubLicenseResponse {
+    license: GithubLicenseLicense,
+}
+
+#[derive(Deserialize)]
+struct GithubLicenseLicense {
+    spdx_id: String,
+}
+
+pub struct GithubClient {
+    agent: ureq::Agent,
+    token: String,
+}
+
+impl GithubClient {
+    pub fn new(token: String) -> Self {
+        let agent: ureq::Agent = ureq::AgentBuilder::new()
+            .user_agent("bevy-website-generate-assets")
+            .build();
+
+        Self { agent, token }
+    }
+
+    /// Gets the content of a file from a github repo
+    pub fn get_content(
+        &self,
+        username: &str,
+        repository_name: &str,
+        content_path: &str,
+    ) -> anyhow::Result<String> {
+        let response: GithubContentResponse = self
+            .agent
+            .get(&format!(
+                "{BASE_URL}/repos/{username}/{repository_name}/contents/{content_path}"
+            ))
+            .set("Accept", "application/json")
+            .set("Authorization", &format!("Bearer {}", self.token))
+            .call()?
+            .into_json()?;
+
+        if response.encoding == "base64" {
+            let data = base64::decode(response.content.replace('\n', "").trim())?;
+            Ok(String::from_utf8(data)?)
+        } else {
+            bail!("Content is not in base64");
+        }
+    }
+
+    /// Gets the license from a github repo
+    /// Technically, github supports multiple licenses, but the api only returns one
+    #[allow(unused)]
+    pub fn get_license(&self, username: &str, repository_name: &str) -> anyhow::Result<String> {
+        let response: GithubLicenseResponse = self
+            .agent
+            .get(&format!(
+                "{BASE_URL}/repos/{username}/{repository_name}/license"
+            ))
+            .set("Accept", "application/json")
+            .set("Authorization", &format!("Bearer {}", self.token))
+            .call()?
+            .into_json()?;
+
+        Ok(response.license.spdx_id)
+    }
+}

--- a/generate-assets/src/gitlab_client.rs
+++ b/generate-assets/src/gitlab_client.rs
@@ -1,0 +1,76 @@
+use anyhow::bail;
+use serde::Deserialize;
+
+const BASE_URL: &str = "https://gitlab.com/api/v4/projects";
+
+#[derive(Deserialize)]
+pub struct GitlabProjectSearchResponse {
+    pub id: usize,
+    pub default_branch: String,
+}
+
+#[derive(Deserialize)]
+struct GitlabContentResponse {
+    encoding: String,
+    content: String,
+}
+
+pub struct GitlabClient {
+    agent: ureq::Agent,
+    // This is not currently used because we have so few assets using gitlab that we don't need it.
+    _token: String,
+}
+
+impl GitlabClient {
+    pub fn new(token: String) -> Self {
+        let agent: ureq::Agent = ureq::AgentBuilder::new()
+            .user_agent("bevy-website-generate-assets")
+            .build();
+
+        Self {
+            agent,
+            _token: token,
+        }
+    }
+
+    /// Finds a list of repo based on their name
+    /// Useful to get the repo id and default_branch
+    pub fn search_project_by_name(
+        &self,
+        repository_name: &str,
+    ) -> anyhow::Result<Vec<GitlabProjectSearchResponse>> {
+        let reponse: Vec<GitlabProjectSearchResponse> = self
+            .agent
+            .get(&format!("{BASE_URL}?search={repository_name}"))
+            .set("Accept", "application/json")
+            // .set("Authorization", &format!("Bearer {}", self.token))
+            .call()?
+            .into_json()?;
+        Ok(reponse)
+    }
+
+    /// Gets the content of a file from a gitlab repo
+    pub fn get_content(
+        &self,
+        id: usize,
+        default_branch: &str,
+        content_path: &str,
+    ) -> anyhow::Result<String> {
+        let reponse: GitlabContentResponse = self
+            .agent
+            .get(&format!(
+                "{BASE_URL}/{id}/repository/files/{content_path}?ref={default_branch}"
+            ))
+            .set("Accept", "application/json")
+            // .set("Authorization", &format!("Bearer {}", self.token))
+            .call()?
+            .into_json()?;
+
+        if reponse.encoding == "base64" {
+            let data = base64::decode(reponse.content.replace('\n', "").trim())?;
+            Ok(String::from_utf8(data)?)
+        } else {
+            bail!("Content is not in base64");
+        }
+    }
+}

--- a/generate-assets/src/lib.rs
+++ b/generate-assets/src/lib.rs
@@ -1,5 +1,14 @@
+use anyhow::{bail, Context};
+use cratesio_dbdump_csvtab::CratesIODumpLoader;
+use github_client::GithubClient;
+use gitlab_client::GitlabClient;
 use serde::Deserialize;
-use std::{fs, io, path::PathBuf, str::FromStr};
+use std::{fs, path::PathBuf, str::FromStr};
+
+pub mod github_client;
+pub mod gitlab_client;
+
+type CratesIoDb = cratesio_dbdump_csvtab::rusqlite::Connection;
 
 #[derive(Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
@@ -9,10 +18,37 @@ pub struct Asset {
     pub description: String,
     pub order: Option<usize>,
     pub image: Option<String>,
+    pub licenses: Option<Vec<String>>,
+    pub bevy_versions: Option<Vec<String>>,
 
     // this field is not read from the toml file
     #[serde(skip)]
     pub original_path: Option<PathBuf>,
+}
+
+impl Asset {
+    /// Parses a license string separated with OR into a Vec<String>
+    fn set_license(&mut self, license: Option<String>) {
+        if self.licenses.is_some() {
+            return;
+        }
+        if let Some(license) = license {
+            let licenses = license
+                .split(" OR ")
+                .map(|x| x.trim().to_string())
+                .collect();
+            self.licenses = Some(licenses);
+        }
+    }
+
+    fn set_bevy_version(&mut self, version: Option<String>) {
+        if self.bevy_versions.is_some() {
+            return;
+        }
+        if let Some(version) = version {
+            self.bevy_versions = Some(vec![version]);
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -45,7 +81,13 @@ impl AssetNode {
     }
 }
 
-fn visit_dirs(dir: PathBuf, section: &mut Section) -> io::Result<()> {
+fn visit_dirs(
+    dir: PathBuf,
+    section: &mut Section,
+    crates_io_db: Option<&CratesIoDb>,
+    github_client: Option<&GithubClient>,
+    gitlab_client: Option<&GitlabClient>,
+) -> anyhow::Result<()> {
     if dir.is_dir() {
         for entry in fs::read_dir(dir)? {
             let entry = entry?;
@@ -81,7 +123,13 @@ fn visit_dirs(dir: PathBuf, section: &mut Section) -> io::Result<()> {
                     order,
                     sort_order_reversed,
                 };
-                visit_dirs(path.clone(), &mut new_section)?;
+                visit_dirs(
+                    path.clone(),
+                    &mut new_section,
+                    crates_io_db,
+                    github_client,
+                    gitlab_client,
+                )?;
                 section.content.push(AssetNode::Section(new_section));
             } else {
                 if path.file_name().unwrap() == "_category.toml"
@@ -89,9 +137,18 @@ fn visit_dirs(dir: PathBuf, section: &mut Section) -> io::Result<()> {
                 {
                     continue;
                 }
-                let mut asset: Asset =
-                    toml::de::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+
+                let mut asset: Asset = toml::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
                 asset.original_path = Some(path);
+
+                if let Err(err) =
+                    get_extra_metadata(&mut asset, crates_io_db, github_client, gitlab_client)
+                {
+                    // We don't want to stop execution here
+                    eprintln!("Failed to get metadata for {}", asset.name);
+                    eprintln!("ERROR: {err:?}");
+                }
+
                 section.content.push(AssetNode::Asset(asset));
             }
         }
@@ -99,7 +156,12 @@ fn visit_dirs(dir: PathBuf, section: &mut Section) -> io::Result<()> {
     Ok(())
 }
 
-pub fn parse_assets(asset_dir: &str) -> io::Result<Section> {
+pub fn parse_assets(
+    asset_dir: &str,
+    crates_io_db: Option<&CratesIoDb>,
+    github_client: Option<&GithubClient>,
+    gitlab_client: Option<&GitlabClient>,
+) -> anyhow::Result<Section> {
     let mut asset_root_section = Section {
         name: "Assets".to_string(),
         content: vec![],
@@ -109,8 +171,209 @@ pub fn parse_assets(asset_dir: &str) -> io::Result<Section> {
         sort_order_reversed: false,
     };
     visit_dirs(
-        PathBuf::from_str(&asset_dir).unwrap(),
+        PathBuf::from_str(asset_dir).unwrap(),
         &mut asset_root_section,
+        crates_io_db,
+        github_client,
+        gitlab_client,
     )?;
     Ok(asset_root_section)
+}
+
+/// Tries to get bevy supported version and license information from various external sources
+fn get_extra_metadata(
+    asset: &mut Asset,
+    crates_io_db: Option<&CratesIoDb>,
+    github_client: Option<&GithubClient>,
+    gitlab_client: Option<&GitlabClient>,
+) -> anyhow::Result<()> {
+    println!("Getting extra metadata for {}", asset.name);
+
+    let url = url::Url::parse(&asset.link)?;
+    let segments = url.path_segments().map(|c| c.collect::<Vec<_>>()).unwrap();
+    let metadata = match url.host_str() {
+        Some("crates.io") if crates_io_db.is_some() => {
+            if let Some(db) = crates_io_db {
+                let crate_name = segments[1];
+                Some(get_metadata_from_crates_io_db(db, crate_name)?)
+            } else {
+                None
+            }
+        }
+        Some("github.com") => {
+            if let Some(client) = github_client {
+                let username = segments[0];
+                let repository_name = segments[1];
+                Some(get_metadata_from_github(client, username, repository_name)?)
+            } else {
+                None
+            }
+        }
+        Some("gitlab.com") => {
+            if let Some(client) = gitlab_client {
+                let repository_name = segments[1];
+                Some(get_metadata_from_gitlab(client, repository_name)?)
+            } else {
+                None
+            }
+        }
+        None => None,
+        _ => bail!("Unknown host: {}", asset.link),
+    };
+
+    if let Some((license, version)) = metadata {
+        asset.set_license(license);
+        asset.set_bevy_version(version);
+    }
+
+    Ok(())
+}
+
+fn get_metadata_from_github(
+    client: &GithubClient,
+    username: &str,
+    repository_name: &str,
+) -> anyhow::Result<(Option<String>, Option<String>)> {
+    let content = client
+        .get_content(username, repository_name, "Cargo.toml")
+        .context("Failed to get Cargo.toml from github")?;
+
+    let cargo_manifest = toml::from_str::<cargo_toml::Manifest>(&content)?;
+    Ok((
+        get_license(&cargo_manifest),
+        get_bevy_version(&cargo_manifest),
+    ))
+}
+
+fn get_metadata_from_gitlab(
+    client: &GitlabClient,
+    repository_name: &str,
+) -> anyhow::Result<(Option<String>, Option<String>)> {
+    let search_result = client.search_project_by_name(repository_name)?;
+
+    let repo = search_result
+        .first()
+        .context("Failed to find gitlab repo")?;
+
+    let content = client
+        .get_content(repo.id, &repo.default_branch, "Cargo.toml")
+        .context("Failed to get Cargo.toml from gitlab")?;
+
+    let cargo_manifest = toml::from_str::<cargo_toml::Manifest>(&content)?;
+    Ok((
+        get_license(&cargo_manifest),
+        get_bevy_version(&cargo_manifest),
+    ))
+}
+
+/// Gets the bevy version from the dependency list
+/// Returns the version number if available.
+/// If is is a git dependency, return either "main" or "git" for anything that isn't "main".
+fn get_bevy_dependency_version(dep: &cargo_toml::Dependency) -> Option<String> {
+    match dep {
+        cargo_toml::Dependency::Simple(version) => Some(version.to_string()),
+        cargo_toml::Dependency::Detailed(detail) => {
+            if let Some(version) = &detail.version {
+                Some(version.to_string())
+            } else if detail.git.is_some() {
+                if detail.branch == Some(String::from("main")) {
+                    Some(String::from("main"))
+                } else {
+                    Some(String::from("git"))
+                }
+            } else {
+                None
+            }
+        }
+    }
+}
+
+/// Gets the license from a Cargo.toml file
+/// Tries to emulate crates.io behaviour
+fn get_license(cargo_manifest: &cargo_toml::Manifest) -> Option<String> {
+    // Get the license from the package information
+    if let Some(cargo_toml::Package {
+        license,
+        license_file,
+        ..
+    }) = &cargo_manifest.package
+    {
+        if let Some(license) = license {
+            Some(license.clone())
+        } else {
+            license_file.as_ref().map(|_| String::from("non-standard"))
+        }
+    } else {
+        None
+    }
+}
+
+/// Find any dep that starts with bevy and get the version
+/// This makes sure to handle all the bevy_* crates
+fn get_bevy_version(cargo_manifest: &cargo_toml::Manifest) -> Option<String> {
+    cargo_manifest
+        .dependencies
+        .keys()
+        .find(|k| k.starts_with("bevy"))
+        .and_then(|key| {
+            cargo_manifest
+                .dependencies
+                .get(key)
+                .and_then(get_bevy_dependency_version)
+        })
+}
+
+/// Downloads the crates.io database dump and open a connection to the db
+pub fn prepare_crates_db() -> anyhow::Result<CratesIoDb> {
+    let cache_dir = {
+        let mut current_dir = std::env::current_dir()?;
+        current_dir.push("data");
+        current_dir
+    };
+
+    if cache_dir.exists() {
+        println!("Using crates.io data dump cache from: {:?}", cache_dir);
+    } else {
+        println!("Downloading crates.io data dump");
+    }
+
+    Ok(CratesIODumpLoader::default()
+        .tables(&["crates", "dependencies", "versions"])
+        .preload(true)
+        .update()?
+        .open_db()?)
+}
+
+/// Gets the required metadata from the crates.io database dump
+fn get_metadata_from_crates_io_db(
+    db: &CratesIoDb,
+    crate_name: &str,
+) -> anyhow::Result<(Option<String>, Option<String>)> {
+    if let Ok(metadata) = get_metadata_from_db_by_crate_name(db, crate_name) {
+        Ok(metadata)
+    } else if let Ok(metadata) =
+        get_metadata_from_db_by_crate_name(db, &crate_name.replace('_', "-"))
+    {
+        Ok(metadata)
+    } else {
+        bail!("Failed to get data from crates.io db for {crate_name}")
+    }
+}
+
+fn get_metadata_from_db_by_crate_name(
+    db: &CratesIoDb,
+    crate_name: &str,
+) -> anyhow::Result<(Option<String>, Option<String>)> {
+    if let Some(Ok((_, _, license, _, deps))) =
+        &cratesio_dbdump_lookup::get_rev_dependency(db, crate_name, "bevy")?.first()
+    {
+        let version = deps
+            .as_ref()
+            .ok()
+            .and_then(|deps| deps.first())
+            .map(|(version, _)| version.clone());
+        Ok((Some(license.clone()), version))
+    } else {
+        bail!("Not found in crates.io db: {crate_name}")
+    }
 }


### PR DESCRIPTION
## Objective

The new asset cards (#394) need more metadata for license and bevy compatible versions.

## Solution

- For assets with a link to github or gitlab:
  - Get the Cargo.toml file using the apis, parse it and read the bevy version and license fields.
  - This is done on a best effort basis. It's not always possible to have this information. For example, when the Cargo.toml is not at the top level. 
- For assets with crates.io links
  - Use the crates.io dbdump to get the required data.
- If the metadata is entered manually directly in bevy_assets it will be used instead.

The github client relies on a GITHUB_TOKEN env var to exist in CI or locally. It should be already there since we use github actions. The rate limit in github actions is 1000 per hour https://docs.github.com/en/rest/overview/resources-in-the-rest-api#requests-from-github-actions so we should be fine for a little while.

The gitlab client implementation ignores the token because we have so few crates that it doesn't matter.

## Notes

Querying the crates.io dump is pretty slow and the deps-tree required is pretty big. I think we should consider eventually rolling our own way to do that, but it works well right now.

This is going to be pretty slow to execute in the job once it is merged, but it's pretty easy to parallelize all the generate-* jobs so I did it in #401 .