### PR TITLE
[Merged by Bors] - Suggest to add bevy using cargo add

### DIFF
--- a/content/learn/book/getting-started/_index.md
+++ b/content/learn/book/getting-started/_index.md
@@ -41,13 +41,17 @@ Note: the "fast compiles" setup is on the next page, so you might want to read t
 
 Bevy is [available as a library on crates.io](https://crates.io/crates/bevy).
 
-Add the bevy crate to your project's Cargo.toml like this:
+The easiest way to add it to your project is to use `cargo add`:
+
+```cli
+$ cargo add bevy
+```
+
+Alternatively, you can manually add it to your project's Cargo.toml like this:
 
 ```toml
 [dependencies]
 bevy = "0.8" # make sure this is the latest version
 ```
 
-This is the current `bevy` crate version:
-
-<a href="https://crates.io/crates/bevy"><img src="https://img.shields.io/crates/v/bevy.svg" style="height: 1.7rem;"/></a>
+Make sure to use the latest `bevy` crate version ([![Crates.io](https://img.shields.io/crates/v/bevy.svg)](https://crates.io/crates/bevy)).

--- a/content/learn/book/getting-started/setup/_index.md
+++ b/content/learn/book/getting-started/setup/_index.md
@@ -69,9 +69,17 @@ edition = "2021"
 [dependencies]
 ```
 
-### Add Bevy to your project's Cargo.toml
+### Add Bevy as a dependency
 
-Bevy is [available as a library on crates.io](https://crates.io/crates/bevy), the official Rust package repository. Find the latest version number ([![Crates.io](https://img.shields.io/crates/v/bevy.svg)](https://crates.io/crates/bevy)) and add it to your Cargo.toml file:
+Bevy is [available as a library on crates.io](https://crates.io/crates/bevy), the official Rust package repository.
+
+The easiest way to add it to your project is to use `cargo add`:
+
+```cli
+$ cargo add bevy
+```
+
+Alternatively, you can manually add it to your project's Cargo.toml like this:
 
 ```toml
 [package]
@@ -82,6 +90,8 @@ edition = "2021" # this needs to be 2021, or you need to set "resolver=2"
 [dependencies]
 bevy = "0.8" # make sure this is the latest version
 ```
+
+Make sure to use the latest `bevy` crate version ([![Crates.io](https://img.shields.io/crates/v/bevy.svg)](https://crates.io/crates/bevy)).
 
 ### Cargo Workspaces
 


### PR DESCRIPTION
Closes #356.

With this PR, we will suggest to add bevy as dependency using `cargo add bevy`, which is the easiest option now.

I still left in instructions on how to manually add it in `Cargo.toml` (e.g. if someone is on an older Rust version that doesn't have `cargo add`), but we could also take that out.

:warning: In the original issue there were some concerns regarding typo squatting, so those should probably be discussed before merging this.