### PR TITLE
[Merged by Bors] - Clarify description of API docs

### DIFF
--- a/content/learn/book/next-steps/_index.md
+++ b/content/learn/book/next-steps/_index.md
@@ -12,7 +12,7 @@ You have reached the end of The Bevy Book! And unfortunately, we haven't even sc
 * **[The Bevy Examples](https://github.com/bevyengine/bevy/tree/latest/examples#examples)**: We create an example for every major Bevy feature. This is currently the best way to learn Bevy's features and how to use them.
   * **[The Bevy Web Examples](https://bevyengine.org/examples)**: We also try to make most of these examples available directly in your browser.
 * **[Breakout](https://github.com/bevyengine/bevy/blob/latest/examples/games/breakout.rs)**: A small "breakout" clone that illustrates what a real Bevy game looks like.
-* **[Bevy API Docs](https://docs.rs/bevy)**: Bevy's Rust API documentation.
+* **[Bevy API Docs](https://docs.rs/bevy)**: Bevy's Rust API reference documentation which includes both auto-generated entries and hand-written explanations.
 * **[Bevy Assets](https://bevyengine.org/assets/)**: List of projects by the Bevy community, including:
   * **[Learning Resources](https://bevyengine.org/assets/#learning)**: Tutorials, documentation, and examples.
   * **[Plugins](https://bevyengine.org/assets/#assets)**: Extra functionality you can use in your projects.

--- a/content/learn/book/next-steps/_index.md
+++ b/content/learn/book/next-steps/_index.md
@@ -12,7 +12,7 @@ You have reached the end of The Bevy Book! And unfortunately, we haven't even sc
 * **[The Bevy Examples](https://github.com/bevyengine/bevy/tree/latest/examples#examples)**: We create an example for every major Bevy feature. This is currently the best way to learn Bevy's features and how to use them.
   * **[The Bevy Web Examples](https://bevyengine.org/examples)**: We also try to make most of these examples available directly in your browser.
 * **[Breakout](https://github.com/bevyengine/bevy/blob/latest/examples/games/breakout.rs)**: A small "breakout" clone that illustrates what a real Bevy game looks like.
-* **[Bevy API Docs](https://docs.rs/bevy)**: Bevy's Rust API reference documentation which includes both auto-generated entries and hand-written explanations.
+* **[Bevy API Docs](https://docs.rs/bevy)**: Documentation and examples for each type, trait and method in Bevy.
 * **[Bevy Assets](https://bevyengine.org/assets/)**: List of projects by the Bevy community, including:
   * **[Learning Resources](https://bevyengine.org/assets/#learning)**: Tutorials, documentation, and examples.
   * **[Plugins](https://bevyengine.org/assets/#assets)**: Extra functionality you can use in your projects.

--- a/content/learn/book/next-steps/_index.md
+++ b/content/learn/book/next-steps/_index.md
@@ -12,7 +12,7 @@ You have reached the end of The Bevy Book! And unfortunately, we haven't even sc
 * **[The Bevy Examples](https://github.com/bevyengine/bevy/tree/latest/examples#examples)**: We create an example for every major Bevy feature. This is currently the best way to learn Bevy's features and how to use them.
   * **[The Bevy Web Examples](https://bevyengine.org/examples)**: We also try to make most of these examples available directly in your browser.
 * **[Breakout](https://github.com/bevyengine/bevy/blob/latest/examples/games/breakout.rs)**: A small "breakout" clone that illustrates what a real Bevy game looks like.
-* **[Bevy API Docs](https://docs.rs/bevy)**: Documentation and examples for each type, trait and method in Bevy.
+* **[Bevy API Docs](https://docs.rs/bevy)**: Documentation with examples for types, traits, methods and other items in Bevy's API.
 * **[Bevy Assets](https://bevyengine.org/assets/)**: List of projects by the Bevy community, including:
   * **[Learning Resources](https://bevyengine.org/assets/#learning)**: Tutorials, documentation, and examples.
   * **[Plugins](https://bevyengine.org/assets/#assets)**: Extra functionality you can use in your projects.

--- a/templates/learn.html
+++ b/templates/learn.html
@@ -24,7 +24,7 @@
         Bevy Rust API Docs
       </div>
       <div class="card-description">
-        Learn Bevy's Rust API in-depth using the reference documentation. Includes both auto-generated entries and hand-written explanations.
+Learn how to use Bevy's types, traits and methods using the in-depth reference documentation, complete with inline examples.
       </div>
     </div>
   </a>

--- a/templates/learn.html
+++ b/templates/learn.html
@@ -24,7 +24,7 @@
         Bevy Rust API Docs
       </div>
       <div class="card-description">
-        Learn about Bevy's Rust API using the generated Rust documentation.
+        Learn Bevy's Rust API in-depth using the reference documentation. Includes both auto-generated entries and hand-written explanations.
       </div>
     </div>
   </a>

--- a/templates/learn.html
+++ b/templates/learn.html
@@ -24,7 +24,7 @@
         Bevy Rust API Docs
       </div>
       <div class="card-description">
-Learn how to use Bevy's types, traits and methods using the in-depth reference documentation, complete with inline examples.
+        Learn how to use Bevy's types, traits and methods using the in-depth reference documentation, complete with inline examples.
       </div>
     </div>
   </a>


### PR DESCRIPTION
The way the docs are described on the website may make people think that there are only autogenerated entries in the docs without much useful information for a learner, especially the word "generated" makes such impression. This PR fixes that.