### PR TITLE
[Merged by Bors] - automatically resize examples to canvas parent

### DIFF
--- a/generate-wasm-examples/generate_wasm_examples.sh
+++ b/generate-wasm-examples/generate_wasm_examples.sh
@@ -10,6 +10,7 @@ find assets -type f -name '*.md' -exec rm {} +
 
 # setting a canvas by default to help with integration
 sed -i.bak 's/canvas: None,/canvas: Some("#bevy".to_string()),/' crates/bevy_window/src/window.rs
+sed -i.bak 's/fit_canvas_to_parent: false,/fit_canvas_to_parent: true,/' crates/bevy_window/src/window.rs
 
 # setting the asset folder root to the root url of this domain
 sed -i.bak 's/asset_folder: "assets"/asset_folder: "\/assets\/examples\/"/' crates/bevy_asset/src/lib.rs

--- a/sass/components/_bevy-instance.scss
+++ b/sass/components/_bevy-instance.scss
@@ -61,6 +61,7 @@
     }
 
     &__canvas {
+        width: 100% !important;
         height: auto !important;
         border-radius: $border-radius;
         background: #2b2c2f;

--- a/sass/components/_bevy-instance.scss
+++ b/sass/components/_bevy-instance.scss
@@ -61,7 +61,6 @@
     }
 
     &__canvas {
-        width: 100% !important;
         height: auto !important;
         border-radius: $border-radius;
         background: #2b2c2f;


### PR DESCRIPTION
## Objective

Fixes https://github.com/bevyengine/bevy/issues/4963
Issue is not in Bevy but on CSS of the page to resize the canvas

## Solution

Use the new option from Bevy 0.8 to resize canvas to parent