### PR TITLE
[Merged by Bors] - Improved error handling in asset validator

### DIFF
--- a/generate-assets/src/bin/validate.rs
+++ b/generate-assets/src/bin/validate.rs
@@ -62,8 +62,7 @@ impl AssetValidator for Section {
     fn validate(&self) -> Vec<Result<(), AssetError>> {
         self.content
             .iter()
-            .map(|content| content.validate())
-            .flatten()
+            .flat_map(|content| content.validate())
             .collect()
     }
 }

--- a/generate-assets/src/bin/validate.rs
+++ b/generate-assets/src/bin/validate.rs
@@ -3,6 +3,8 @@ use regex::Regex;
 
 use generate_assets::*;
 
+const MAX_DESCRIPTION_LENGTH: usize = 100;
+
 fn main() -> Result<()> {
     let asset_dir = std::env::args()
         .nth(1)
@@ -60,7 +62,7 @@ impl AssetValidator for Asset {
     fn validate(&self) -> Vec<AssetError> {
         let mut errors = vec![];
 
-        if self.description.len() > 100 {
+        if self.description.len() > MAX_DESCRIPTION_LENGTH {
             errors.push(AssetError::DescriptionTooLong(self.name.clone()));
         }
 

--- a/generate-assets/src/bin/validate.rs
+++ b/generate-assets/src/bin/validate.rs
@@ -8,7 +8,7 @@ const MAX_DESCRIPTION_LENGTH: usize = 100;
 fn main() -> Result<()> {
     let asset_dir = std::env::args()
         .nth(1)
-        .ok_or_else(|| anyhow!("Specify asset dir"))?;
+        .ok_or_else(|| anyhow!("Please specify the path to bevy-assets"))?;
 
     let asset_root_section =
         parse_assets(&asset_dir, None, None, None).with_context(|| "Parsing assets")?;

--- a/generate-assets/src/bin/validate.rs
+++ b/generate-assets/src/bin/validate.rs
@@ -23,6 +23,7 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
+    eprintln!();
     for error in &errors {
         eprintln!("{}", error);
     }
@@ -39,7 +40,7 @@ impl Display for AssetError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "{}", self.asset_name)?;
         for error in &self.errors {
-            write!(f, "  {:?}", error)?;
+            writeln!(f, "  {:?}", error)?;
         }
         Ok(())
     }

--- a/generate-assets/src/lib.rs
+++ b/generate-assets/src/lib.rs
@@ -138,7 +138,7 @@ fn visit_dirs(
                     continue;
                 }
 
-                let mut asset: Asset = toml::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+                let mut asset: Asset = toml::from_str(&fs::read_to_string(&path).unwrap())?;
                 asset.original_path = Some(path);
 
                 if let Err(err) =

--- a/generate-assets/src/lib.rs
+++ b/generate-assets/src/lib.rs
@@ -88,71 +88,73 @@ fn visit_dirs(
     github_client: Option<&GithubClient>,
     gitlab_client: Option<&GitlabClient>,
 ) -> anyhow::Result<()> {
-    if dir.is_dir() {
-        for entry in fs::read_dir(dir)? {
-            let entry = entry?;
-            let path = entry.path();
-            if path.file_name().unwrap() == ".git" || path.file_name().unwrap() == ".github" {
+    if dir.is_file() {
+        return Ok(());
+    }
+
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.file_name().unwrap() == ".git" || path.file_name().unwrap() == ".github" {
+            continue;
+        }
+        if path.is_dir() {
+            let folder = path.file_name().unwrap();
+            let (order, sort_order_reversed) = if path.join("_category.toml").exists() {
+                let from_file: toml::Value =
+                    toml::de::from_str(&fs::read_to_string(path.join("_category.toml")).unwrap())
+                        .unwrap();
+                (
+                    from_file
+                        .get("order")
+                        .and_then(|v| v.as_integer())
+                        .map(|v| v as usize),
+                    from_file
+                        .get("sort_order_reversed")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false),
+                )
+            } else {
+                (None, false)
+            };
+            let mut new_section = Section {
+                name: folder.to_str().unwrap().to_string(),
+                content: vec![],
+                template: None,
+                header: None,
+                order,
+                sort_order_reversed,
+            };
+            visit_dirs(
+                path.clone(),
+                &mut new_section,
+                crates_io_db,
+                github_client,
+                gitlab_client,
+            )?;
+            section.content.push(AssetNode::Section(new_section));
+        } else {
+            if path.file_name().unwrap() == "_category.toml"
+                || path.extension().expect("file must have an extension") != "toml"
+            {
                 continue;
             }
-            if path.is_dir() {
-                let folder = path.file_name().unwrap();
-                let (order, sort_order_reversed) = if path.join("_category.toml").exists() {
-                    let from_file: toml::Value = toml::de::from_str(
-                        &fs::read_to_string(path.join("_category.toml")).unwrap(),
-                    )
-                    .unwrap();
-                    (
-                        from_file
-                            .get("order")
-                            .and_then(|v| v.as_integer())
-                            .map(|v| v as usize),
-                        from_file
-                            .get("sort_order_reversed")
-                            .and_then(|v| v.as_bool())
-                            .unwrap_or(false),
-                    )
-                } else {
-                    (None, false)
-                };
-                let mut new_section = Section {
-                    name: folder.to_str().unwrap().to_string(),
-                    content: vec![],
-                    template: None,
-                    header: None,
-                    order,
-                    sort_order_reversed,
-                };
-                visit_dirs(
-                    path.clone(),
-                    &mut new_section,
-                    crates_io_db,
-                    github_client,
-                    gitlab_client,
-                )?;
-                section.content.push(AssetNode::Section(new_section));
-            } else {
-                if path.file_name().unwrap() == "_category.toml"
-                    || path.extension().expect("file must have an extension") != "toml"
-                {
-                    continue;
-                }
 
-                let mut asset: Asset = toml::from_str(&fs::read_to_string(&path).unwrap())?;
-                asset.original_path = Some(path);
+            let mut asset: Asset = toml::from_str(&fs::read_to_string(&path).unwrap())?;
+            asset.original_path = Some(path);
 
-                if let Err(err) =
-                    get_extra_metadata(&mut asset, crates_io_db, github_client, gitlab_client)
-                {
-                    // We don't want to stop execution here
-                    eprintln!("Failed to get metadata for {}", asset.name);
-                    eprintln!("ERROR: {err:?}");
-                }
-
-                section.content.push(AssetNode::Asset(asset));
+            if let Err(err) =
+                get_extra_metadata(&mut asset, crates_io_db, github_client, gitlab_client)
+            {
+                // We don't want to stop execution here
+                eprintln!("Failed to get metadata for {}", asset.name);
+                eprintln!("ERROR: {err:?}");
             }
+
+            section.content.push(AssetNode::Asset(asset));
         }
     }
+
     Ok(())
 }
 


### PR DESCRIPTION
Some minor improvements to this tool both for contributors who may be working with it and for end-users making PRs to `bevy-assets`

- Show a friendlier error when failing to specify the `bevy-assets` path as a cli argument
- Show an error if the user specifies the `bevy-assets` path incorrectly
- Show errors that occur during `parse_assets`
- Check that images exist
- Group errors by asset

I felt a bit awkward working around the `AssetValidator` trait, and I'm not super strong with rust error handling / `anyhow` so any feedback would be appreciated.

Now outputs something like

```
(a bunch of metadata spam)

UnFlock
  DescriptionWithFormatting

taipo
  DescriptionTooLong
  ImageInvalidLink

Error: 2 asset(s) are invalid.
```

The change to `lib.rs` is much smaller than it looks. It consists of:
- removing a level of indentation by exiting early
- allowing `fs::read_dir` to potentially fail rather than hiding it behind `is_dir`
- removing the unwrap from `toml::from_str` in favor of `?`