### PR TITLE
[Merged by Bors] - Add an outline on focused elements for accessibility

### DIFF
--- a/sass/_utils.scss
+++ b/sass/_utils.scss
@@ -3,7 +3,7 @@
 }
 
 // Visual outline on focused elements, for accessibility
-*:focus {
+*:focus-visible {
     border-radius: 5px;
     outline: $focus-outline;
 }

--- a/sass/_utils.scss
+++ b/sass/_utils.scss
@@ -2,8 +2,9 @@
     display: none;
 }
 
-a:focus {
-    outline: none;
+// Visual outline on focused elements, for accessibility
+*:focus {
+    outline: $focus-outline;
 }
 
 .section {

--- a/sass/_utils.scss
+++ b/sass/_utils.scss
@@ -4,6 +4,7 @@
 
 // Visual outline on focused elements, for accessibility
 *:focus {
+    border-radius: 5px;
     outline: $focus-outline;
 }
 

--- a/sass/_vars.scss
+++ b/sass/_vars.scss
@@ -59,3 +59,6 @@ $card-list-gap: 15px;
         --header-height: 72px;
     }
 }
+
+// Accessibility
+$focus-outline: solid #b1d9ff 3px;

--- a/sass/components/_main-menu.scss
+++ b/sass/components/_main-menu.scss
@@ -42,6 +42,7 @@
 
         // Instead we have the outline on the text inside the link
         &:focus span {
+            border-radius: 5px;
             outline: $focus-outline;
         }
     }

--- a/sass/components/_main-menu.scss
+++ b/sass/components/_main-menu.scss
@@ -33,6 +33,17 @@
                 color: $color-blue;
             }
         }
+
+        // Having the focus outline on the header link directly looks weird,
+        // because it is cut off at the top
+        &:focus {
+            outline: none;
+        }
+
+        // Instead we have the outline on the text inside the link
+        &:focus span {
+            outline: $focus-outline;
+        }
     }
 }
 

--- a/sass/components/_main-menu.scss
+++ b/sass/components/_main-menu.scss
@@ -36,12 +36,12 @@
 
         // Having the focus outline on the header link directly looks weird,
         // because it is cut off at the top
-        &:focus {
+        &:focus-visible {
             outline: none;
         }
 
         // Instead we have the outline on the text inside the link
-        &:focus span {
+        &:focus-visible span {
             border-radius: 5px;
             outline: $focus-outline;
         }

--- a/templates/macros/header.html
+++ b/templates/macros/header.html
@@ -17,6 +17,8 @@
     {% endif %}
 
     <li class="main-menu__entry">
-        <a href="{{route | lower}}" class="{{ class }}">{{name}}</a>
+        <a href="{{route | lower}}" class="{{ class }}">
+            <span>{{name}}</span>
+        </a>
     </li>
 {% endmacro %}


### PR DESCRIPTION
Fixes #395.

For users that depend on keyboard navigation, it is crucial to have a visual indication of which element is currently focused.

This PR adds a bright blue outline to the focused element:

- Header links:
    
    ![Focus outline on the header links](https://user-images.githubusercontent.com/13908946/181996367-5eb0ffac-21a3-4922-a90b-e41b6bc597ed.png)

- Header buttons:

    ![Focus outline on the header buttons](https://user-images.githubusercontent.com/13908946/181996389-cdaddaa8-f5a7-482b-92f1-73ac990f76dc.png)

- Cards:

    ![image](https://user-images.githubusercontent.com/13908946/181996399-6cfb36af-bb92-4738-ae56-2f6e1b459264.png)
