### PR TITLE
Encourage updating Rust

### DIFF
--- a/content/learn/book/getting-started/setup/_index.md
+++ b/content/learn/book/getting-started/setup/_index.md
@@ -15,8 +15,10 @@ All Bevy app and engine code is written in Rust. This means that before we begin
 
 ### Installing Rust
 
-Bevy relies heavily on improvements in the Rust language and compiler.
+Bevy relies heavily on improvements in the Rust language and compiler, and often releases shortly after the compiler.
 As a result, the Minimum Supported Rust Version (MSRV) is "the latest stable release" of Rust.
+
+Note that [Rust stable releases](https://github.com/rust-lang/rust/blob/master/RELEASES.md) happen almost every month! If you already have Rust installed, unless you updated Rust in the last couple of weeks, **you probably need to update Rust**.
 
 Install Rust by following the [Rust Getting Started Guide](https://www.rust-lang.org/learn/get-started).
 


### PR DESCRIPTION
This should help stop people from making mistakes like https://github.com/bevyengine/bevy/issues/6777.

Novice Rust programmers might see "latest stable release" and think that that means "what I installed last month when I started learning Rust". However, that's not likely to be the case.

Rust makes stable releases often enough that anyone who doesn't update it every couple weeks or so actually needs to update Rust in order to use Bevy.

This should make that clearer.