### PR TITLE
[Merged by Bors] - Fix animated webp files crashing site generation

### DIFF
--- a/templates/macros/images.html
+++ b/templates/macros/images.html
@@ -1,5 +1,5 @@
 {% macro resize_image(path, width, height) -%}
-    {%- if path is ending_with(".svg") or path is ending_with(".gif") -%}
+    {%- if path is ending_with(".svg") or path is ending_with(".gif") or path is ending_with(".webp") -%}
         {{- get_url(path=path) -}}
     {%- else -%}
         {%- set image = resize_image(path=path, width=width, height=height, op="fit") -%}


### PR DESCRIPTION
Zola's `resize_image` actually panics when trying to resize animated webp files.

So we guard against trying to resize those, especially given that animated webps are not supported by zola's resize_image (only static images)