### PR TITLE
[Merged by Bors] - Add FAQ redirect

### DIFF
--- a/content/faq/index.md
+++ b/content/faq/index.md
@@ -1,0 +1,4 @@
++++
+title = "FAQ"
+template = "faq.html"
++++

--- a/templates/faq.html
+++ b/templates/faq.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <style>
+            body {
+                background-color: #232326;
+            }
+        </style>
+        <meta http-equiv="refresh" content="0; URL='https://github.com/bevyengine/bevy/discussions?discussions_q=label%3AFAQ+sort%3Atop
+        '" />
+    </head>
+</html>

--- a/templates/learn.html
+++ b/templates/learn.html
@@ -68,5 +68,18 @@
       </div>
     </div>
   </a>
+  <a class="card" href="/faq">
+    <div class="card-image">
+      <img src="/assets/bevy_icon_dark.svg" class="centered-card-image" alt="Bevy logo" />
+    </div>
+    <div class="card-text">
+      <div class="card-title">
+        Frequently Asked Questions
+      </div>
+      <div class="card-description">
+        A curated list of answers to questions Bevy users frequently ask.
+      </div>
+    </div>
+  </a>
 </div>
 {% endblock content %}


### PR DESCRIPTION
This adds a redirect to a curated FAQ list, backed by our Github Discussions:
https://github.com/bevyengine/bevy/discussions?discussions_q=label%3AFAQ+sort%3Atop

Includes a small inline style to remove a distracting "pure white" color transition when clicking the FAQ link from the website. 