### PR TITLE
[Merged by Bors] - use original file name for people file

### DIFF
--- a/generate-community/src/bin/generate.rs
+++ b/generate-community/src/bin/generate.rs
@@ -107,10 +107,13 @@ impl FrontMatterWriter for Member {
             let _ = fs::copy(original_image, image_file_path);
         }
 
-        let mut file = File::create(path.join(format!(
-            "{}.md",
-            self.name.to_ascii_lowercase().replace("/", "-")
-        )))?;
+        let file_name = self
+            .original_path
+            .as_ref()
+            .and_then(|f| f.file_name())
+            .map(|f| f.to_string_lossy().replace(".toml", ""))
+            .expect("Failed to get file_name");
+        let mut file = File::create(path.join(format!("{}.md", file_name)))?;
         file.write_all(
             format!(
                 r#"+++


### PR DESCRIPTION
## Objective
When generating the file, it uses the name field for the file name, but this breaks when those names contain invalid character. 

The website is currently unable to be built because of this.

## Solution
Use the original file name instead since we know it's already valid.