### PR TITLE
[Merged by Bors] - Condense Bevy Community items in a grid layout

### DIFF
--- a/sass/pages/_community.scss
+++ b/sass/pages/_community.scss
@@ -5,7 +5,7 @@
 
 .community-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, 500px);
+    grid-template-columns: repeat(auto-fill,  minmax(300px, 500px));
     justify-content: center;
     gap: 1rem;
 }

--- a/sass/pages/_community.scss
+++ b/sass/pages/_community.scss
@@ -2,3 +2,14 @@
     width: 50% !important;
     max-width: 7rem;
 }
+
+.community-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, 500px);
+    justify-content: center;
+    gap: 1rem;
+}
+
+.community-card {
+    margin-bottom: 0px;
+}

--- a/templates/community.html
+++ b/templates/community.html
@@ -1,8 +1,8 @@
 {% extends "layouts/base.html" %}
 
 {% block content %}
-<div class="padded-content">
-    <a class="card" href="https://github.com/bevyengine/bevy">
+<div class="padded-content community-grid">
+    <a class="card community-card" href="https://github.com/bevyengine/bevy">
         <div class="card-image">
             <img src="/assets/github.svg" class="centered-card-image community-icon" alt="GitHub logo" />
         </div>
@@ -11,14 +11,30 @@
                 GitHub
             </div>
             <div class="card-subtitle">
-                github.com/bevyengine
+                bevyengine
             </div>
             <div class="card-description">
                 Interact with Bevy's source code, report issues, and suggest changes.
             </div>
         </div>
     </a>
-    <a class="card" href="https://github.com/bevyengine/bevy/discussions/categories/q-a">
+    <a class="card community-card" href="/community/people/">
+        <div class="card-image">
+            <svg xmlns="http://www.w3.org/2000/svg" class="centered-card-image community-icon" viewBox="0 0 640 512">
+                <!--! Font Awesome Pro 6.2.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. -->
+                <path fill="white" d="M184 88c0 30.9-25.1 56-56 56s-56-25.1-56-56s25.1-56 56-56s56 25.1 56 56zM64 245.7C54 256.9 48 271.8 48 288s6 31.1 16 42.3V245.7zm144.4-49.3C178.7 222.7 160 261.2 160 304c0 34.3 12 65.8 32 90.5V416c0 17.7-14.3 32-32 32H96c-17.7 0-32-14.3-32-32V389.2C26.2 371.2 0 332.7 0 288c0-61.9 50.1-112 112-112h32c24 0 46.2 7.5 64.4 20.3zM448 416V394.5c20-24.7 32-56.2 32-90.5c0-42.8-18.7-81.3-48.4-107.7C449.8 183.5 472 176 496 176h32c61.9 0 112 50.1 112 112c0 44.7-26.2 83.2-64 101.2V416c0 17.7-14.3 32-32 32H480c-17.7 0-32-14.3-32-32zM568 88c0 30.9-25.1 56-56 56s-56-25.1-56-56s25.1-56 56-56s56 25.1 56 56zm8 157.7v84.7c10-11.3 16-26.1 16-42.3s-6-31.1-16-42.3zM320 160c-35.3 0-64-28.7-64-64s28.7-64 64-64s64 28.7 64 64s-28.7 64-64 64zM240 304c0 16.2 6 31 16 42.3V261.7c-10 11.3-16 26.1-16 42.3zm144-42.3v84.7c10-11.3 16-26.1 16-42.3s-6-31.1-16-42.3zM448 304c0 44.7-26.2 83.2-64 101.2V448c0 17.7-14.3 32-32 32H288c-17.7 0-32-14.3-32-32V405.2c-37.8-18-64-56.5-64-101.2c0-61.9 50.1-112 112-112h32c61.9 0 112 50.1 112 112z"/>
+            </svg>
+        </div>
+        <div class="card-text">
+            <div class="card-title">
+                Bevy People
+            </div>
+            <div class="card-description">
+                Members of The Bevy Organization and the Bevy Community.
+            </div>
+        </div>
+    </a>
+    <a class="card community-card" href="https://github.com/bevyengine/bevy/discussions/categories/q-a">
         <div class="card-image">
             <img src="/assets/q_and_a.svg" class="centered-card-image community-icon" alt="Q and A logo" />
         </div>
@@ -27,14 +43,27 @@
                 Bevy Q&A
             </div>
             <div class="card-subtitle">
-                github.com/bevyengine
+                bevyengine
             </div>
             <div class="card-description">
                 The go-to place to ask Bevy questions and get Bevy answers
             </div>
         </div>
     </a>
-    <a class="card" href="https://discord.gg/bevy">
+    <a class="card community-card" href="https://bevyengine.org/assets/">
+        <div class="card-image">
+            <img src="/assets/bevy_icon_dark.svg" class="centered-card-image community-icon" alt="Bevy logo" />
+        </div>
+        <div class="card-text">
+            <div class="card-title">
+                Bevy Assets
+            </div>
+            <div class="card-description">
+                List of community projects in Bevy, including plugins, games, books, and tutorials.
+            </div>
+        </div>
+    </a>
+    <a class="card community-card" href="https://discord.gg/bevy">
         <div class="card-image">
             <img src="/assets/discord.svg" class="centered-card-image community-icon" alt="Discord logo" />
         </div>
