### PR TITLE
Add example WASM optimization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
+      - name: "Install binaryen for wasm-opt tool"
+        run: sudo apt-get install -y binaryen
+
       - name: "Build Bevy Assets"
         run: cd generate-assets && ./generate_assets.sh
 
@@ -25,7 +28,7 @@ jobs:
           target: wasm32-unknown-unknown
 
       - name: "Build Bevy Examples"
-        run: cargo install wasm-bindgen-cli && cd generate-wasm-examples && ./generate_wasm_examples.sh
+        run: cargo install wasm-bindgen-cli && cd generate-wasm-examples && ./generate_wasm_examples.sh --ci
 
       - name: "Build website"
         uses: shalzz/zola-deploy-action@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           target: wasm32-unknown-unknown
 
       - name: "Build Bevy Examples"
-        run: cargo install wasm-bindgen-cli && cd generate-wasm-examples && ./generate_wasm_examples.sh --ci
+        run: cargo install wasm-bindgen-cli && cd generate-wasm-examples && ./generate_wasm_examples.sh
 
       - name: "Build website"
         uses: shalzz/zola-deploy-action@master

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
           target: wasm32-unknown-unknown
 
       - name: "Build Bevy Examples"
-        run: cargo install wasm-bindgen-cli && cd generate-wasm-examples && ./generate_wasm_examples.sh
+        run: cargo install wasm-bindgen-cli && cd generate-wasm-examples && ./generate_wasm_examples.sh --optimize-wasm
 
       - name: "Build and deploy website"
         if: github.repository_owner == 'bevyengine'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,9 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
+      - name: "Install binaryen for wasm-opt tool"
+        run: sudo apt-get install -y binaryen
+
       - name: "Build Bevy Assets"
         run: cd generate-assets && ./generate_assets.sh
 

--- a/generate-wasm-examples/generate_wasm_examples.sh
+++ b/generate-wasm-examples/generate_wasm_examples.sh
@@ -19,19 +19,19 @@ sed -i.bak 's/asset_folder: "assets"/asset_folder: "\/assets\/examples\/"/' crat
 
 export CARGO_TARGET_DIR="target"
 
-if [ "$1" = --ci ] ; then
+if [ "$1" = --optimize-wasm ] ; then
+    # enable optimizations
+    cargo_profile="wasm-release"
+    cargo_target_dir="wasm-release"
+    # Optimize for size
+    wasm_opt_flag="-Oz"
+else
     # disable optimizations
     cargo_profile="dev"
     cargo_target_dir="debug"
     # Do not optimize on --ci check,
     # wasm-opt takes A LOT of time to run
     wasm_opt_flag="-O0"
-else
-    # enable optimizations
-    cargo_profile="wasm-release"
-    cargo_target_dir="wasm-release"
-    # Optimize for size
-    wasm_opt_flag="-Oz"
 fi
 
 examples_dir="../../content/examples"

--- a/generate-wasm-examples/generate_wasm_examples.sh
+++ b/generate-wasm-examples/generate_wasm_examples.sh
@@ -1,8 +1,12 @@
 #!/bin/sh
 
+# Print all executed lines
+# set -x
+
 git init bevy
 cd bevy
 git remote add origin https://github.com/bevyengine/bevy
+git restore Cargo.toml
 git pull --depth=1 origin latest
 
 # remove markdown files from assets so that they don't get picked up by Zola
@@ -14,6 +18,26 @@ sed -i.bak 's/canvas: None,/canvas: Some("#bevy".to_string()),/' crates/bevy_win
 # setting the asset folder root to the root url of this domain
 sed -i.bak 's/asset_folder: "assets"/asset_folder: "\/assets\/examples\/"/' crates/bevy_asset/src/lib.rs
 
+export CARGO_TARGET_DIR="target"
+
+if [ "$1" = --ci ] ; then
+    # Do not optimize on --ci check,
+    # wasm-opt takes A LOT of time to run
+    wasm_opt_flag="-O0"
+else
+    echo "
+
+[profile.release]
+opt-level = \"z\"
+lto = \"fat\"
+codegen-units = 1
+" >> Cargo.toml
+
+    # Optimize for size
+    wasm_opt_flag="-Oz"
+fi
+
+examples_dir="../../content/examples"
 
 add_category()
 {
@@ -22,7 +46,7 @@ add_category()
     category_slug=`echo $category_path | tr '_' '-'`
     example_weight=0
 
-    mkdir ../../content/examples/$category_slug
+    mkdir "$examples_dir/$category_slug"
 
     # Remove first two arguments
     shift 2
@@ -34,17 +58,27 @@ add_category()
         echo "building $category / $example"
         example_slug=`echo $example | tr '_' '-'`
         code_filename="$example.rs"
-        mkdir ../../content/examples/$category_slug/$example_slug
-        cp examples/$category_path/$code_filename ../../content/examples/$category_slug/$example_slug/
+        out_dir=$examples_dir/$category_slug/$example_slug
+        mkdir $out_dir
+        cp examples/$category_path/$code_filename $out_dir
         cargo build --release --target wasm32-unknown-unknown --example $example
-        wasm-bindgen --out-dir ../../content/examples/$category_slug/$example_slug --no-typescript --target web target/wasm32-unknown-unknown/release/examples/$example.wasm
+
+        wasm-bindgen --out-dir $out_dir \
+            --no-typescript --target web target/wasm32-unknown-unknown/release/examples/$example.wasm
+
+        wasm-opt $wasm_opt_flag \
+            --output "$out_dir/${example}_bg.wasm.optimized" \
+            "$out_dir/${example}_bg.wasm"
+        
+        mv "$out_dir/${example}_bg.wasm.optimized" "$out_dir/${example}_bg.wasm"
+
 
         # Patch generated JS to allow to inject custom `fetch` with loading feedback.
         # See: https://github.com/bevyengine/bevy-website/pull/355
         sed -i.bak \
           -e 's/getObject(arg0).fetch(/window.bevyLoadingBarFetch(/' \
           -e 's/input = fetch(/input = window.bevyLoadingBarFetch(/' \
-          ../../content/examples/$category_slug/$example_slug/$example.js
+          "$out_dir/$example.js"
 
         echo "+++
 title = \"$example\"
@@ -55,7 +89,7 @@ weight = $example_weight
 code_path = \"content/examples/$category_slug/$example_slug/$code_filename\"
 github_code_path = \"examples/$category_path/$code_filename\"
 header_message = \"Examples\"
-+++" > ../../content/examples/$category_slug/$example_slug/index.md
++++" > $out_dir/index.md
 
         example_weight=$((example_weight+1))
     done
@@ -65,12 +99,12 @@ header_message = \"Examples\"
 title = \"$category\"
 sort_by = \"weight\"
 weight = $category_weight
-+++" > ../../content/examples/$category_slug/_index.md
++++" > $examples_dir/$category_slug/_index.md
 
     category_weight=$((category_weight+1))
 }
 
-mkdir ../../content/examples
+mkdir $examples_dir
 cp -r assets/ ../../static/assets/examples/
 
 echo "+++
@@ -80,7 +114,7 @@ sort_by = \"weight\"
 
 [extra]
 header_message = \"Examples\"
-+++" > ../../content/examples/_index.md
++++" > $examples_dir/_index.md
 
 category_weight=0
 


### PR DESCRIPTION
- Add the standard code size optimization flags to `Cargo.toml`
- Use wasm-opt from binaryen

This reduces the generated wasm file sizes from `12M` to `5.9M`.

**DISCLAIMER**:

This increases **massively** deployment times. On my very
beefy machine, I get 30 minutes to generate all examples
on a cold build.