### PR TITLE
[Merged by Bors] - Fix broken assets page

### DIFF
--- a/generate-assets/src/bin/generate.rs
+++ b/generate-assets/src/bin/generate.rs
@@ -79,7 +79,7 @@ impl FrontMatterWriter for Asset {
                 .replace('/', "-")
                 .replace(' ', "_")
                 .replace(
-                    |c: char| !c.is_ascii_alphanumeric() || !matches!(c, '-' | '_'),
+                    |c: char| !c.is_ascii_alphanumeric() && !matches!(c, '-' | '_'),
                     ""
                 )
         ));


### PR DESCRIPTION
Fixes #444

It's not completely clear to me exactly what was intended with this change in #401, but this logic seems obviously reversed (it just completely erased the path).

This fixes the assets page locally for me.

edit: I see the note in 401 now about the paths needing to be filtered to make some part of the the CI / zipping work. Not entirely sure how to test that.