### PR TITLE
[Merged by Bors] - Migrate ci actions-rs to dtolnay/rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,9 +92,8 @@ jobs:
             content/examples/**/*.wasm
           key: ${{ runner.os }}-generate-wasm-examples-${{ hashFiles('generate-wasm-examples/bevy/Cargo.toml') }}
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           target: wasm32-unknown-unknown
 
       - name: "Build Bevy Examples"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,9 +34,8 @@ jobs:
       - name: "Build Bevy Community"
         run: cd generate-community && ./generate_community.sh
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           target: wasm32-unknown-unknown
 
       - name: "Build Bevy Examples"


### PR DESCRIPTION
Migrates `actions-rs/toolchain@v1` to `dtolnay/rust-toolchain@stable` in Ci workflow

Resolves #473 

Co-Authored-By: Victor Lima <limavictor49@gmail.com>