### PR TITLE
[Merged by Bors] - Remove unnecessary doc comments in 8.0 post

### DIFF
--- a/content/news/2022-07-30-bevy-0.8/index.md
+++ b/content/news/2022-07-30-bevy-0.8/index.md
@@ -173,8 +173,8 @@ This can be used for things like "custom UI passes", "minimaps", etc.
 Cameras now store their [`RenderTarget`] size locally, which makes retrieving the size much simpler:
 
 ```rust
-/// Much nicer than needing to look up the size on the target Window or Image manually,
-/// like you had to in previous Bevy versions!
+// Much nicer than needing to look up the size on the target Window or Image manually,
+// like you had to in previous Bevy versions!
 let target_size = camera.logical_target_size();
 let viewport_size = camera.logical_viewport_size();
 ```


### PR DESCRIPTION
The [0.8 blog post](https://bevyengine.org/news/bevy-0-8/#ergonomic-target-size-access) contains the following code snippet:

```rust
/// Much nicer than needing to look up the size on the target Window or Image manually,
/// like you had to in previous Bevy versions!
let target_size = camera.logical_target_size();
let viewport_size = camera.logical_viewport_size();
```

To my knowledge, using doc comments has no special effect here.

This PR replaces them by regular inline comments.