### PR TITLE
[Merged by Bors] - Community: Add Role tags and consolidate Bevy Organization

### DIFF
--- a/generate-community/generate_community.sh
+++ b/generate-community/generate_community.sh
@@ -1,9 +1,12 @@
 #!/bin/sh
 
-git init bevy-community
+git clone https://github.com/cart/bevy-community
 cd bevy-community
-git remote add origin https://github.com/bevyengine/bevy-community
-git pull --depth=1 origin main
+git checkout roles-and-unify
+# git init bevy-community
+# cd bevy-community
+# git remote add origin https://github.com/bevyengine/bevy-community
+# git pull --depth=1 origin main
 cd ..
 
 cargo run --bin generate -- bevy-community ../content/ community

--- a/generate-community/src/bin/validate.rs
+++ b/generate-community/src/bin/validate.rs
@@ -59,6 +59,10 @@ fn validate_node(node: &CommunityNode) -> Result<(), String> {
                     Err(format!("Bio is longer than the maximum allowed length of {}. It is currently {} characters long.", MAX_BIO_LENGTH, grapheme_count))?;
                 }
             }
+
+            if member.roles.is_some() {
+                Err(format!("Roles must be defined in the roles.toml file"))?;
+            }
         }
     }
     Ok(())

--- a/generate-community/src/lib.rs
+++ b/generate-community/src/lib.rs
@@ -1,11 +1,10 @@
 use serde::Deserialize;
-use std::{fs, io, path::PathBuf, str::FromStr};
+use std::{collections::HashMap, fs, io, path::PathBuf, str::FromStr};
 
 #[derive(Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct Member {
     pub name: String,
-    pub order: Option<usize>,
     #[serde(default, deserialize_with = "extract_profile_picture")]
     pub profile_picture: Option<ProfilePicture>,
     pub sponsor: Option<String>,
