### PR TITLE
[Merged by Bors] - Add aditional description to access assets tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ To check out any local changes you've made:
 
 A local server should start and you should be able to access a local version of the website from there.
 
-## Assets Page
+### Assets Page
 
-To access Assets Page with successfully, it's necessary to go into the repository in **.\generate-assets** and run the command in terminal: <br>
-``generate_assets.sh``<br>
-If you are on Windows, maybe this cannot work, so It`s suggest recommending to use WSL or Git Bash.<br>
+1. To build the Assets page, it's necessary to go into the **.\generate-assets** folder and run the command:
+   1. `generate_assets.sh`
+2. If you are on Windows, it`s recommended to use WSL or Git Bash.
 
 ## Assets generation
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ To check out any local changes you've made:
 
 A local server should start and you should be able to access a local version of the website from there.
 
+* Note: If you try to access tab assets, and recover 404 Not Found, it's necessary to into the repository .\generate-assets and run the command in terminal: <br>
+``generate_assets.sh``<br>
+* If you are on Windows, maybe this cannot work, so in the file have commands for run in your terminal:<br>
+``git clone --depth=1 https://github.com/bevyengine/bevy-assets assets``<br>
+``cargo run --release --bin generate -- assets ../content``
+
 ## Assets generation
 
 Assets are generated using data from /generate/assets and crates.io using their [datadump](https://crates.io/data-access) trough [cratesio-dbdump-lookup](https://github.com/alyti/cratesio-dbdump-lookup).

--- a/README.md
+++ b/README.md
@@ -20,7 +20,3 @@ A local server should start and you should be able to access a local version of 
 
 These pages need to be generated in a separate step by running the shell scripts in the `generate-assets`, `generate-errors`, and `generate-wasm-examples` directories. On Windows, you can use [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) or [git bash](https://gitforwindows.org/).
 
-Assets are generated from a [crates.io data dump](https://crates.io/data-access) through [cratesio-dbdump-lookup](https://github.com/alyti/cratesio-dbdump-lookup).
-
-Please note that when unpacked, the crates.io dump fills about 500 mb.
-Please notice when unpacked, the crates.io dump fills about 500 mb.

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ To check out any local changes you've made:
 
 A local server should start and you should be able to access a local version of the website from there.
 
-* Note: If you try to access tab assets, and recover 404 Not Found, it's necessary to into the repository .\generate-assets and run the command in terminal: <br>
+## Assets Page
+
+To access Assets Page with successfully, it's necessary to go into the repository in **.\generate-assets** and run the command in terminal: <br>
 ``generate_assets.sh``<br>
-* If you are on Windows, maybe this cannot work, so in the file have commands for run in your terminal:<br>
-``git clone --depth=1 https://github.com/bevyengine/bevy-assets assets``<br>
-``cargo run --release --bin generate -- assets ../content``
+If you are on Windows, maybe this cannot work, so It`s suggest recommending to use WSL or Git Bash.<br>
 
 ## Assets generation
 

--- a/README.md
+++ b/README.md
@@ -16,13 +16,11 @@ To check out any local changes you've made:
 
 A local server should start and you should be able to access a local version of the website from there.
 
-### Assets Page
+### Assets, Errors, and Examples pages
 
-1. To build the Assets page, it's necessary to go into the **.\generate-assets** folder and run the command:
-   1. `generate_assets.sh`
-2. If you are on Windows, it`s recommended to use WSL or Git Bash.
+These pages need to be generated in a separate step by running the shell scripts in the `generate-assets`, `generate-errors`, and `generate-wasm-examples` directories. On Windows, you can use [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) or [git bash](https://gitforwindows.org/).
 
-## Assets generation
+Assets are generated from a [crates.io data dump](https://crates.io/data-access) through [cratesio-dbdump-lookup](https://github.com/alyti/cratesio-dbdump-lookup).
 
-Assets are generated using data from /generate/assets and crates.io using their [datadump](https://crates.io/data-access) trough [cratesio-dbdump-lookup](https://github.com/alyti/cratesio-dbdump-lookup).
+Please note that when unpacked, the crates.io dump fills about 500 mb.
 Please notice when unpacked, the crates.io dump fills about 500 mb.


### PR DESCRIPTION
It isn't clear to run bevy website to new contributors, especificy the assets tab. When new users uses the ``zola serve``, aparently everything is ok, but the assets tab doesn't work. With this description is more clear what need to do.

Fixes #423 

Co-authored-by: Erick <erickmelovidal@gmail.com>