### PR TITLE
Prevent distortion of images in blog cards

### DIFF
--- a/sass/components/_card.scss
+++ b/sass/components/_card.scss
@@ -34,9 +34,17 @@
 .centered-card-image {
     display: block;
     align-self: center;
-    height: 85%;
-    max-width: 85%;
+    height: auto;
+    width: auto;
+    max-width: 100%;
+    max-height: 100%;
     border-radius: $border-radius;
+
+
+    @media #{$bp-tablet-landscape-up} {
+        max-height: 85%;
+        max-width: 85%;
+    }
 }
 
 .card-text {


### PR DESCRIPTION
Fixes #420.

On mobile devices, the images were previously distorted. This PR enforces that the images always keep their original aspect ratio.

TBH it looks a bit weird, but probably better than before:
![Preview of the changes. The images now preserve their aspect ratio, but only take up a low portion of the card height.](https://user-images.githubusercontent.com/13908946/182024796-b7361171-4014-4e68-8579-c9e5ab9a2936.png)
