### PR TITLE
[Merged by Bors] - Enable lazy loading for card images

### DIFF
--- a/templates/macros/assets.html
+++ b/templates/macros/assets.html
@@ -5,7 +5,7 @@
     <a href="{{ post.extra.link }}">
         {% if post.extra.image %}
         <div class="card-image card-image-default">
-            <img src="{{ image_macros::resize_image(path=post.extra.image, width=340, height=340) }}" />
+            <img src="{{ image_macros::resize_image(path=post.extra.image, width=340, height=340) }}" loading="lazy" />
         </div>
         {% endif %}
         <div class="card-text">

--- a/templates/news.html
+++ b/templates/news.html
@@ -8,11 +8,11 @@
     {% if page.extra.image %}
     {% set image_parent = page.path | replace(from="_index.md", to="") %}
     <div class="card-image">
-      <img src="{{ image_macros::resize_image(path=image_parent ~ page.extra.image, width=580, height=326) }}" class="centered-card-image" />
+      <img src="{{ image_macros::resize_image(path=image_parent ~ page.extra.image, width=580, height=326) }}"  class="centered-card-image" loading="lazy" />
     </div>
     {% else %}
     <div class="card-image">
-      <img src="/assets/bevy_logo_dark.svg" class="centered-card-image" style="max-width: 15rem;" />
+      <img src="/assets/bevy_logo_dark.svg" class="centered-card-image" style="max-width: 15rem;" loading="lazy" />
     </div>
     {% endif %}
     <div class="card-text">


### PR DESCRIPTION
This is a first step to improve the performance on the asset page (#361).

The card images are now lazily loaded, meaning that images are only loaded once they are in the viewport of the user.