### PR TITLE
[Merged by Bors] - Add Mold to "recommended linker" section

### DIFF
--- a/content/learn/book/getting-started/setup/_index.md
+++ b/content/learn/book/getting-started/setup/_index.md
@@ -146,6 +146,18 @@ Bevy can be built just fine using default configuration on stable Rust. However 
         rustup component add llvm-tools-preview
         ```
     * **MacOS**: Modern LLD does not yet support MacOS, but we can use zld instead: `brew install michaeleisel/zld/zld`
+* **Alternative - Mold linker**: Mold is _up to five times faster_ than LLD, but with a few caveats like limited platform support and occasional stability issues. To install mold, find your OS below and run the given command:
+    * **Ubuntu**: `sudo apt-get install mold`
+    * **Arch**: `sudo pacman -S mold`
+    * **Windows**: Mold does not yet support Windows. [See this tracking issue](https://github.com/rui314/mold/issues/190) for more information.
+    * **MacOS**: Mold does not yet support MacOS. [See this tracking issue](https://github.com/rui314/mold/issues/189) for more information.
+
+    You will also need to add the following to your Cargo config at `YOUR_WORKSPACE/.cargo/config.toml`:
+    ```toml
+    [target.x86_64-unknown-linux-gnu]
+    linker = "clang"
+    rustflags = ["-C", "link-arg=-fuse-ld=/usr/bin/mold"]
+    ```
 * **Nightly Rust Compiler**: This gives access to the latest performance improvements and "unstable" optimizations
     
     Create a ```rust-toolchain.toml``` file in the root of your project, next to ```Cargo.toml```.

--- a/content/learn/book/getting-started/setup/_index.md
+++ b/content/learn/book/getting-started/setup/_index.md
@@ -146,7 +146,7 @@ Bevy can be built just fine using default configuration on stable Rust. However 
         rustup component add llvm-tools-preview
         ```
     * **MacOS**: Modern LLD does not yet support MacOS, but we can use zld instead: `brew install michaeleisel/zld/zld`
-* **Alternative - Mold linker**: Mold is _up to five times faster_ than LLD, but with a few caveats like limited platform support and occasional stability issues. To install mold, find your OS below and run the given command:
+* **Alternative - Mold linker**: Mold is _up to five times faster_ than LLD, but with a few caveats like limited platform support and occasional stability issues.  To install mold, find your OS below and run the given command:
     * **Ubuntu**: `sudo apt-get install mold`
     * **Arch**: `sudo pacman -S mold`
     * **Windows**: Mold does not yet support Windows. [See this tracking issue](https://github.com/rui314/mold/issues/190) for more information.
@@ -158,6 +158,8 @@ Bevy can be built just fine using default configuration on stable Rust. However 
     linker = "clang"
     rustflags = ["-C", "link-arg=-fuse-ld=/usr/bin/mold"]
     ```
+
+    NOTE: Disabling `bevy/dynamic` may improve the performance of this linker.
 * **Nightly Rust Compiler**: This gives access to the latest performance improvements and "unstable" optimizations
     
     Create a ```rust-toolchain.toml``` file in the root of your project, next to ```Cargo.toml```.


### PR DESCRIPTION
> mold is a faster drop-in replacement for existing Unix linkers. It is several times faster than the LLVM lld linker, the second-fastest open-source linker which I originally created a few years ago. mold is designed to increase developer productivity by reducing build time, especially in rapid debug-edit-rebuild cycles.

| Program (linker output size)  | GNU gold | LLVM lld | mold
|-------------------------------|----------|----------|--------
| Chrome 96 (1.89 GiB)          | 53.86s   | 11.74s   | 2.21s
| Clang 13 (3.18 GiB)           | 64.12s   | 5.82s    | 2.90s
| Firefox 89 libxul (1.64 GiB)  | 32.95s   | 6.80s    | 1.42s

Mold is exclusive to Linux, with support for Windows and MacOS in progress.

---

This PR adds mold to the recommended linkers in [the setup page](https://bevyengine.org/learn/book/getting-started/setup/).

Note that this addition is somewhat clunky, and this section may need to be reworked entirely. See #329 for further discussion.