### PR TITLE
[Merged by Bors] - Fix header text being cut off when navigating to anchors

### DIFF
--- a/sass/_utils.scss
+++ b/sass/_utils.scss
@@ -26,15 +26,6 @@
     color: #c8c864;
 }
 
-// Anchor target that applies an offset to compesate for the header height
-// Thanks: https://stackoverflow.com/a/13184714/379923
-.anchor-target {
-    display: block;
-    position: relative;
-    top: calc(0px - var(--header-height) - 8px);
-    visibility: hidden;
-}
-
 .anchor-link, .anchor-link:focus, .anchor-link:hover, .anchor-link:active, .anchor-link:hover, .anchor-link:link, .anchor-link:visited {
     margin-left: 0.3rem;
     color: #505050;

--- a/sass/_vars.scss
+++ b/sass/_vars.scss
@@ -54,9 +54,11 @@ $card-list-gap: 15px;
 // CSS Vars
 :root {
     --header-height: 60px;
+    scroll-padding-top: 76px;
 
     @media #{$bp-tablet-landscape-up} {
         --header-height: 72px;
+        scroll-padding-top: 88px;
     }
 }
 

--- a/sass/_vars.scss
+++ b/sass/_vars.scss
@@ -54,11 +54,10 @@ $card-list-gap: 15px;
 // CSS Vars
 :root {
     --header-height: 60px;
-    scroll-padding-top: 76px;
+    --scroll-padding-top: calc(var(--header-height) + 16px);
 
     @media #{$bp-tablet-landscape-up} {
         --header-height: 72px;
-        scroll-padding-top: 88px;
     }
 }
 

--- a/sass/elements/_html.scss
+++ b/sass/elements/_html.scss
@@ -3,6 +3,7 @@ html {
     font-family: 'Fira Sans', sans-serif;
     font-size: calc-rem($size-body-mobile);
     background-color: $color-grey-900;
+    scroll-padding-top: 76px;
 
     * {
         box-sizing: border-box;
@@ -12,5 +13,6 @@ html {
 
     @media #{$bp-tablet-portrait-up} {
         font-size: calc-rem($size-body);
+        scroll-padding-top: 88px;
     }
 }

--- a/sass/elements/_html.scss
+++ b/sass/elements/_html.scss
@@ -3,7 +3,7 @@ html {
     font-family: 'Fira Sans', sans-serif;
     font-size: calc-rem($size-body-mobile);
     background-color: $color-grey-900;
-    scroll-padding-top: 76px;
+    scroll-padding-top: var(--scroll-padding-top);
 
     * {
         box-sizing: border-box;
@@ -13,6 +13,5 @@ html {
 
     @media #{$bp-tablet-portrait-up} {
         font-size: calc-rem($size-body);
-        scroll-padding-top: 88px;
     }
 }

--- a/templates/assets.html
+++ b/templates/assets.html
@@ -23,8 +23,7 @@
         {% for subsection in section.subsections %}
         {% set section = get_section(path=subsection) %}
 
-        <a class="anchor-target" id="{{ section.title | slugify }}"></a>
-        <h1 id="{{ section.title | slugify }}" class="asset-section">
+        <h1 class="asset-section" id="{{ section.title | slugify }}" >
             {{ section.title }}<a class="anchor-link" href="#{{ section.title | slugify }}">#</a>
         </h1>
 
@@ -47,8 +46,7 @@
         {% for subsection in subsections %}
         {% set section = get_section(path=subsection) %}
 
-        <a class="anchor-target" id="{{ section.title | slugify }}"></a>
-        <h3 class="asset-subsection">
+        <h3 class="asset-subsection" id="{{ section.title | slugify }}">
             {{ section.title }}<a class="anchor-link" href="#{{ section.title | slugify }}">#</a>
         </h3>
         <div class="item-grid">

--- a/templates/assets.html
+++ b/templates/assets.html
@@ -23,7 +23,7 @@
         {% for subsection in section.subsections %}
         {% set section = get_section(path=subsection) %}
 
-        <h1 class="asset-section" id="{{ section.title | slugify }}" >
+        <h1 class="asset-section" id="{{ section.title | slugify }}">
             {{ section.title }}<a class="anchor-link" href="#{{ section.title | slugify }}">#</a>
         </h1>
 

--- a/templates/errors.html
+++ b/templates/errors.html
@@ -8,7 +8,7 @@
             <a href="https://github.com/bevyengine/bevy/tree/main/errors">repository</a>.</p>
         </div>
         {% for page in section.pages %}
-            <h1 id="{{ page.title | slugify }}" class="asset-section">
+            <h1 class="asset-section" id="{{ page.title | slugify }}">
                 {{ page.title }}<a class="anchor-link" href="#{{ page.title | slugify }}">#</a>
             </h1>
             <div class="media-content">{{ page.content | safe }}</div>

--- a/templates/examples.html
+++ b/templates/examples.html
@@ -21,8 +21,7 @@
     {% for subsection in section.subsections %}
         {% set section = get_section(path=subsection) %}
 
-        <a class="anchor-target" id="{{ section.title | slugify }}"></a>
-        <h1 class="asset-section">
+        <h1 class="asset-section" id="{{ section.title | slugify }}">
             {{ section.title }}<a class="anchor-link" href="#{{ section.title | slugify }}">#</a>
         </h1>
 


### PR DESCRIPTION
Fixes #488 

Closes #502 
Closes #499 

Using `scroll-padding-top`. I am just discovering this CSS property, but it seems to be just the thing we need.

https://caniuse.com/?search=scroll-padding-top
https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-top

> This allows the author to exclude regions of the scrollport that are obscured by other content (such as fixed-positioned toolbars or sidebars) or to put more breathing room between a targeted element and the edges of the scrollport.

