### PR TITLE
[Merged by Bors] - Update MacOS requirements

### DIFF
--- a/content/learn/book/getting-started/setup/_index.md
+++ b/content/learn/book/getting-started/setup/_index.md
@@ -22,7 +22,7 @@ Once this is done, you should have the ```rustc``` compiler and the ```cargo``` 
 ### Install OS dependencies
 * [Linux](https://github.com/bevyengine/bevy/blob/main/docs/linux_dependencies.md)
 * Windows: Make sure to install [VS2019 build tools](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=16)
-* MacOS: No dependencies here
+* MacOS: xcode-select --install or [Xcode](https://apps.apple.com/de/app/xcode/id497799835?mt=12)
 
 ### Code Editor / IDE
 

--- a/content/learn/book/getting-started/setup/_index.md
+++ b/content/learn/book/getting-started/setup/_index.md
@@ -22,7 +22,7 @@ Once this is done, you should have the ```rustc``` compiler and the ```cargo``` 
 ### Install OS dependencies
 * [Linux](https://github.com/bevyengine/bevy/blob/main/docs/linux_dependencies.md)
 * Windows: Make sure to install [VS2019 build tools](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=16)
-* MacOS: xcode-select --install or [Xcode](https://apps.apple.com/de/app/xcode/id497799835?mt=12)
+* MacOS: Install the Xcode command line tools with `xcode-select --install` or the [Xcode app](https://apps.apple.com/en/app/xcode/id497799835)
 
 ### Code Editor / IDE
 


### PR DESCRIPTION
To run rust on MacOS you require Xcode or it will give the Following error: 
xcrun: error: invalid active developer path