### PR TITLE
add font-swap

### DIFF
--- a/sass/fonts/_firamono.scss
+++ b/sass/fonts/_firamono.scss
@@ -3,6 +3,7 @@
      font-family: 'Fira Mono';
      font-style: normal;
      font-weight: 400;
+     font-display: swap;
      src: url('../fonts/fira-mono-v8-latin-regular.eot'); /* IE9 Compat Modes */
      src: local('Fira Mono Regular'), local('FiraMono-Regular'),
           url('../fonts/fira-mono-v8-latin-regular.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */

--- a/sass/fonts/_firasans.scss
+++ b/sass/fonts/_firasans.scss
@@ -3,6 +3,7 @@
     font-family: 'Fira Sans';
     font-style: normal;
     font-weight: 300;
+    font-display: swap;
     src: url('/assets/fonts/fira-sans-v10-latin-300.eot'); /* IE9 Compat Modes */
     src: local('Fira Sans Light'), local('FiraSans-Light'),
          url('/assets/fonts/fira-sans-v10-latin-300.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
@@ -17,6 +18,7 @@
     font-family: 'Fira Sans';
     font-style: normal;
     font-weight: 400;
+    font-display: swap;
     src: url('/assets/fonts/fira-sans-v10-latin-regular.eot'); /* IE9 Compat Modes */
     src: local('Fira Sans Regular'), local('FiraSans-Regular'),
          url('/assets/fonts/fira-sans-v10-latin-regular.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
@@ -31,6 +33,7 @@
     font-family: 'Fira Sans';
     font-style: italic;
     font-weight: 400;
+    font-display: swap;
     src: url('/assets/fonts/fira-sans-v10-latin-italic.eot'); /* IE9 Compat Modes */
     src: local('Fira Sans Italic'), local('FiraSans-Italic'),
          url('/assets/fonts/fira-sans-v10-latin-italic.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
@@ -45,6 +48,7 @@
     font-family: 'Fira Sans';
     font-style: normal;
     font-weight: 500;
+    font-display: swap;
     src: url('/assets/fonts/fira-sans-v10-latin-500.eot'); /* IE9 Compat Modes */
     src: local('Fira Sans Medium'), local('FiraSans-Medium'),
          url('/assets/fonts/fira-sans-v10-latin-500.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
@@ -59,6 +63,7 @@
     font-family: 'Fira Sans';
     font-style: normal;
     font-weight: 800;
+    font-display: swap;
     src: url('/assets/fonts/fira-sans-v10-latin-800.eot'); /* IE9 Compat Modes */
     src: local('Fira Sans ExtraBold'), local('FiraSans-ExtraBold'),
          url('/assets/fonts/fira-sans-v10-latin-800.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */


### PR DESCRIPTION
This PR might improve render performance of the website a little (even though it's already super fast). 
`font-display: swap;` will display the fallback font until the requested font is loaded and swap them. So the browser wont block rendering the text.