### PR TITLE
Fix errors page anchors offset so error headings are visible

### DIFF
--- a/templates/errors.html
+++ b/templates/errors.html
@@ -8,7 +8,8 @@
             <a href="https://github.com/bevyengine/bevy/tree/main/errors">repository</a>.</p>
         </div>
         {% for page in section.pages %}
-            <h1 id="{{ page.title | slugify }}" class="asset-section">
+            <a class="anchor-target" id="{{ page.title | slugify }}"></a>
+            <h1 class="asset-section">
                 {{ page.title }}<a class="anchor-link" href="#{{ page.title | slugify }}">#</a>
             </h1>
             <div class="media-content">{{ page.content | safe }}</div>


### PR DESCRIPTION
Fixes the scroll position for the error links. Right now the error headings end up under the header (first screenshot). With this fix now it scrolls to the correct position. This uses the same solution as in [`assets.html`](https://github.com/bevyengine/bevy-website/blob/master/templates/assets.html#L26).

**Before**
![image](https://user-images.githubusercontent.com/188612/208856766-3a0761e2-97a6-464a-8980-162cb0912151.png)

**After**
![image](https://user-images.githubusercontent.com/188612/208856877-c50e955a-7af3-4353-b8dc-822cc76b049b.png)
