### PR TITLE
[Merged by Bors] - fix extra scroll bar on book

### DIFF
--- a/sass/pages/_content.scss
+++ b/sass/pages/_content.scss
@@ -1,7 +1,6 @@
 $content-font-size: 1.22rem;
 .media-content {
     width: 100%;
-    height: 100%;
     font-size: $content-font-size;
     font-weight: 400;
     line-height: $content-font-size * 1.43;


### PR DESCRIPTION
Book pages are showing a double scroll bar after https://github.com/bevyengine/bevy-website/pull/501.

![image](https://user-images.githubusercontent.com/2180432/211416606-8e36edd2-a310-41f1-9316-17cc5e6b4993.png)

`height: 100%` was added to `media-content` in that PR. As far as I can tell removing it doesn't change the appearance of the people page at all. `media-content` is used as container inside each car. But the card is at a fixed height of 12rem and has overflow hidden. So I wouldn't expect the height to be needed here.