@@ -50,7 +79,7 @@
             </div>
         </div>
     </a>
-    <a class="card" href="https://twitter.com/BevyEngine">
+    <a class="card community-card" href="https://twitter.com/BevyEngine">
         <div class="card-image">
             <img src="/assets/twitter.svg" class="centered-card-image community-icon" alt="Twitter logo" />
         </div>
@@ -59,14 +88,14 @@
                 Twitter
             </div>
             <div class="card-subtitle">
-                twitter.com/bevyengine
+                bevyengine
             </div>
             <div class="card-description">
                 Quick updates and shared Bevy content from the community
             </div>
         </div>
     </a>
-    <a class="card" href="https://www.reddit.com/r/bevy/">
+    <a class="card community-card" href="https://www.reddit.com/r/bevy/">
         <div class="card-image">
             <img src="/assets/reddit.svg" class="centered-card-image community-icon" alt="Reddit logo" />
         </div>
@@ -75,30 +104,14 @@
                 Reddit
             </div>
             <div class="card-subtitle">
-                reddit.com/r/bevy/
+                /r/bevy
             </div>
             <div class="card-description">
-                A place to stay up to date on Bevy news, share your Bevy games or plugins, and discuss Bevy topics.
+                Stay up to date on Bevy news, share your games or plugins, and discuss Bevy.
             </div>
         </div>
     </a>
-    <a class="card" href="https://bevyengine.org/assets/">
-        <div class="card-image">
-            <img src="/assets/bevy_icon_dark.svg" class="centered-card-image community-icon" alt="Bevy logo" />
-        </div>
-        <div class="card-text">
-            <div class="card-title">
-                Bevy Assets
-            </div>
-            <div class="card-subtitle">
-                bevyengine.org/assets/
-            </div>
-            <div class="card-description">
-                List of community projects in Bevy, including plugins, games, books, and tutorials.
-            </div>
-        </div>
-    </a>
-    <a class="card" href="https://itch.io/games/tag-bevy">
+    <a class="card community-card" href="https://itch.io/games/tag-bevy">
         <div class="card-image">
             <img src="/assets/itchio-textless.svg" class="centered-card-image community-icon" alt="itch.io logo" />
         </div>
@@ -107,29 +120,10 @@
                 itch.io
             </div>
             <div class="card-subtitle">
-                itch.io/games/tag-bevy
+                bevy
             </div>
             <div class="card-description">
                 Games tagged with "bevy" on itch.io.
-            </div>
-        </div>
-    </a>
-    <a class="card" href="/community/people/">
-        <div class="card-image">
-            <svg xmlns="http://www.w3.org/2000/svg" class="centered-card-image community-icon" viewBox="0 0 640 512">
-                <!--! Font Awesome Pro 6.2.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. -->
-                <path fill="white" d="M184 88c0 30.9-25.1 56-56 56s-56-25.1-56-56s25.1-56 56-56s56 25.1 56 56zM64 245.7C54 256.9 48 271.8 48 288s6 31.1 16 42.3V245.7zm144.4-49.3C178.7 222.7 160 261.2 160 304c0 34.3 12 65.8 32 90.5V416c0 17.7-14.3 32-32 32H96c-17.7 0-32-14.3-32-32V389.2C26.2 371.2 0 332.7 0 288c0-61.9 50.1-112 112-112h32c24 0 46.2 7.5 64.4 20.3zM448 416V394.5c20-24.7 32-56.2 32-90.5c0-42.8-18.7-81.3-48.4-107.7C449.8 183.5 472 176 496 176h32c61.9 0 112 50.1 112 112c0 44.7-26.2 83.2-64 101.2V416c0 17.7-14.3 32-32 32H480c-17.7 0-32-14.3-32-32zM568 88c0 30.9-25.1 56-56 56s-56-25.1-56-56s25.1-56 56-56s56 25.1 56 56zm8 157.7v84.7c10-11.3 16-26.1 16-42.3s-6-31.1-16-42.3zM320 160c-35.3 0-64-28.7-64-64s28.7-64 64-64s64 28.7 64 64s-28.7 64-64 64zM240 304c0 16.2 6 31 16 42.3V261.7c-10 11.3-16 26.1-16 42.3zm144-42.3v84.7c10-11.3 16-26.1 16-42.3s-6-31.1-16-42.3zM448 304c0 44.7-26.2 83.2-64 101.2V448c0 17.7-14.3 32-32 32H288c-17.7 0-32-14.3-32-32V405.2c-37.8-18-64-56.5-64-101.2c0-61.9 50.1-112 112-112h32c61.9 0 112 50.1 112 112z"/>
-            </svg>
-        </div>
-        <div class="card-text">
-            <div class="card-title">
-                People
-            </div>
-            <div class="card-subtitle">
-                bevyengine.org/community/people/
-            </div>
-            <div class="card-description">
-                Community members.
             </div>
         </div>
     </a>


### PR DESCRIPTION
This condenses the Bevy Community item layout to make the content more visible.

It also moves "Bevy People" up next to the github link to give it increased prominence. I also moved Bevy Assets above the Discord link, which means that "official bevy stuff" comes first, then "social media" stuff. 

![image](https://user-images.githubusercontent.com/2694663/211126301-1c8e8708-0feb-4d68-b168-3915e2103fcf.png)
