### PR TITLE
Fix window position on anchors navigation

### DIFF
--- a/templates/layouts/base.html
+++ b/templates/layouts/base.html
@@ -110,4 +110,13 @@
             </main>
         </div>
     </body>
+    <script>
+        // Moves window position when navigating to anchors to prevent content cut
+        if (location.hash) {
+            scrollBy(0, -70)
+        };
+        window.onhashchange = () => { 
+            scrollBy(0, -70) 
+        };
+    </script>
 </html>


### PR DESCRIPTION
When navigating to anchors, the content of the page often gets cut off. With this modification any anchors in pages that renders from `base.html` will have the window position adjusted to it's corrected position.

Fixes #488 

Co-Authored-By: Victor Lima <limavictor49@gmail.com>