### PR TITLE
[Merged by Bors] - Fix sorting of errors section

### DIFF
--- a/generate-errors/src/lib.rs
+++ b/generate-errors/src/lib.rs
@@ -74,6 +74,8 @@ fn visit_dirs(dir: PathBuf, section: &mut Section) -> io::Result<()> {
         }
     }
 
+    section.content.sort_by(|a, b| a.code.cmp(&b.code));
+
     Ok(())
 }
 


### PR DESCRIPTION
Fixes #451 

Added a `.sort` so we're not relying on the file system's ordering.

I could not reproduce the error locally, but I tested with some debug logging in the [action on my fork ](https://github.com/rparrett/bevy-website/runs/8079655275?check_suite_focus=true)and confirmed that this was the issue and that this should fix it.
