### PR TITLE
[Merged by Bors] - add "before migrating" section to migration guide

### DIFF
--- a/content/learn/book/migration-guides/0.7-0.8/_index.md
+++ b/content/learn/book/migration-guides/0.7-0.8/_index.md
@@ -9,6 +9,11 @@ insert_anchor_links = "right"
 long_title = "Migration Guide: 0.7 to 0.8"
 +++
 
+Before migrating make sure to run `rustup update`
+
+Bevy relies heavily on improvements in the Rust language and compiler.
+As a result, the Minimum Supported Rust Version (MSRV) is "the latest stable release" of Rust.
+
 <!-- Github filter used to find the relevant PRs "is:pr label:C-Breaking-Change closed:>2022-04-15 [Merged by Bors]" -->
 
 ### [Camera Driven Rendering](https://github.com/bevyengine/bevy/pull/4745)
@@ -545,7 +550,6 @@ bevy = { version = "0.8", default-features = false, features = [
 
 `Text::with_section` was renamed to `Text::from_section` and no longer takes a `TextAlignment` as argument.
 Use `with_alignment` to set the alignment instead.
-
 
 ### [Add QueryState::get_single_unchecked_manual and its family](https://github.com/bevyengine/bevy/pull/4841)
 


### PR DESCRIPTION
## Objective

It's not uncommon for people to forget to update their rust versions. 

## Solution

Add a short warning to remind people to run `rustup update` and a short description as to why

![image](https://user-images.githubusercontent.com/8348954/182221263-3f079b08-22e6-40c9-9d09-9296b75d4490.png)

## Notes

For now this is only on the latest migration guide, but I already have plans to make migration guide a dedicated section on the website and use a template that could include this warning on every page.