### PR TITLE
[Merged by Bors] - Typo in getting-started/resources

### DIFF
--- a/content/learn/book/getting-started/resources/_index.md
+++ b/content/learn/book/getting-started/resources/_index.md
@@ -32,7 +32,7 @@ fn greet_people(time: Res<Time>, query: Query<&Name, With<Person>>) {
 
 `Res` and `ResMut` pointers provide read and write access (respectively) to resources.
 
-The `delta_seconds` field on `Time` gives us the time that has passed since the last update. But in order to run our system once every two seconds, we must track the amount of time that has passed over a series of updates. To make this easier, Bevy provides the `Timer` type. Let's create a new Resource for our system to track elapsed time with a `Timer`:
+The `delta` field on `Time` gives us the time that has passed since the last update. But in order to run our system once every two seconds, we must track the amount of time that has passed over a series of updates. To make this easier, Bevy provides the `Timer` type. Let's create a new Resource for our system to track elapsed time with a `Timer`:
 
 ```rs
 struct GreetTimer(Timer);


### PR DESCRIPTION
`delta` is correct because it's in the snippet below and I've checked that it works.