@@ -26,6 +25,42 @@ pub struct Member {
     // this field is not read from the toml file
     #[serde(skip)]
     pub original_path: Option<PathBuf>,
+    pub roles: Option<Vec<String>>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+pub struct Roles {
+    pub project_lead: Vec<String>,
+    pub maintainer: Vec<String>,
+    pub sme: Vec<Sme>,
+}
+
+impl Roles {
+    pub fn into_map(self) -> HashMap<String, Vec<String>> {
+        let mut map: HashMap<String, Vec<String>> = HashMap::default();
+        for id in self.project_lead {
+            let roles = map.entry(id).or_default();
+            roles.push("Project Lead".to_string());
+        }
+        for id in self.maintainer {
+            let roles = map.entry(id).or_default();
+            roles.push("Maintainer".to_string());
+        }
+
+        for sme in self.sme {
+            let roles = map.entry(sme.id).or_default();
+            roles.push(format!("SME-{}", sme.area));
+        }
+        map
+    }
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+pub struct Sme {
+    pub area: String,
+    pub id: String,
 }
 
 #[derive(Debug, Clone)]
@@ -74,6 +109,22 @@ pub struct Section {
     pub sort_order_reversed: bool,
 }
 
+impl Section {
+    pub fn apply_roles(&mut self, roles: &HashMap<String, Vec<String>>) {
+        for content in &mut self.content {
+            match content {
+                CommunityNode::Section(section) => section.apply_roles(roles),
+                CommunityNode::Member(member) => {
+                    member.roles = member
+                        .github
+                        .as_ref()
+                        .and_then(|github| roles.get(github).cloned());
+                }
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum CommunityNode {
     Section(Section),
@@ -89,7 +140,21 @@ impl CommunityNode {
     pub fn order(&self) -> usize {
         match self {
             CommunityNode::Section(content) => content.order.unwrap_or(99999),
-            CommunityNode::Member(content) => content.order.unwrap_or(99999),
+            CommunityNode::Member(content) => {
+                if let Some(roles) = &content.roles {
+                    if roles.iter().find(|p| *p == "Project Lead").is_some() {
+                        0
+                    } else if roles.iter().find(|p| *p == "Maintainer").is_some() {
+                        1
+                    } else if !roles.is_empty() {
+                        2
+                    } else {
+                        99999
+                    }
+                } else {
+                    99999
+                }
+            }
         }
     }
 }
@@ -134,6 +199,7 @@ fn visit_dirs(dir: PathBuf, section: &mut Section) -> io::Result<()> {
                 section.content.push(CommunityNode::Section(new_section));
             } else {
                 if path.file_name().unwrap() == "_category.toml"
+                    || path.file_name().unwrap() == "_roles.toml"
                     || path.extension().expect("file must have an extension") != "toml"
                 {
                     continue;
@@ -157,6 +223,7 @@ pub fn parse_members(community_dir: &str) -> io::Result<Section> {
         order: None,
         sort_order_reversed: false,
     };
+
     visit_dirs(
         PathBuf::from_str(&community_dir).unwrap(),
         &mut people_root_section,

--- a/sass/pages/_people.scss
+++ b/sass/pages/_people.scss
@@ -18,7 +18,7 @@
 }
 
 .people-card {
-    height: 14.5rem;
+    height: 14rem;
     margin-bottom: 0px;
 }
 
@@ -42,6 +42,9 @@
     font-size: 0.8rem;
     padding-left: 0.3rem;
     padding-right: 0.3rem;
+    padding-top: 0.3rem;
+    padding-bottom: 0.3rem;
+    line-height: 1;
     border-radius: 0.3rem;
     border-style: solid;
     border-width: 1px;

--- a/sass/pages/_people.scss
+++ b/sass/pages/_people.scss
@@ -1,0 +1,69 @@
+.people-section-description {
+    margin-bottom: 1.5rem;
+}
+
+.people-role-descriptions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.people-role-description {
+    display: block;
+    flex-direction: row;
+}
+
+.people-role-description-text {
+    line-height: 1.45rem;
+}
+
+.people-card {
+    height: 14.5rem;
+    margin-bottom: 0px;
+}
+
+.people-links {
+    display: flex;
+    flex-direction: row;
+    gap: 1rem;
+}
+
+.people-roles {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.3rem;
+    margin-top: 0.3rem;
+    margin-bottom: 0.4rem;
+}
+
+.people-role {
+    display: block;
+    font-weight: 400;
+    font-size: 0.8rem;
+    padding-left: 0.3rem;
+    padding-right: 0.3rem;
+    border-radius: 0.3rem;
+    border-style: solid;
+    border-width: 1px;
+}
+
+.people-role-top-level {
+    float: left;
+    font-size: 1.0rem;
+    margin-right: 0.2rem;
+}
+
+.people-role-project-lead {
+    border-color: rgb(200, 200, 50);
+    color:rgb(200, 200, 50);
+}
+
+.people-role-maintainer {
+    border-color: rgb(242, 103, 255);
+    color: rgb(242, 103, 255);
+}
+
+.people-role-sme {
+    border-color: rgb(80, 200, 50);
+    color: rgb(80, 200, 50);
+}

--- a/sass/site.scss
+++ b/sass/site.scss
@@ -45,6 +45,7 @@
 // Pages
 // - Page specific CSS
 @import "pages/community";
+@import "pages/people";
 @import "pages/assets";
 @import "pages/book";
 @import "pages/news";

--- a/templates/people.html
+++ b/templates/people.html
@@ -67,7 +67,10 @@
             if you would like to join!
         </p>
         <p>
-            Bevy Organization members can also have the following roles:
+            <a class="anchor-target" id="org-roles"></a>
+            <h2>
+                Roles<a class="anchor-link" href="#org-roles">#</a>
+            </h2>
             <div class="people-role-descriptions">
                 <div class="people-role-description">
                     <div class="people-role people-role-top-level people-role-project-lead">Project Leads</div>
@@ -86,6 +89,12 @@
         </div>
         {% endif %}
 
+        {% if section.title == "The Bevy Organization" %}
+        <a class="anchor-target" id="org-members"></a>
+        <h2>
+            Members<a class="anchor-link" href="#org-members">#</a>
+        </h2>
+        {% endif %}
         {% if section.pages %}
         <div class="item-grid">
             {% set pages = section.pages %}

--- a/templates/people.html
+++ b/templates/people.html
@@ -55,15 +55,47 @@
             {{ section.title }}<a class="anchor-link" href="#{{ section.title | slugify }}">#</a>
         </h1>
 
+        {% if section.title == "The Bevy Organization" %}
+        <div class="people-section-description">
+        <p>
+            The Bevy Organization is the group of people responsible for stewarding the Bevy project. It handles things
+            like choosing project direction, merging pull requests, managing bugs / issues / feature requests, running
+            the Bevy website, controlling access to secrets, defining and enforcing best practices, etc.
+        </p>
+        <p>
+            Anyone with a history of contributing to Bevy can join the Bevy Organization. Reach out to the Project Lead
+            if you would like to join!
+        </p>
+        <p>
+            Bevy Organization members can also have the following roles:
+            <div class="people-role-descriptions">
+                <div class="people-role-description">
+                    <div class="people-role people-role-top-level people-role-project-lead">Project Leads</div>
+                    <div class="people-role-description-text">have the final call on all design and code changes within Bevy. They are responsible for representing the project publicly and they choose how the project is organized.</div>
+                </div>
+                <div class="people-role-description">
+                    <div class="people-role people-role-top-level people-role-maintainer">Maintainers</div>
+                    <div class="people-role-description-text">have merge rights in Bevy repos. They assess the scope of pull requests and whether they fit into the Bevy project's vision. They also serve as representatives of the Bevy project.</div>
+                </div>
+                <div class="people-role-description">
+                    <div class="people-role people-role-top-level people-role-sme">SMEs</div>
+                    <div class="people-role-description-text">(Subject Matter Experts) have proven themselves to be experts in a given development area. They help guide Bevy's direction in their area and they are great people to reach out to if you have questions about a given area.</div>
+                </div>
+            </div>
+        </p>
+        </div>
+        {% endif %}
+
         {% if section.pages %}
         <div class="item-grid">
             {% set pages = section.pages %}
             {% if section.extra.sort_order_reversed %}
             {% set pages = section.pages | reverse %}
             {% endif %}
+            
             {% for post in pages %}
 
-            <div class="card" id="{{ post.title | slugify }}">
+            <div class="card people-card" id="{{ post.title | slugify }}">
                 <div class="card-text media-content card-dense">
                     <div class="card-title">
                         <div style="width: 210px; font-size: {% if post.title | length > 30 %} 0.5rem; {% elif post.title | length > 20 %} 1.0rem; {% else %} 1.5rem; {% endif %}">
@@ -80,7 +112,7 @@
                         {% endif %}    
                     </div>
                     <div class="asset-card__small_description">
-                        <div style="display: flex; flex-direction: row; gap: 1rem;">
+                        <div class="people-links">
                             {% if post.extra.github %}
                                 <div>
                                     <a href="https://github.com/{{ post.extra.github }}">
@@ -156,6 +188,21 @@
                                 </div>
                             {% endif %}
                         </div>
+                        {% if post.extra.roles %}
+                        <div class="people-roles">
+                            {% for role in post.extra.roles %}
+                                {% if role == "Project Lead" %}
+                                    <div class="people-role people-role-project-lead">{{ role }}</div>
+                                {% elif role == "Maintainer" %}
+                                    <div class="people-role people-role-maintainer">{{ role }}</div>
+                                {% elif role is starting_with("SME-") %}
+                                    <div class="people-role people-role-sme">{{ role }}</div>
+                                {% else %}
+                                    <div class="people-role">{{ role }}</div>
+                                {% endif %}
+                            {% endfor %}
+                        </div>
+                        {% endif %}
                         {% if post.extra.bio %}
                             <div class="card-text-dense">
                                 {{ post.extra.bio }}


### PR DESCRIPTION
This adds Bevy Organization Role "tags" to the Bevy People/Community page (Project Lead, Maintainer, SME). These are displayed on each card. I've also added a short description of the Bevy Org and each role.
It also consolidates all org sections (Maintainers, Bevy Org) into a single "The Bevy Organization" section. 

You might notice we have a new role! We'll be announcing what that is and the people that will occupy it in the next day or so.

The Bevy People page now looks like this.

![image](https://user-images.githubusercontent.com/2694663/212442625-b3f90ed6-586e-444f-a84d-b2767e1ac91c.png)

Note that this currently uses my fork of bevy-community. We should merge this first, then migrate bevy-community to the new format.
