### PR TITLE
[Merged by Bors] - Fix role description text line height

### DIFF
--- a/sass/pages/_people.scss
+++ b/sass/pages/_people.scss
@@ -14,7 +14,7 @@
 }
 
 .people-role-description-text {
-    line-height: 1.45rem;
+    line-height: 1.75rem;
 }
 
 .people-card {


### PR DESCRIPTION
This allows the role tag to be rendered "inline" instead of breaking lines and creating weird indentation.