### PR TITLE
[Merged by Bors] - Fix markdown lint warnings in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
 # Bevy Website
 
-The source files for https://bevyengine.org. This includes official Bevy news and docs, so if you would like to contribute feel free to create a pull request!
+The source files for <https://bevyengine.org>. This includes official Bevy news and docs, so if you would like to contribute feel free to create a pull request!
 
 ## Zola
 
 The Bevy website is built using the Zola static site engine. In our experience, it is fast, flexible, and straightforward to use.
 
 To check out any local changes you've made:
+
 1. [Download Zola](https://www.getzola.org/).
 2. Clone the Bevy Website git repo and enter that directory:
-    1. `git clone https://github.com/bevyengine/bevy-website.git`
-    2. `cd bevy-website`
+   1. `git clone https://github.com/bevyengine/bevy-website.git`
+   2. `cd bevy-website`
 3. Start the Zola server with `zola serve`.
 
 A local server should start and you should be able to access a local version of the website from there.


### PR DESCRIPTION
This PR fixes two minor markdown lint warnings in the README, to make sure that it renders correctly everywhere:

- MD032/blanks-around-lists: Lists should be surrounded by blank lines
- MD034/no-bare-urls: Bare URL used
