### PR TITLE
[Merged by Bors] - Make the People page less confusing

### DIFF
--- a/templates/people.html
+++ b/templates/people.html
@@ -85,7 +85,7 @@
                     <div class="people-role-description-text">(Subject Matter Experts) have proven themselves to be experts in a given development area. They help guide Bevy's direction in their area and they are great people to reach out to if you have questions about a given area.</div>
                 </div>
                 <div class="people-role-description">
-                    <div class="people-role-description-text">The other members, without a special role, are part of the triage team. They can manage GitHub issues and pull requests.</div>
+                    <div class="people-role-description-text">Other members, without a special role, are part of the GitHub organization. They have the power to manage GitHub issues and pull requests.</div>
                 </div>
             </div>
         </p>
@@ -102,7 +102,7 @@
         {% if section.title == "Community Members" %}
         <div class="people-section-description media-content">
         <p>
-            People from the Bevy community, who are not part of the organization.
+            People in the Bevy community who are not part of the organization.
         </p>
         <p>
             Anyone can add themselves here! <a href="https://github.com/bevyengine/bevy-community">Submit a pull request</a>!

--- a/templates/people.html
+++ b/templates/people.html
@@ -84,6 +84,9 @@
                     <div class="people-role people-role-top-level people-role-sme">SMEs</div>
                     <div class="people-role-description-text">(Subject Matter Experts) have proven themselves to be experts in a given development area. They help guide Bevy's direction in their area and they are great people to reach out to if you have questions about a given area.</div>
                 </div>
+                <div class="people-role-description">
+                    <div class="people-role-description-text">The other members, without a special role, are part of the triage team. They can manage GitHub issues and pull requests.</div>
+                </div>
             </div>
         </p>
         </div>
@@ -95,6 +98,18 @@
             Members<a class="anchor-link" href="#org-members">#</a>
         </h2>
         {% endif %}
+
+        {% if section.title == "Community Members" %}
+        <div class="people-section-description media-content">
+        <p>
+            People from the Bevy community, who are not part of the organization.
+        </p>
+        <p>
+            Anyone can add themselves here! <a href="https://github.com/bevyengine/bevy-community">Submit a pull request</a>!
+        </p>
+        </div>
+        {% endif %}
+
         {% if section.pages %}
         <div class="item-grid">
             {% set pages = section.pages %}


### PR DESCRIPTION
When I first looked at this page, I found it confusing. I had to read the README in the `bevy-community` repo to understand how it all works and why there is a separate Community Members section.

My first thoughts were "why are there so many people with no Role tags under the bevy org section? what is their role in the org? seems like there are a bunch of random people listed here, and some are separated under the community heading and others lumped in with the project people?"

This PR helps make the page more understandable.
 
 - Add some text under "Roles", to describe the role of the org members without any "special role" tag
 - Add some text under "Community Members", to clarify the purpose of that section
 