### PR TITLE
[Merged by Bors] - Change recommended linker: zld to lld for MacOS

### DIFF
--- a/content/learn/book/getting-started/setup/_index.md
+++ b/content/learn/book/getting-started/setup/_index.md
@@ -155,7 +155,7 @@ Bevy can be built just fine using default configuration on stable Rust. However 
     rustup component add llvm-tools-preview
     ```
 
-  * **MacOS**: Modern LLD does not yet support MacOS, but we can use zld instead: `brew install michaeleisel/zld/zld`
+  * **MacOS**: You can follow this [instructions](https://lld.llvm.org/MachO/index.html) to install lld manually or install llvm through brew which includes lld: `brew install llvm`
 * **Alternative - mold linker**: mold is _up to 5× (five times!) faster_ than LLD, but with a few caveats like limited platform support and occasional stability issues.  To install mold, find your OS below and run the given command:
   * **Ubuntu**: `sudo apt-get install mold`
   * **Arch**: `sudo pacman -S mold`


### PR DESCRIPTION
# Objective

Stop recommending zld on MacOS
Fixes: https://github.com/bevyengine/bevy/issues/7299

## Solution

- Add instructions to install lld for MacOS