### PR TITLE
[Merged by Bors] - add .vscode to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ content/learn/errors
 content/examples
 static/assets/examples
 static/processed_images
+.vscode/


### PR DESCRIPTION
I have a few extensions causing me problem in this repo and I like disabling them in a vscode/settings.json

Since main bevy already has that ignore I feel it's ok to also add it here.