### PR TITLE
[Merged by Bors] - Fix incorrect example in migration guide

### DIFF
--- a/content/learn/book/migration-guides/0.7-0.8/_index.md
+++ b/content/learn/book/migration-guides/0.7-0.8/_index.md
@@ -46,7 +46,7 @@ commands.spawn_bundle(OrthographicCameraBundle::new_3d())
 commands.spawn_bundle(Camera3dBundle {
     projection: OrthographicProjection {
         scale: 3.0,
-        scaling_mode: ScalingMode::FixedVertical,
+        scaling_mode: ScalingMode::FixedVertical(5.0),
         ..default()
     }.into(),
     ..default()


### PR DESCRIPTION
`ScalingMode::FixedVertical` is an enum variant that takes an f32, but it's used without a parameter in the migration guide.