### PR TITLE
[Merged by Bors] - add intro text to assets page

### DIFF
--- a/templates/assets.html
+++ b/templates/assets.html
@@ -13,6 +13,11 @@
 
 {% block page_content %}
     <div class="assets">
+        <div class="assets-intro">
+            A collection of Bevy assets, plugins, learning resources, and apps made by the community. If you would like to
+            share what you're working on, <a href="https://github.com/bevyengine/bevy-assets">submit a PR</a>!
+        </div>
+
         {% for subsection in section.subsections %}
         {% set section = get_section(path=subsection) %}
 

--- a/templates/assets.html
+++ b/templates/assets.html
@@ -15,7 +15,7 @@
     <div class="assets">
         <div class="assets-intro">
             A collection of third-party Bevy assets, plugins, learning resources, and apps made by the community. If you would like to
-            share what you're working on, <a href="https://github.com/bevyengine/bevy-assets">submit a PR</a>!
+            share what you're working on, <a href="https://github.com/bevyengine/bevy-assets">submit a pull request</a>!
         </div>
 
         {% for subsection in section.subsections %}

--- a/templates/assets.html
+++ b/templates/assets.html
@@ -14,7 +14,7 @@
 {% block page_content %}
     <div class="assets">
         <div class="assets-intro">
-            A collection of Bevy assets, plugins, learning resources, and apps made by the community. If you would like to
+            A collection of third-party Bevy assets, plugins, learning resources, and apps made by the community. If you would like to
             share what you're working on, <a href="https://github.com/bevyengine/bevy-assets">submit a PR</a>!
         </div>
 


### PR DESCRIPTION
## Objective

The assets page has no text describing what it actually is, it should be made a bit clearer. 

## Solution
I used the description from the bevy_assets README to clarify it a bit more.

![vivaldi_znFCzIkiSO](https://user-images.githubusercontent.com/8348954/180702648-853d7a8b-481a-45f6-b1d4-8c5ff5342d06.png)

## Notes

I'm sure some people would like a clear disclaimer related to licenses. I'm open to the idea, but this could be done in a separate PR and shouldn't block this PR.