### PR TITLE
[Merged by Bors] - Fix unstyled links in intro paragraphs for assets and examples

### DIFF
--- a/sass/pages/_assets.scss
+++ b/sass/pages/_assets.scss
@@ -1,6 +1,5 @@
 .assets {
     .assets-intro {
-        font-size: 1.2rem;
         margin-bottom: 20px;
     }
 

--- a/templates/assets.html
+++ b/templates/assets.html
@@ -15,7 +15,7 @@
     <div class="assets">
         {{ assets_macros::init_svg() }}
 
-        <div class="assets-intro">
+        <div class="assets-intro media-content">
             A collection of third-party Bevy assets, plugins, learning resources, and apps made by the community. If you would like to
             share what you're working on, <a href="https://github.com/bevyengine/bevy-assets">submit a pull request</a>!
         </div>

--- a/templates/examples.html
+++ b/templates/examples.html
@@ -13,7 +13,7 @@
 
 {% block page_content %}
 <div class="assets">
-    <div class="assets-intro">
+    <div class="assets-intro media-content">
         These examples demonstrate how to use Bevy's features in a minimal, easy to understand way. Click an example below to run it in
         your browser (using WASM + WebGL) and view the source code. You can also view these examples (and others) in the
         <a href="https://github.com/bevyengine/bevy/tree/latest/examples#examples">Bevy repo</a>.


### PR DESCRIPTION
## Objective

Closes #449 

## Solution

Add `.media-content` to the intro paragraphs.

## Before / After

<img width="531" alt="image" src="https://user-images.githubusercontent.com/200550/197818966-9a983324-d305-4493-9c06-d958194f7119.png">
