### PR TITLE
[Merged by Bors] - Add missing Text::from_section and query::QuerySingleError to 0.7-0.8 migration guide

### DIFF
--- a/content/learn/book/migration-guides/0.7-0.8/_index.md
+++ b/content/learn/book/migration-guides/0.7-0.8/_index.md
@@ -538,3 +538,14 @@ bevy = { version = "0.8", default-features = false, features = [
     "bevy_scene",
 ] }
 ```
+
+### [Improve ergonomics and reduce boilerplate around creating text elements](https://github.com/bevyengine/bevy/pull/5343)
+
+`Text::with_section` was renamed to `Text::from_section` and no longer takes a `TextAlignment` as argument.
+Use `with_alignment` to set the alignment instead.
+
+
+### [Add QueryState::get_single_unchecked_manual and its family](https://github.com/bevyengine/bevy/pull/4841)
+
+Change `system::QuerySingleError` to `query::QuerySingleError`
+


### PR DESCRIPTION
While upgrading my game to `0.8` I noticed those two was missing on migration guide. Both migration guide text I copied from their PRs, so feel free to suggest any text changes.