### PR TITLE
[Merged by Bors] - Migration guide 0.9-0.10

### DIFF
--- a/content/learn/book/migration-guides/0.9-0.10/_index.md
+++ b/content/learn/book/migration-guides/0.9-0.10/_index.md
@@ -15,11 +15,6 @@ As a result, the Minimum Supported Rust Version (MSRV) is "the latest stable rel
 
 ### [bevy_reflect: Pre-parsed paths](https://github.com/bevyengine/bevy/pull/7321)
 
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">Animation</div>
-    <div class="migration-guide-area-tag">Reflection</div>
-</div>
-
 `GetPath` methods have been renamed according to the following:
 
 - `path` -> `reflect_path`
@@ -28,10 +23,6 @@ As a result, the Minimum Supported Rust Version (MSRV) is "the latest stable rel
 - `get_path_mut` -> `path_mut`
 
 ### [Remove App::add_sub_app](https://github.com/bevyengine/bevy/pull/7290)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">App</div>
-</div>
 
 `App::add_sub_app` has been removed in favor of `App::insert_sub_app`. Use `SubApp::new` and insert it via `App::add_sub_app`
 
@@ -49,42 +40,22 @@ app.insert_sub_app(MySubAppLabel, SubApp::new(sub_app, extract_fn));
 
 ### [Make HandleUntyped::id private](https://github.com/bevyengine/bevy/pull/7076)
 
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">Assets</div>
-</div>
-
 Instead of directly accessing the ID of a `HandleUntyped` as `handle.id`, use the new getter `handle.id()`.
 
 ### [Break `CorePlugin` into `TaskPoolPlugin`, `TypeRegistrationPlugin`, `FrameCountPlugin`.](https://github.com/bevyengine/bevy/pull/7083)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">Core</div>
-</div>
 
 `CorePlugin` broken into separate plugins.  If not using `DefaultPlugins` or `MinimalPlugins` `PluginGroup`s, the replacement for `CorePlugin` is now to add `TaskPoolPlugin`, `TypeRegistrationPlugin`, and `FrameCountPlugin` to the app.
 
 ### [Remove broken `DoubleEndedIterator` impls on event iterators](https://github.com/bevyengine/bevy/pull/7469)
 
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">ECS</div>
-</div>
-
 `ManualEventIterator` and `ManualEventIteratorWithId` are no longer `DoubleEndedIterator`s.
 
 ### [Replace `RemovedComponents<T>` backing with `Events<Entity>`](https://github.com/bevyengine/bevy/pull/5680)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">ECS</div>
-</div>
 
 - Add a `mut` for `removed: RemovedComponents<T>` since we are now modifying an event reader internally.
 - Iterating over removed components now requires `&mut removed_components` or `removed_components.iter()` instead of `&removed_components`.
 
 ### [Remove `ExclusiveSystemParam::apply`](https://github.com/bevyengine/bevy/pull/7489)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">ECS</div>
-</div>
 
 <!-- TODO -->
 _Note for maintainers: this migration guide makes more sense if it’s placed above the one for #6919._
@@ -93,26 +64,14 @@ The trait method `ExclusiveSystemParamState::apply` has been removed. If you hav
 
 ### [Add `UnsafeWorldCell` abstraction](https://github.com/bevyengine/bevy/pull/6404)
 
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">ECS</div>
-</div>
-
 <!-- TODO no migration required, will remove later -->
 
 ### [Added `resource_id` and changed `init_resource` and `init_non_send_resource` to return `ComponentId`](https://github.com/bevyengine/bevy/pull/7284)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">ECS</div>
-</div>
 
 - Changed `World::init_resource` to return the generated `ComponentId`.
 - Changed `World::init_non_send_resource` to return the generated `ComponentId`.
 
 ### [Basic adaptive batching for parallel query iteration](https://github.com/bevyengine/bevy/pull/4777)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">ECS</div>
-</div>
 
 The `batch_size` parameter for `Query(State)::par_for_each(_mut)` has been removed. These calls will automatically compute a batch size for you. Remove these parameters from all calls to these functions.
 
@@ -134,10 +93,6 @@ fn parallel_system(query: Query<&MyComponent>) {
 
 ### [Support piping exclusive systems](https://github.com/bevyengine/bevy/pull/7023)
 
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">ECS</div>
-</div>
-
 Exclusive systems (systems that access `&mut World`) now support system piping, so the `ExclusiveSystemParamFunction` trait now has generics for the `In`put and `Out`put types.
 
 ```rust
@@ -154,25 +109,13 @@ where T: ExclusiveSystemParamFunction<In, Out, Param>
 
 ### [Document alignment requirements of `Ptr`, `PtrMut` and `OwningPtr`](https://github.com/bevyengine/bevy/pull/7151)
 
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">ECS</div>
-</div>
-
 Safety invariants on `bevy_ptr` types’ `new` `byte_add` and `byte_offset` methods have been changed. All callers should re-audit for soundness.
 
 ### [Panic on dropping NonSend in non-origin thread.](https://github.com/bevyengine/bevy/pull/6534)
 
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">ECS</div>
-</div>
-
 Normal resources and `NonSend` resources no longer share the same backing storage. If `R: Resource`, then `NonSend<R>` and `Res<R>` will return different instances from each other. If you are using both `Res<T>` and `NonSend<T>` (or their mutable variants), to fetch the same resources, it’s strongly advised to use `Res<T>`.
 
 ### [Remove the `SystemParamState` trait and remove types like `ResState`](https://github.com/bevyengine/bevy/pull/6919)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">ECS</div>
-</div>
 
 Note: this replaces the migration guide for #6865.
 This is relative to Bevy 0.9, not main.
@@ -215,41 +158,21 @@ unsafe impl ReadOnlySystemParam for MyParam<'_, '_> {}
 
 ### [Extend EntityLocation with TableId and TableRow](https://github.com/bevyengine/bevy/pull/6681)
 
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">ECS</div>
-</div>
-
 A `World` can only hold a maximum of 2<sup>32</sup> - 1 archetypes and tables now. If your use case requires more than this, please file an issue explaining your use case.
 
 ### [Round out the untyped api s](https://github.com/bevyengine/bevy/pull/7009)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">ECS</div>
-</div>
 
 `MutUntyped::into_inner` now marks things as changed.
 
 ### [Simplify trait hierarchy for `SystemParam`](https://github.com/bevyengine/bevy/pull/6865)
 
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">ECS</div>
-</div>
-
 _Merged with the guide for #6919._
 
 ### [Newtype ArchetypeRow and TableRow](https://github.com/bevyengine/bevy/pull/4878)
 
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">ECS</div>
-</div>
-
 `Archetype` indices and `Table` rows have been newtyped as `ArchetypeRow` and `TableRow`.
 
 ### [Borrow instead of consuming in `EventReader::clear`](https://github.com/bevyengine/bevy/pull/6851)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">ECS</div>
-</div>
 
 `EventReader::clear` now takes a mutable reference instead of consuming the event reader. This means that `clear` now needs explicit mutable access to the reader variable, which previously could have been omitted in some cases:
 
@@ -266,10 +189,6 @@ fn clear_events(mut reader: EventReader<SomeEvent>) {
 ```
 
 ### [Make the `SystemParam` derive macro more flexible](https://github.com/bevyengine/bevy/pull/6694)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">ECS</div>
-</div>
 
 The lifetime `'s` has been removed from `EventWriter`. Any code that explicitly specified the lifetimes for this type will need to be updated.
 
@@ -289,29 +208,17 @@ struct MessageWriter<'w> {
 
 ### [Lock down access to Entities](https://github.com/bevyengine/bevy/pull/6740)
 
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">ECS</div>
-</div>
-
 `Entities`’s `Default` implementation has been removed. You can fetch a reference to a `World`’s `Entities` via `World::entities` and `World::entities_mut`.
 
 `Entities::alloc_at_without_replacement` and `AllocAtWithoutReplacement` has been made private due to difficulty in using it properly outside of `bevy_ecs`. If you still need use of this API, please file an issue.
 
 ### [Document and lock down types in bevy_ecs::archetype](https://github.com/bevyengine/bevy/pull/6742)
 
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">ECS</div>
-</div>
-
 `ArchetypeId`, `ArchetypeGeneration`, and `ArchetypeComponentId` are all now opaque IDs and cannot be turned into a numeric value. Please file an issue if this does not work for your use case.
 
 `Archetype` and `Archetypes` are not constructible outside of `bevy_ecs` now. Use `World::archetypes` to get a read-only reference to either of these types.
 
 ### [Split Component Ticks](https://github.com/bevyengine/bevy/pull/6547)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">ECS</div>
-</div>
 
 Various low level APIs interacting with the change detection ticks no longer return `&UnsafeCell<ComponentTicks>`, instead returning `TickCells` which contains two separate `&UnsafeCell<Tick>`s instead.
 
@@ -325,77 +232,37 @@ column.get_ticks(row).changed.deref()
 
 ### [Immutable sparse sets for metadata storage](https://github.com/bevyengine/bevy/pull/4928)
 
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">ECS</div>
-</div>
-
 `Table::component_capacity()` has been removed as Tables do not support adding/removing columns after construction.
 
 ### [Remove redundant table and sparse set component IDs from Archetype](https://github.com/bevyengine/bevy/pull/4927)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">ECS</div>
-</div>
 
 Do I still need to do this? I really hope people were not relying on the public facing APIs changed here.
 
 ### [Move system_commands spans into apply_buffers](https://github.com/bevyengine/bevy/pull/6900)
 
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">ECS</div>
-    <div class="migration-guide-area-tag">Diagnostics</div>
-</div>
-
 <!-- TODO no migration required, will remove later-->
 
 ### [ReflectComponentFns without World](https://github.com/bevyengine/bevy/pull/7206)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">ECS</div>
-    <div class="migration-guide-area-tag">Reflection</div>
-</div>
 
 Call `World::entity` before calling into the changed `ReflectComponent` methods, most likely user already has a `EntityRef` or `EntityMut` which was being queried redundantly.
 
 ### [Allow iterating over with EntityRef over the entire World](https://github.com/bevyengine/bevy/pull/6843)
 
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">ECS</div>
-    <div class="migration-guide-area-tag">Scenes</div>
-</div>
-
 `World::iter_entities` now returns an iterator of `EntityRef` instead of `Entity`. To get the actual ID, use `EntityRef::id` from the returned `EntityRef`s.
 
 ### [Remove `BuildWorldChildren` impl from `WorldChildBuilder`](https://github.com/bevyengine/bevy/pull/6727)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">Hierarchy</div>
-</div>
 
 Hierarchy editing methods such as `with_children` and `push_children` have been removed from `WorldChildBuilder`. You can edit the hierarchy via `EntityMut` instead.
 
 ### [Rename dynamic feature](https://github.com/bevyengine/bevy/pull/7340)
 
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">Meta</div>
-</div>
-
 `dynamic` feature was renamed to `dynamic_linking`
 
 ### [Add `insert` and `remove` methods to `List`](https://github.com/bevyengine/bevy/pull/7063)
 
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">Reflection</div>
-</div>
-
 Manual implementors of `List` need to implement the new methods `insert` and `remove` and consider whether to use the new default implementation of `push` and `pop`.
 
 ### [Remove `ReflectSerialize` and `ReflectDeserialize` registrations from most glam types](https://github.com/bevyengine/bevy/pull/6580)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">Reflection</div>
-    <div class="migration-guide-area-tag">Scenes</div>
-</div>
 
 This PR removes `ReflectSerialize` and `ReflectDeserialize` registrations from most glam types. This means any code relying on either of those type data existing for those glam types will need to not do that.
 
@@ -436,17 +303,9 @@ This also means that some serialized glam types will need to be updated. For exa
 
 ### [Support recording multiple CommandBuffers in RenderContext](https://github.com/bevyengine/bevy/pull/7248)
 
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">Rendering</div>
-</div>
-
 `RenderContext`’s fields are now private. Use the accessors on `RenderContext` instead, and construct it with `RenderContext::new`.
 
 ### [Changed Msaa to Enum](https://github.com/bevyengine/bevy/pull/7292)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">Rendering</div>
-</div>
 
 ```rust
 // 0.9
@@ -460,17 +319,9 @@ multi.samples()
 
 ### [Make PipelineCache internally mutable.](https://github.com/bevyengine/bevy/pull/7205)
 
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">Rendering</div>
-</div>
-
 Most usages of `resource_mut::<PipelineCache>` and `ResMut<PipelineCache>` can be changed to `resource::<PipelineCache>` and `Res<PipelineCache>` as long as they don’t use any methods requiring mutability - the only public method requiring it is `process_queue`.
 
 ### [Reduce branching in TrackedRenderPass](https://github.com/bevyengine/bevy/pull/7053)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">Rendering</div>
-</div>
 
 `TrackedRenderPass` now requires a `RenderDevice` to construct. To make this easier, use `RenderContext.begin_tracked_render_pass` instead.
 
@@ -489,10 +340,6 @@ render_context.begin_tracked_render_pass(RenderPassDescriptor {
 ```
 
 ### [Rename camera "priority" to "order"](https://github.com/bevyengine/bevy/pull/6908)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">Rendering</div>
-</div>
 
 ```rust
 // 0.9
@@ -516,10 +363,6 @@ Camera2dBundle {
 
 ### [Enum `Visibility` component](https://github.com/bevyengine/bevy/pull/6320)
 
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">Rendering</div>
-</div>
-
 - evaluation of the `visibility.is_visible` field should now check for `visibility == Visibility::Inherited`.
 - setting the `visibility.is_visible` field should now directly set the value: `*visibility = Visibility::Inherited`.
 - usage of `Visibility::VISIBLE` or `Visibility::INVISIBLE` should now use `Visibility::Inherited` or `Visibility::Hidden` respectively.
@@ -527,34 +370,18 @@ Camera2dBundle {
 
 ### [Run clear trackers on render world](https://github.com/bevyengine/bevy/pull/6878)
 
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">Rendering</div>
-</div>
-
 The call to `clear_trackers` in `App` has been moved from the schedule to App::update for the main world and calls to `clear_trackers` have been added for sub_apps in the same function. This was due to needing stronger guarantees. If clear_trackers isn’t called on a world it can lead to memory leaks in `RemovedComponents`.
 
 ### [Get pixel size from wgpu](https://github.com/bevyengine/bevy/pull/6820)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">Rendering</div>
-</div>
 
 `PixelInfo` has been removed. `PixelInfo::components` is equivalent to `texture_format.describe().components`. `PixelInfo::type_size` can be gotten from `texture_format.describe().block_size/ texture_format.describe().components`. But note this can yield incorrect results for some texture types like Rg11b10Float.
 
 ### [Shader defs can now have a value](https://github.com/bevyengine/bevy/pull/5900)
 
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">Rendering</div>
-</div>
-
 - replace `shader_defs.push(String::from("NAME"));` by `shader_defs.push("NAME".into());`
 - if you used shader def `NO_STORAGE_BUFFERS_SUPPORT`, check how `AVAILABLE_STORAGE_BUFFER_BINDINGS` is now used in Bevy default shaders
 
 ### [Add try_* to add_slot_edge, add_node_edge](https://github.com/bevyengine/bevy/pull/6720)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">Rendering</div>
-</div>
 
 Remove `.unwrap()` from `add_node_edge` and `add_slot_edge`. For cases where the error was handled, use `try_add_node_edge` and `try_add_slot_edge` instead.
 
@@ -562,17 +389,9 @@ Remove `.unwrap()` from `input_node`. For cases where the option was handled, us
 
 ### [Add AutoMax next to ScalingMode::AutoMin](https://github.com/bevyengine/bevy/pull/6496)
 
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">Rendering</div>
-</div>
-
 Rename `ScalingMode::Auto` to `ScalingMode::AutoMin` if you are using it.
 
 ### [Change `From<Icosphere>` to `TryFrom<Icosphere>`](https://github.com/bevyengine/bevy/pull/6484)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">Rendering</div>
-</div>
 
 ```rust
 // 0.9
@@ -593,38 +412,17 @@ shape::Icosphere {
 
 ### [Directly extract joints into SkinnedMeshJoints](https://github.com/bevyengine/bevy/pull/6833)
 
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">Rendering</div>
-    <div class="migration-guide-area-tag">Animation</div>
-</div>
-
 `ExtractedJoints` has been removed. Read the bound bones from `SkinnedMeshJoints` instead.
 
 ### [Intepret glTF colors as linear instead of sRGB](https://github.com/bevyengine/bevy/pull/6828)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">Rendering</div>
-    <div class="migration-guide-area-tag">Assets</div>
-</div>
 
 No api changes are required, but it's possible that your gltf meshes look different
 
 ### [The `update_frame_count` system should be placed in CorePlugin](https://github.com/bevyengine/bevy/pull/6676)
 
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">Rendering</div>
-    <div class="migration-guide-area-tag">Core</div>
-    <div class="migration-guide-area-tag">Time</div>
-</div>
-
 The `FrameCount`  resource was previously only updated when using the `bevy_render` feature. If you are not using this feature but still want the `FrameCount` it will now be updated correctly.
 
 ### [Migrate engine to Schedule v3](https://github.com/bevyengine/bevy/pull/7267)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">Rendering</div>
-    <div class="migration-guide-area-tag">ECS</div>
-</div>
 
 - Calls to `.label(MyLabel)` should be replaced with `.in_set(MySet)`
 - Stages have been removed. Replace these with system sets, and then add command flushes using the `apply_system_buffers` exclusive system where needed.
@@ -650,55 +448,27 @@ The `FrameCount`  resource was previously only updated when using the `bevy_rend
 
 ### [Pipelined Rendering](https://github.com/bevyengine/bevy/pull/6503)
 
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">Rendering</div>
-    <div class="migration-guide-area-tag">Tasks</div>
-</div>
-
 __App `runner` and SubApp `extract` functions are now required to be Send__
 
 This was changed to enable pipelined rendering. If this breaks your use case please report it as these new bounds might be able to be relaxed.
 
 ### [Rename the `background_color` of 'ExtractedUiNode` to `color`](https://github.com/bevyengine/bevy/pull/7452)
 
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">Rendering</div>
-    <div class="migration-guide-area-tag">UI</div>
-</div>
-
 The `background_color` field of `ExtractedUiNode` is now named `color`.
 
 ### [Remove ImageMode](https://github.com/bevyengine/bevy/pull/6674)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">Rendering</div>
-    <div class="migration-guide-area-tag">UI</div>
-</div>
 
 `ImageNode` never worked, if you were using it please create an issue.
 
 ### [Make `spawn_dynamic` return InstanceId](https://github.com/bevyengine/bevy/pull/6663)
 
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">Scenes</div>
-</div>
-
 <!-- TODO no migration required, will remove it later-->
 
 ### [Parallelized transform propagation](https://github.com/bevyengine/bevy/pull/4775)
 
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">Transform</div>
-</div>
-
 <!-- TODO no migration required, will remove it later-->
 
 ### [Remove the `GlobalTransform::translation_mut` method](https://github.com/bevyengine/bevy/pull/7134)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">Transform</div>
-    <div class="migration-guide-area-tag">Hierarchy</div>
-</div>
 
 `GlobalTransform::translation_mut` has been removed without alternative, if you were relying on this, update the `Transform` instead. If the given entity had children or parent, you may need to remove its parent to make its transform independent (in which case the new `Commands::set_parent_in_place` and `Commands::remove_parent_in_place` may be of interest)
 
@@ -706,25 +476,13 @@ Bevy may add in the future a way to toggle transform propagation on an entity ba
 
 ### [change the default `width` and `height` of `Size` to `Val::Auto`](https://github.com/bevyengine/bevy/pull/7475)
 
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">UI</div>
-</div>
-
 The default values for `Size` `width` and `height` have been changed from `Val::Undefined` to `Val::Auto`. It’s unlikely to cause any issues with existing code.
 
 ### [Remove `QueuedText`](https://github.com/bevyengine/bevy/pull/7414)
 
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">UI</div>
-</div>
-
 `QueuedText` was never meant to be user facing. If you relied on it, please make an issue.
 
 ### [Remove VerticalAlign from TextAlignment](https://github.com/bevyengine/bevy/pull/6807)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">UI</div>
-</div>
 
 The `alignment` field of `Text` now only affects the text’s internal alignment.
 
@@ -740,25 +498,13 @@ __Changes for `Text2dBundle`__
 
 ### [Change default FocusPolicy to Pass](https://github.com/bevyengine/bevy/pull/7161)
 
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">UI</div>
-</div>
-
 `FocusPolicy` default has changed from `FocusPolicy::Block` to `FocusPolicy::Pass`
 
 ### [Remove `TextError::ExceedMaxTextAtlases(usize)` variant](https://github.com/bevyengine/bevy/pull/6796)
 
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">UI</div>
-</div>
-
 `TextError::ExceedMaxTextAtlases(usize)` was never thrown so if you were matching on this variant you can simply remove it.
 
 ### [Flip UI image](https://github.com/bevyengine/bevy/pull/6292)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">UI</div>
-</div>
 
 ```rust
 // 0.9
@@ -777,10 +523,6 @@ commands.spawn(ImageBundle {
 ```
 
 ### [Update winit to 0.28](https://github.com/bevyengine/bevy/pull/7480)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">Windowing</div>
-</div>
 
 ```rust
 // 0.9
@@ -806,17 +548,9 @@ app.new()
 
 ### [Allow not preventing default event behaviors on wasm](https://github.com/bevyengine/bevy/pull/7304)
 
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">Windowing</div>
-</div>
-
 <!-- TODO I'm not sure this needs a guide, I assume most people would be using the ..default() anyway and the ones that aren't doing that will just have a clear compile error -->
 
 ### [Windows as Entities](https://github.com/bevyengine/bevy/pull/5589)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">Windowing</div>
-</div>
 
 - Replace `WindowDescriptor` with `Window`.
 - Change `width` and `height` fields in a `WindowResolution`, either by doing

--- a/content/learn/book/migration-guides/0.9-0.10/_index.md
+++ b/content/learn/book/migration-guides/0.9-0.10/_index.md
@@ -61,7 +61,7 @@ Instead of directly accessing the ID of a `HandleUntyped` as `handle.id`, use th
     <div class="migration-guide-area-tag">Core</div>
 </div>
 
-`CorePlugin` broken into separate plugins.  If not using `DefaultPlugins` or `MinimalPlugins` `PluginGroup`s, the replacement for `CorePlugin` is now to add `TaskPoolPlugin`, `TypeRegistrationPlugin`, and `FrameCountPlugin` to the app.
+`CorePlugin` broken into separate plugins. If not using `DefaultPlugins` or `MinimalPlugins` `PluginGroup`s, the replacement for `CorePlugin` is now to add `TaskPoolPlugin`, `TypeRegistrationPlugin`, and `FrameCountPlugin` to the app.
 
 ### [Immutable sparse sets for metadata storage](https://github.com/bevyengine/bevy/pull/4928)
 
@@ -192,7 +192,7 @@ The traits `SystemParamState` and `SystemParamFetch` have been removed, and thei
 The trait `ReadOnlySystemParamFetch` has been replaced with `ReadOnlySystemParam`.
 
 ```rust
-// 0.9 (0.9)
+// 0.9
 impl SystemParam for MyParam<'_, '_> {
     type State = MyParamState;
 }
@@ -205,7 +205,7 @@ unsafe impl<'w, 's> SystemParamFetch<'w, 's> for MyParamState {
 }
 unsafe impl ReadOnlySystemParamFetch for MyParamState { }
 
-// 0.10 (0.10)
+// 0.10
 unsafe impl SystemParam for MyParam<'_, '_> {
     type State = MyParamState;
     type Item<'w, 's> = MyParam<'w, 's>;
@@ -271,7 +271,7 @@ fn parallel_system(query: Query<&MyComponent>) {
     <div class="migration-guide-area-tag">ECS</div>
 </div>
 
-The type UnsafeWorldCellEntityRef has been renamed to UnsafeEntityCell
+The type `UnsafeWorldCellEntityRef` has been renamed to UnsafeEntityCell
 
 ### [Replace `RemovedComponents<T>` backing with `Events<Entity>`](https://github.com/bevyengine/bevy/pull/5680)
 
@@ -356,7 +356,7 @@ where
 `ChangeTrackers<T>` has been deprecated, and will be removed in the next release. Any usage should be replaced with `Ref<T>`.
 
 ```rust
-// 0.9 (0.9)
+// 0.9
 fn my_system(q: Query<(&MyComponent, ChangeTrackers<MyComponent>)>) {
     for (value, trackers) in &q {
         if trackers.is_changed() {
@@ -365,7 +365,7 @@ fn my_system(q: Query<(&MyComponent, ChangeTrackers<MyComponent>)>) {
     }
 }
 
-// 0.10 (0.10)
+// 0.10
 fn my_system(q: Query<Ref<MyComponent>>) {
     for value in &q {
         if value.is_changed() {
@@ -374,14 +374,6 @@ fn my_system(q: Query<Ref<MyComponent>>) {
     }
 }
 ```
-
-### [Make boxed conditions read-only](https://github.com/bevyengine/bevy/pull/7786)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">ECS</div>
-</div>
-
-<!-- TODO -->
 
 ### [`EntityMut`: rename `remove_intersection` to `remove` and `remove` to `take`](https://github.com/bevyengine/bevy/pull/7810)
 
@@ -595,8 +587,8 @@ For cases where the option was handled, use `get_input_node` instead.
     <div class="migration-guide-area-tag">Rendering</div>
 </div>
 
-- replace `shader_defs.push(String::from("NAME"));` by `shader_defs.push("NAME".into());`
-- if you used shader def `NO_STORAGE_BUFFERS_SUPPORT`, check how `AVAILABLE_STORAGE_BUFFER_BINDINGS` is now used in [Bevy default shaders](https://github.com/bevyengine/bevy/blob/3ec87e49ca49767fad658e72fbae353f6687198c/crates/bevy_pbr/src/render/mesh_view_bindings.wgsl#L28)
+- Replace `shader_defs.push(String::from("NAME"));` by `shader_defs.push("NAME".into());`
+- If you used shader def `NO_STORAGE_BUFFERS_SUPPORT`, check how `AVAILABLE_STORAGE_BUFFER_BINDINGS` is now used in [Bevy default shaders](https://github.com/bevyengine/bevy/blob/3ec87e49ca49767fad658e72fbae353f6687198c/crates/bevy_pbr/src/render/mesh_view_bindings.wgsl#L28)
 
 ### [Get pixel size from wgpu](https://github.com/bevyengine/bevy/pull/6820)
 
@@ -622,15 +614,15 @@ The call to `clear_trackers` in `App` has been moved from the schedule to `App::
 
 Rename `priority` to `order` in usage of `Camera`.
 
-### [enum `Visibility` component](https://github.com/bevyengine/bevy/pull/6320)
+### [Enum `Visibility` component](https://github.com/bevyengine/bevy/pull/6320)
 
 <div class="migration-guide-area-tags">
     <div class="migration-guide-area-tag">Rendering</div>
 </div>
 
-- evaluation of the `visibility.is_visible` field should now check for `visibility == Visibility::Inherited`.
-- setting the `visibility.is_visible` field should now directly set the value: `*visibility = Visibility::Inherited`.
-- usage of `Visibility::VISIBLE` or `Visibility::INVISIBLE` should now use `Visibility::Inherited` or `Visibility::Hidden` respectively.
+- Evaluation of the `visibility.is_visible` field should now check for `visibility == Visibility::Inherited`.
+- Setting the `visibility.is_visible` field should now directly set the value: `*visibility = Visibility::Inherited`.
+- Usage of `Visibility::VISIBLE` or `Visibility::INVISIBLE` should now use `Visibility::Inherited` or `Visibility::Hidden` respectively.
 - `ComputedVisibility::INVISIBLE` and `SpatialBundle::VISIBLE_IDENTITY` have been renamed to `ComputedVisibility::HIDDEN` and `SpatialBundle::INHERITED_IDENTITY` respectively.
 
 ### [Reduce branching in TrackedRenderPass](https://github.com/bevyengine/bevy/pull/7053)
@@ -743,7 +735,7 @@ Some detailed bevy trace events now require the use of the cargo feature `detail
     <div class="migration-guide-area-tag">Rendering</div>
 </div>
 
-- Removed `SetShadowViewBindGroup`, `queue_shadow_view_bind_group()`, and `LightMeta::shadow_view_bind_group` in favor of reusing the prepass view bind group.
+Removed `SetShadowViewBindGroup`, `queue_shadow_view_bind_group()`, and `LightMeta::shadow_view_bind_group` in favor of reusing the prepass view bind group.
 
 ### [Directly extract joints into SkinnedMeshJoints](https://github.com/bevyengine/bevy/pull/6833)
 
@@ -864,7 +856,7 @@ an entity basis.
     <div class="migration-guide-area-tag">UI</div>
 </div>
 
-TextError::ExceedMaxTextAtlases(usize)` was never thrown so if you were matching on this variant you can simply remove it.
+`TextError::ExceedMaxTextAtlases(usize)` was never thrown so if you were matching on this variant you can simply remove it.
 
 ### [Change default FocusPolicy to Pass](https://github.com/bevyengine/bevy/pull/7161)
 
@@ -890,7 +882,7 @@ __Change `TextAlignment` to TextAlignment` which is now an enum. Replace:__
 
 __Changes for `Text2dBundle`__
 
-`Text2dBundle` has a new field ‘text_anchor’ that takes an `Anchor` component that controls its position relative to its transform.
+`Text2dBundle` has a new field `text_anchor` that takes an `Anchor` component that controls its position relative to its transform.
 
 `Text2dSize` was removed. Use `TextLayoutInfo` instead.
 `Text2dSize` was removed. Use `TextLayoutInfo` instead.
@@ -935,8 +927,9 @@ The size field of `CalculatedSize` has been changed to a `Vec2`.
     <div class="migration-guide-area-tag">Windowing</div>
 </div>
 
-- Replace `WindowDescriptor` with `Window`.
-  - Change `width` and `height` fields in a `WindowResolution`, either by doing
+Replace `WindowDescriptor` with `Window`.
+
+Change `width` and `height` fields in a `WindowResolution`, either by doing
 
 ```rust
 WindowResolution::new(width, height) // Explicitly
@@ -944,14 +937,14 @@ WindowResolution::new(width, height) // Explicitly
 (1920., 1080.).into()
 ```
 
-- Replace any `WindowCommand` code to just modify the `Window`’s fields directly  and creating/closing windows is now by spawning/despawning an entity with a `Window` component like so:
+Replace any `WindowCommand` code to just modify the `Window`’s fields directly  and creating/closing windows is now by spawning/despawning an entity with a `Window` component like so:
 
 ```rust
 let window = commands.spawn(Window { ... }).id(); // open window
 commands.entity(window).despawn(); // close window
 ```
 
-- To get a window, you now need to use a `Query` instead of a `Res`
+To get a window, you now need to use a `Query` instead of a `Res`
 
 ```rust
 // 0.9

--- a/content/learn/book/migration-guides/0.9-0.10/_index.md
+++ b/content/learn/book/migration-guides/0.9-0.10/_index.md
@@ -755,6 +755,13 @@ Removed `SetShadowViewBindGroup`, `queue_shadow_view_bind_group()`, and `LightMe
 
 No api changes are required, but it's possible that your gltf meshes look different
 
+### [Send emissive color to uniform as linear instead of sRGB](https://github.com/bevyengine/bevy/pull/7897)
+
+- If you have previously manually specified emissive values with `Color::rgb()` and would like to retain the old visual results, you must now use `Color::rgb_linear()` instead;
+- If you have previously manually specified emissive values with `Color::rgb_linear()` and would like to retain the old visual results, you'll need to apply a one-time gamma calculation to your channels manually to get the _actual_ linear RGB value: 
+  - For channel values greater than `0.0031308`, use `(1.055 * value.powf(1.0 / 2.4)) - 0.055`;
+  - For channel values lower than or equal to `0.0031308`, use `value * 12.92`;
+- Otherwise, the results should now be more consistent with other tools/engines.
 ### [The `update_frame_count` system should be placed in CorePlugin](https://github.com/bevyengine/bevy/pull/6676)
 
 <div class="migration-guide-area-tags">

--- a/content/learn/book/migration-guides/0.9-0.10/_index.md
+++ b/content/learn/book/migration-guides/0.9-0.10/_index.md
@@ -35,29 +35,25 @@ As a result, the Minimum Supported Rust Version (MSRV) is "the latest stable rel
 
 `App::add_sub_app` has been removed in favor of `App::insert_sub_app`. Use `SubApp::new` and insert it via `App::insert_sub_app`
 
-Old:
-
 ```rust
+// 0.9
 let mut sub_app = App::new()
 // Build subapp here
 app.add_sub_app(MySubAppLabel, sub_app, extract_fn);
-```
 
-New:
-
-```rust
+// 0.10
 let mut sub_app = App::new()
 // Build subapp here
 app.insert_sub_app(MySubAppLabel, SubApp::new(sub_app, extract_fn));
 ```
 
-### [asset: make HandleUntyped::id private](https://github.com/bevyengine/bevy/pull/7076)
+### [Make HandleUntyped::id private](https://github.com/bevyengine/bevy/pull/7076)
 
 <div class="migration-guide-area-tags">
     <div class="migration-guide-area-tag">Assets</div>
 </div>
 
-- Instead of directly accessing the ID of a `HandleUntyped` as `handle.id`, use the new getter `handle.id()`.
+Instead of directly accessing the ID of a `HandleUntyped` as `handle.id`, use the new getter `handle.id()`.
 
 ### [Break `CorePlugin` into `TaskPoolPlugin`, `TypeRegistrationPlugin`, `FrameCountPlugin`.](https://github.com/bevyengine/bevy/pull/7083)
 
@@ -65,7 +61,7 @@ app.insert_sub_app(MySubAppLabel, SubApp::new(sub_app, extract_fn));
     <div class="migration-guide-area-tag">Core</div>
 </div>
 
-- `CorePlugin` broken into separate plugins.  If not using `DefaultPlugins` or `MinimalPlugins` `PluginGroup`s, the replacement for `CorePlugin` is now to add `TaskPoolPlugin`, `TypeRegistrationPlugin`, and `FrameCountPlugin` to the app.
+`CorePlugin` broken into separate plugins.  If not using `DefaultPlugins` or `MinimalPlugins` `PluginGroup`s, the replacement for `CorePlugin` is now to add `TaskPoolPlugin`, `TypeRegistrationPlugin`, and `FrameCountPlugin` to the app.
 
 ### [Immutable sparse sets for metadata storage](https://github.com/bevyengine/bevy/pull/4928)
 
@@ -120,13 +116,13 @@ column.get_ticks(row).changed.deref()
 The lifetime `'s` has been removed from `EventWriter`. Any code that explicitly specified the lifetimes for this type will need to be updated.
 
 ```rust
-// Before
+// 0.9
 #[derive(SystemParam)]
 struct MessageWriter<'w, 's> {
     events: EventWriter<'w, 's, Message>,
 }
 
-// After
+// 0.10
 #[derive(SystemParam)]
 struct MessageWriter<'w> {
     events: EventWriter<'w, Message>,
@@ -167,7 +163,7 @@ fn clear_events(mut reader: EventReader<SomeEvent>) {
     <div class="migration-guide-area-tag">ECS</div>
 </div>
 
-- `MutUntyped::into_inner` now marks things as changed.
+`MutUntyped::into_inner` now marks things as changed.
 
 ### [Extend EntityLocation with TableId and TableRow](https://github.com/bevyengine/bevy/pull/6681)
 
@@ -196,7 +192,7 @@ The traits `SystemParamState` and `SystemParamFetch` have been removed, and thei
 The trait `ReadOnlySystemParamFetch` has been replaced with `ReadOnlySystemParam`.
 
 ```rust
-// Before (0.9)
+// 0.9 (0.9)
 impl SystemParam for MyParam<'_, '_> {
     type State = MyParamState;
 }
@@ -209,7 +205,7 @@ unsafe impl<'w, 's> SystemParamFetch<'w, 's> for MyParamState {
 }
 unsafe impl ReadOnlySystemParamFetch for MyParamState { }
 
-// After (0.10)
+// 0.10 (0.10)
 unsafe impl SystemParam for MyParam<'_, '_> {
     type State = MyParamState;
     type Item<'w, 's> = MyParam<'w, 's>;
@@ -233,7 +229,7 @@ Normal resources and `NonSend` resources no longer share the same backing storag
     <div class="migration-guide-area-tag">ECS</div>
 </div>
 
-- Safety invariants on `bevy_ptr` types’ `new` `byte_add` and `byte_offset` methods have been changed. All callers should re-audit for soundness.
+Safety invariants on `bevy_ptr` types’ `new` `byte_add` and `byte_offset` methods have been changed. All callers should re-audit for soundness.
 
 ### [Basic adaptive batching for parallel query iteration](https://github.com/bevyengine/bevy/pull/4777)
 
@@ -243,19 +239,15 @@ Normal resources and `NonSend` resources no longer share the same backing storag
 
 The `batch_size` parameter for `Query(State)::par_for_each(_mut)` has been removed. These calls will automatically compute a batch size for you. Remove these parameters from all calls to these functions.
 
-Before:
-
 ```rust
+// 0.9
 fn parallel_system(query: Query<&MyComponent>) {
    query.par_for_each(32, |comp| {
         ...
    });
 }
-```
 
-After:
-
-```rust
+// 0.10
 fn parallel_system(query: Query<&MyComponent>) {
    query.par_iter().for_each(|comp| {
         ...
@@ -268,11 +260,12 @@ fn parallel_system(query: Query<&MyComponent>) {
 <div class="migration-guide-area-tags">
     <div class="migration-guide-area-tag">ECS</div>
 </div>
+
 - Added `Components::resource_id`.
 - Changed `World::init_resource` to return the generated `ComponentId`.
 - Changed `World::init_non_send_resource` to return the generated `ComponentId`.
 
-### [add `UnsafeWorldCell` abstraction](https://github.com/bevyengine/bevy/pull/6404)
+### [Add `UnsafeWorldCell` abstraction](https://github.com/bevyengine/bevy/pull/6404)
 
 <div class="migration-guide-area-tags">
     <div class="migration-guide-area-tag">ECS</div>
@@ -303,7 +296,7 @@ The type UnsafeWorldCellEntityRef has been renamed to UnsafeEntityCell
     <div class="migration-guide-area-tag">ECS</div>
 </div>
 
-- Replace usages of `Tick::is_older_than` with `Tick::is_newer_than`.
+Replace usages of `Tick::is_older_than` with `Tick::is_newer_than`.
 
 ### [Cleanup system sets called labels](https://github.com/bevyengine/bevy/pull/7678)
 
@@ -322,14 +315,14 @@ The type UnsafeWorldCellEntityRef has been renamed to UnsafeEntityCell
 For the `SystemParamFunction` trait, the type parameters `In`, `Out`, and `Param` have been turned into associated types.
 
 ```rust
-// Before
+// 0.9
 fn my_generic_system<T, In, Out, Param, Marker>(system_function: T)
 where
     T: SystemParamFunction<In, Out, Param, Marker>,
     T: Param: SystemParam,
 { ... }
 
-// After
+// 0.10
 fn my_generic_system<T, Marker>(system_function: T)
 where
     T: SystemParamFunction<Marker>,
@@ -340,14 +333,14 @@ For the `ExclusiveSystemParamFunction` trait, the type parameter `Param` has bee
 Also, `In` and `Out` associated types have been added, since exclusive systems now support system piping.
 
 ```rust
-// Before
+// 0.9
 fn my_exclusive_system<T, Param, Marker>(system_function: T)
 where
     T: ExclusiveSystemParamFunction<Param, Marker>,
     T: Param: ExclusiveSystemParam,
 { ... }
 
-// After
+// 0.10
 fn my_exclusive_system<T, Marker>(system_function: T)
 where
     T: ExclusiveSystemParamFunction<Marker>,
@@ -363,7 +356,7 @@ where
 `ChangeTrackers<T>` has been deprecated, and will be removed in the next release. Any usage should be replaced with `Ref<T>`.
 
 ```rust
-// Before (0.9)
+// 0.9 (0.9)
 fn my_system(q: Query<(&MyComponent, ChangeTrackers<MyComponent>)>) {
     for (value, trackers) in &q {
         if trackers.is_changed() {
@@ -372,7 +365,7 @@ fn my_system(q: Query<(&MyComponent, ChangeTrackers<MyComponent>)>) {
     }
 }
 
-// After (0.10)
+// 0.10 (0.10)
 fn my_system(q: Query<Ref<MyComponent>>) {
     for value in &q {
         if value.is_changed() {
@@ -396,9 +389,8 @@ fn my_system(q: Query<Ref<MyComponent>>) {
     <div class="migration-guide-area-tag">ECS</div>
 </div>
 
-Before
-
 ```rust
+// 0.9
 fn clear_children(parent: Entity, world: &mut World) {
     if let Some(children) = world.entity_mut(parent).remove::<Children>() {
         for &child in &children.0 {
@@ -406,11 +398,8 @@ fn clear_children(parent: Entity, world: &mut World) {
         }
     }
 }
-```
 
-After
-
-```rust
+// 0.10
 fn clear_children(parent: Entity, world: &mut World) {
     if let Some(children) = world.entity_mut(parent).take::<Children>() {
         for &child in &children.0 {
@@ -427,7 +416,7 @@ fn clear_children(parent: Entity, world: &mut World) {
     <div class="migration-guide-area-tag">Reflection</div>
 </div>
 
-- Call `World::entity` before calling into the changed `ReflectComponent` methods, most likely user already has a `EntityRef` or `EntityMut` which was being queried redundantly.
+Call `World::entity` before calling into the changed `ReflectComponent` methods, most likely user already has a `EntityRef` or `EntityMut` which was being queried redundantly.
 
 ### [Allow iterating over with EntityRef over the entire World](https://github.com/bevyengine/bevy/pull/6843)
 
@@ -453,15 +442,15 @@ You can edit the hierarchy via `EntityMut` instead.
     <div class="migration-guide-area-tag">Meta</div>
 </div>
 
-- `dynamic` feature was renamed to `dynamic_linking`
+`dynamic` feature was renamed to `dynamic_linking`
 
-### [reflect: add `insert` and `remove` methods to `List`](https://github.com/bevyengine/bevy/pull/7063)
+### [bevy_reflect: add `insert` and `remove` methods to `List`](https://github.com/bevyengine/bevy/pull/7063)
 
 <div class="migration-guide-area-tags">
     <div class="migration-guide-area-tag">Reflection</div>
 </div>
 
-- Manual implementors of `List` need to implement the new methods `insert` and `remove` and
+Manual implementors of `List` need to implement the new methods `insert` and `remove` and
 consider whether to use the new default implementation of `push` and `pop`.
 
 ### [bevy_reflect: Decouple `List` and `Array` traits](https://github.com/bevyengine/bevy/pull/7467)
@@ -473,7 +462,7 @@ consider whether to use the new default implementation of `push` and `pop`.
 The `List` trait is no longer dependent on `Array`. Implementors of `List` can remove the `Array` impl and move its methods into the `List` impl (with only a couple tweaks).
 
 ```rust
-// BEFORE
+// 0.9
 impl Array for Foo {
   fn get(&self, index: usize) -> Option<&dyn Reflect> {/* ... */}
   fn get_mut(&mut self, index: usize) -> Option<&mut dyn Reflect> {/* ... */}
@@ -492,7 +481,7 @@ impl List for Foo {
   fn clone_dynamic(&self) -> DynamicList {/* ... */}
 }
 
-// AFTER
+// 0.10
 impl List for Foo {
   fn get(&self, index: usize) -> Option<&dyn Reflect> {/* ... */}
   fn get_mut(&mut self, index: usize) -> Option<&mut dyn Reflect> {/* ... */}
@@ -525,11 +514,11 @@ This PR removes `ReflectSerialize` and `ReflectDeserialize` registrations from m
 This also means that some serialized glam types will need to be updated. For example, here is `Affine3A`:
 
 ```rust
-// BEFORE
+// 0.9
 (
   "glam::f32::affine3a::Affine3A": (1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0),
 
-// AFTER
+// 0.10
   "glam::f32::affine3a::Affine3A": (
     matrix3: (
       x_axis: (
@@ -563,7 +552,7 @@ This also means that some serialized glam types will need to be updated. For exa
     <div class="migration-guide-area-tag">Rendering</div>
 </div>
 
-- Rename `ScalingMode::Auto` to `ScalingMode::AutoMin` if you are using it.
+Rename `ScalingMode::Auto` to `ScalingMode::AutoMin`.
 
 ### [Change `From<Icosphere>` to `TryFrom<Icosphere>`](https://github.com/bevyengine/bevy/pull/6484)
 
@@ -609,7 +598,7 @@ For cases where the option was handled, use `get_input_node` instead.
 - replace `shader_defs.push(String::from("NAME"));` by `shader_defs.push("NAME".into());`
 - if you used shader def `NO_STORAGE_BUFFERS_SUPPORT`, check how `AVAILABLE_STORAGE_BUFFER_BINDINGS` is now used in [Bevy default shaders](https://github.com/bevyengine/bevy/blob/3ec87e49ca49767fad658e72fbae353f6687198c/crates/bevy_pbr/src/render/mesh_view_bindings.wgsl#L28)
 
-### [get pixel size from wgpu](https://github.com/bevyengine/bevy/pull/6820)
+### [Get pixel size from wgpu](https://github.com/bevyengine/bevy/pull/6820)
 
 <div class="migration-guide-area-tags">
     <div class="migration-guide-area-tag">Rendering</div>
@@ -617,7 +606,7 @@ For cases where the option was handled, use `get_input_node` instead.
 
 `PixelInfo` has been removed. `PixelInfo::components` is equivalent to `texture_format.describe().components`. `PixelInfo::type_size` can be gotten from `texture_format.describe().block_size/ texture_format.describe().components`. But note this can yield incorrect results for some texture types like Rg11b10Float.
 
-### [run clear trackers on render world](https://github.com/bevyengine/bevy/pull/6878)
+### [Run clear trackers on render world](https://github.com/bevyengine/bevy/pull/6878)
 
 <div class="migration-guide-area-tags">
     <div class="migration-guide-area-tag">Rendering</div>
@@ -631,7 +620,7 @@ The call to `clear_trackers` in `App` has been moved from the schedule to `App::
     <div class="migration-guide-area-tag">Rendering</div>
 </div>
 
-- Rename `priority` to `order` in usage of `Camera`.
+Rename `priority` to `order` in usage of `Camera`.
 
 ### [enum `Visibility` component](https://github.com/bevyengine/bevy/pull/6320)
 
@@ -672,7 +661,7 @@ render_context.begin_tracked_render_pass(RenderPassDescriptor {
     <div class="migration-guide-area-tag">Rendering</div>
 </div>
 
-- Most usages of `resource_mut::<PipelineCache>` and `ResMut<PipelineCache>` can be changed to `resource::<PipelineCache>` and `Res<PipelineCache>` as long as they don’t use any methods requiring mutability - the only public method requiring it is `process_queue`.
+Most usages of `resource_mut::<PipelineCache>` and `ResMut<PipelineCache>` can be changed to `resource::<PipelineCache>` and `Res<PipelineCache>` as long as they don’t use any methods requiring mutability - the only public method requiring it is `process_queue`.
 
 ### [Changed Msaa to Enum](https://github.com/bevyengine/bevy/pull/7292)
 
@@ -681,12 +670,14 @@ render_context.begin_tracked_render_pass(RenderPassDescriptor {
 </div>
 
 ```rust
+// 0.9
 let multi = Msaa { samples: 4 }
-// is now
+// 0.10
 let multi = Msaa::Sample4
 
+// 0.9
 multi.samples
-// is now
+// 0.10
 multi.samples()
 ```
 
@@ -714,13 +705,13 @@ multi.samples()
 
 - Change `ScalingMode::WindowSize` to `ScalingMode::WindowSize(1.0)`
 
-### [Changed &mut PipelineCache to &PipelineCache](https://github.com/bevyengine/bevy/pull/7598)
+### [Changed `&mut PipelineCache` to `&PipelineCache`](https://github.com/bevyengine/bevy/pull/7598)
 
 <div class="migration-guide-area-tags">
     <div class="migration-guide-area-tag">Rendering</div>
 </div>
 
-- `SpecializedComputePipelines::specialize` now takes a `&PipelineCache` instead of a `&mut PipelineCache`
+`SpecializedComputePipelines::specialize` now takes a `&PipelineCache` instead of a `&mut PipelineCache`
 
 ### [Introduce detailed_trace macro, use in TrackedRenderPass](https://github.com/bevyengine/bevy/pull/7639)
 
@@ -728,15 +719,15 @@ multi.samples()
     <div class="migration-guide-area-tag">Rendering</div>
 </div>
 
-- Some detailed bevy trace events now require the use of the cargo feature `detailed_trace` in addition to enabling `TRACE` level logging to view. Should you wish to see these logs, please compile your code with the bevy feature `detailed_trace`. Currently, the only logs that are affected are the renderer logs pertaining to `TrackedRenderPass` functions
+Some detailed bevy trace events now require the use of the cargo feature `detailed_trace` in addition to enabling `TRACE` level logging to view. Should you wish to see these logs, please compile your code with the bevy feature `detailed_trace`. Currently, the only logs that are affected are the renderer logs pertaining to `TrackedRenderPass` functions
 
-### [added subdivisions to shape::Plane](https://github.com/bevyengine/bevy/pull/7546)
+### [Added subdivisions to shape::Plane](https://github.com/bevyengine/bevy/pull/7546)
 
 <div class="migration-guide-area-tags">
     <div class="migration-guide-area-tag">Rendering</div>
 </div>
 
-- `shape::Plane` now takes an additional `subdivisions` parameter so users should provide it or use the new `shape::Plane::from_size`.
+`shape::Plane` now takes an additional `subdivisions` parameter so users should provide it or use the new `shape::Plane::from_size()`.
 
 ### [Change standard material defaults and update docs](https://github.com/bevyengine/bevy/pull/7664)
 
@@ -782,7 +773,7 @@ No api changes are required, but it's possible that your gltf meshes look differ
 
 The `FrameCount`  resource was previously only updated when using the `bevy_render` feature. If you are not using this feature but still want the `FrameCount` it will now be updated correctly.
 
-### [Migrate engine to Schedule v3](https://github.com/bevyengine/bevy/pull/7267)
+### [Migrate engine to Schedule v3 (stageless)](https://github.com/bevyengine/bevy/pull/7267)
 
 <div class="migration-guide-area-tags">
     <div class="migration-guide-area-tag">Rendering</div>
@@ -840,7 +831,7 @@ This was changed to enable pipelined rendering. If this breaks your use case ple
     <div class="migration-guide-area-tag">UI</div>
 </div>
 
-- The `background_color` field of `ExtractedUiNode` is now named `color`.
+The `background_color` field of `ExtractedUiNode` is now named `color`.
 
 ### [Remove the `GlobalTransform::translation_mut` method](https://github.com/bevyengine/bevy/pull/7134)
 
@@ -881,7 +872,7 @@ TextError::ExceedMaxTextAtlases(usize)` was never thrown so if you were matching
     <div class="migration-guide-area-tag">UI</div>
 </div>
 
-- `FocusPolicy` default has changed from `FocusPolicy::Block` to `FocusPolicy::Pass`
+`FocusPolicy` default has changed from `FocusPolicy::Block` to `FocusPolicy::Pass`
 
 ### [Remove VerticalAlign from TextAlignment](https://github.com/bevyengine/bevy/pull/6807)
 
@@ -912,7 +903,7 @@ __Changes for `Text2dBundle`__
 
 `QueuedText` was never meant to be user facing. If you relied on it, please make an issue.
 
-### [change the default `width` and `height` of `Size` to `Val::Auto`](https://github.com/bevyengine/bevy/pull/7475)
+### [Change the default `width` and `height` of `Size` to `Val::Auto`](https://github.com/bevyengine/bevy/pull/7475)
 
 <div class="migration-guide-area-tags">
     <div class="migration-guide-area-tag">UI</div>
@@ -936,7 +927,7 @@ The `Size::height` constructor function now sets the `width` to `Val::Auto` inst
     <div class="migration-guide-area-tag">UI</div>
 </div>
 
-- The size field of `CalculatedSize` has been changed to a `Vec2`.
+The size field of `CalculatedSize` has been changed to a `Vec2`.
 
 ### [Windows as Entities](https://github.com/bevyengine/bevy/pull/5589)
 
@@ -960,7 +951,7 @@ let window = commands.spawn(Window { ... }).id(); // open window
 commands.entity(window).despawn(); // close window
 ```
 
-Now that windows are components on entity, you should use `Query` instead of `Res` to access windows.
+- To get a window, you now need to use a `Query` instead of a `Res`
 
 ```rust
 // 0.9
@@ -980,36 +971,32 @@ fn count_pixels(primary_query: Query<&Window, With<PrimaryWindow>>) {
 }
 ```
 
-### [update winit to 0.28](https://github.com/bevyengine/bevy/pull/7480)
+### [Update winit to 0.28](https://github.com/bevyengine/bevy/pull/7480)
 
 <div class="migration-guide-area-tags">
     <div class="migration-guide-area-tag">Windowing</div>
 </div>
 
-before:
-
 ```rust
-    app.new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                always_on_top: true,
-                ..default()
-            }),
+// 0.9
+app.new()
+    .add_plugins(DefaultPlugins.set(WindowPlugin {
+        primary_window: Some(Window {
+            always_on_top: true,
             ..default()
-        }));
-```
+        }),
+        ..default()
+    }));
 
-after:
-
-```rust
-    app.new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                window_level: bevy::window::WindowLevel::AlwaysOnTop,
-                ..default()
-            }),
+// 0.9
+app.new()
+    .add_plugins(DefaultPlugins.set(WindowPlugin {
+        primary_window: Some(Window {
+            window_level: bevy::window::WindowLevel::AlwaysOnTop,
             ..default()
-        }));
+        }),
+        ..default()
+    }));
 ```
 
 </div>

--- a/content/learn/book/migration-guides/0.9-0.10/_index.md
+++ b/content/learn/book/migration-guides/0.9-0.10/_index.md
@@ -800,7 +800,6 @@ The `FrameCount`  resource was previously only updated when using the `bevy_rend
 
 Apps may now only have one unified fixed timestep. If you were relying on this functionality, you should swap to using timers, via the `on_timer(MY_PERIOD)` run condition.
 
-
 ### [Pipelined Rendering](https://github.com/bevyengine/bevy/pull/6503)
 
 <div class="migration-guide-area-tags">

--- a/content/learn/book/migration-guides/0.9-0.10/_index.md
+++ b/content/learn/book/migration-guides/0.9-0.10/_index.md
@@ -796,6 +796,10 @@ The `FrameCount`  resource was previously only updated when using the `bevy_rend
 - States have been dramatically simplified: there is no longer a “state stack”. To queue a transition to the next state, call `NextState::set`
 - Strings can no longer be used as a `SystemLabel` or `SystemSet`. Use a type, or use the system function instead.
 
+#### Multiple fixed timesteps
+
+Only one fixed timestep is supported. If you were relying on this functionality, you should swap to using timers, via the on_timer(MY_PERIOD) run condition.
+
 ### [Pipelined Rendering](https://github.com/bevyengine/bevy/pull/6503)
 
 <div class="migration-guide-area-tags">

--- a/content/learn/book/migration-guides/0.9-0.10/_index.md
+++ b/content/learn/book/migration-guides/0.9-0.10/_index.md
@@ -831,7 +831,7 @@ This was changed to enable pipelined rendering. If this breaks your use case ple
     <div class="migration-guide-area-tag">UI</div>
 </div>
 
-`ImageNode` never worked, if you were using it please create an issue.
+`ImageMode` never worked, if you were using it please create an issue.
 
 ### [Rename the `background_color` of 'ExtractedUiNode` to `color`](https://github.com/bevyengine/bevy/pull/7452)
 
@@ -901,6 +901,7 @@ __Changes for `Text2dBundle`__
 
 `Text2dBundle` has a new field ‘text_anchor’ that takes an `Anchor` component that controls its position relative to its transform.
 
+`Text2dSize` was removed. Use `TextLayoutInfo` instead.
 `Text2dSize` was removed. Use `TextLayoutInfo` instead.
 
 ### [Remove `QueuedText`](https://github.com/bevyengine/bevy/pull/7414)

--- a/content/learn/book/migration-guides/0.9-0.10/_index.md
+++ b/content/learn/book/migration-guides/0.9-0.10/_index.md
@@ -1,0 +1,473 @@
++++
+title = "0.9 to 0.10"
+weight = 6
+sort_by = "weight"
+template = "book-section.html"
+page_template = "book-section.html"
+insert_anchor_links = "right"
+[extra]
+long_title = "Migration Guide: 0.9 to 0.10"
++++
+
+Bevy relies heavily on improvements in the Rust language and compiler.
+As a result, the Minimum Supported Rust Version (MSRV) is "the latest stable release" of Rust.
+
+### [Replace `RemovedComponents<T>` backing with `Events<Entity>`](https://github.com/bevyengine/bevy/pull/5680)
+
+* Add a `mut` for `removed: RemovedComponents<T>` since we are now modifying an event reader internally.
+* Iterating over removed components now requires `&mut removed_components` or `removed_components.iter()` instead of `&removed_components`.
+
+### [Remove `ExclusiveSystemParam::apply`](https://github.com/bevyengine/bevy/pull/7489)
+
+_Note for maintainers: this migration guide makes more sense if it’s placed above the one for #6919._
+
+The trait method `ExclusiveSystemParamState::apply` has been removed. If you have an exclusive system with buffers that must be applied, you should apply them within the body of the exclusive system.
+
+### [update winit to 0.28](https://github.com/bevyengine/bevy/pull/7480)
+
+before:
+
+```rust
+    app.new()
+        .add_plugins(DefaultPlugins.set(WindowPlugin {
+            primary_window: Some(Window {
+                always_on_top: true,
+                ..default()
+            }),
+            ..default()
+        }));
+```
+
+after:
+
+```rust
+    app.new()
+        .add_plugins(DefaultPlugins.set(WindowPlugin {
+            primary_window: Some(Window {
+                window_level: bevy::window::WindowLevel::AlwaysOnTop,
+                ..default()
+            }),
+            ..default()
+        }));
+```
+
+### [bevy_ecs: ReflectComponentFns without World](https://github.com/bevyengine/bevy/pull/7206)
+
+* Call `World::entity` before calling into the changed `ReflectComponent` methods, most likely user already has a `EntityRef` or `EntityMut` which was being queried redundantly.
+
+### [change the default `width` and `height` of `Size` to `Val::Auto`](https://github.com/bevyengine/bevy/pull/7475)
+
+The default values for `Size` `width` and `height` have been changed from `Val::Undefined` to `Val::Auto`.
+It’s unlikely to cause any issues with existing code.
+
+### [Rename the `background_color` of 'ExtractedUiNode` to `color`](https://github.com/bevyengine/bevy/pull/7452)
+
+* The `background_color` field of `ExtractedUiNode` is now named `color`.
+
+### [Remove `QueuedText`](https://github.com/bevyengine/bevy/pull/7414)
+
+<!-- TODO -->
+
+### [add `UnsafeWorldCell` abstraction](https://github.com/bevyengine/bevy/pull/6404)
+
+<!-- TODO -->
+
+### [Remove App::add_sub_app](https://github.com/bevyengine/bevy/pull/7290)
+
+`App::add_sub_app` has been removed in favor of `App::insert_sub_app`. Use `SubApp::new` and insert it via `App::add_sub_app`
+
+Old:
+
+```rust
+let mut sub_app = App::new()
+// Build subapp here
+app.add_sub_app(MySubAppLabel, sub_app);
+```
+
+New:
+
+```rust
+let mut sub_app = App::new()
+// Build subapp here
+app.insert_sub_app(MySubAppLabel, SubApp::new(sub_app, extract_fn));
+```
+
+### [Rename dynamic feature](https://github.com/bevyengine/bevy/pull/7340)
+
+* `dynamic` feature was renamed to `dynamic_linking`
+
+### [bevy_reflect: Pre-parsed paths](https://github.com/bevyengine/bevy/pull/7321)
+
+`GetPath` methods have been renamed according to the following:
+
+* `path` -> `reflect_path`
+* `path_mut` -> `reflect_path_mut`
+* `get_path` -> `path`
+* `get_path_mut` -> `path_mut`
+
+### [Allow not preventing default event behaviors on wasm](https://github.com/bevyengine/bevy/pull/7304)
+
+<!-- TODO -->
+
+### [Support recording multiple CommandBuffers in RenderContext](https://github.com/bevyengine/bevy/pull/7248)
+
+`RenderContext`’s fields are now private. Use the accessors on `RenderContext` instead, and construct it with `RenderContext::new`.
+
+### [Added `resource_id` and changed `init_resource` and `init_non_send_resource` to return `ComponentId`](https://github.com/bevyengine/bevy/pull/7284)
+
+<!-- TODO -->
+
+### [Changed Msaa to Enum](https://github.com/bevyengine/bevy/pull/7292)
+
+```rust
+let multi = Msaa { samples: 4 }
+// is now
+let multi = Msaa::Sample4
+
+multi.samples
+// is now
+multi.samples()
+```
+
+### [Basic adaptive batching for parallel query iteration](https://github.com/bevyengine/bevy/pull/4777)
+
+The `batch_size` parameter for `Query(State)::par_for_each(_mut)` has been removed. These calls will automatically compute a batch size for you. Remove these parameters from all calls to these functions.
+
+Before:
+
+```rust
+fn parallel_system(query: Query<&MyComponent>) {
+   query.par_for_each(32, |comp| {
+        ...
+   });
+}
+```
+
+After:
+
+```rust
+fn parallel_system(query: Query<&MyComponent>) {
+   query.par_iter().for_each(|comp| {
+        ...
+   });
+}
+```
+
+### [Pipelined Rendering](https://github.com/bevyengine/bevy/pull/6503)
+
+### [Windows as Entities](https://github.com/bevyengine/bevy/pull/5589)
+
+* Replace `WindowDescriptor` with `Window`.
+* Change `width` and `height` fields in a `WindowResolution`, either by doing
+
+```rust
+WindowResolution::new(width, height) // Explicitly
+// or using From<_> for tuples for convenience
+(1920., 1080.).into()
+```
+
+* Replace any `WindowCommand` code to just modify the `Window`’s fields directly  and creating/closing windows is now by spawning/despawning an entity with a `Window` component like so:
+
+```rust
+let window = commands.spawn(Window { ... }).id(); // open window
+commands.entity(window).despawn(); // close window
+```
+
+### [Remove VerticalAlign from TextAlignment](https://github.com/bevyengine/bevy/pull/6807)
+
+The `alignment` field of `Text` now only affects the text’s internal alignment.
+
+### [Make PipelineCache internally mutable.](https://github.com/bevyengine/bevy/pull/7205)
+
+* Most usages of `resource_mut::<PipelineCache>` and `ResMut<PipelineCache>` can be changed to `resource::<PipelineCache>` and `Res<PipelineCache>` as long as they don’t use any methods requiring mutability - the only public method requiring it is `process_queue`.
+
+### [Support piping exclusive systems](https://github.com/bevyengine/bevy/pull/7023)
+
+Exclusive systems (systems that access `&mut World`) now support system piping, so the `ExclusiveSystemParamFunction` trait now has generics for the `In`put and `Out`put types.
+
+```rust
+// Before
+fn my_generic_system<T, Param>(system_function: T)
+where T: ExclusiveSystemParamFunction<Param>
+{ ... }
+
+// After
+fn my_generic_system<T, In, Out, Param>(system_function: T)
+where T: ExclusiveSystemParamFunction<In, Out, Param>
+{ ... }
+```
+
+### [Change default FocusPolicy to Pass](https://github.com/bevyengine/bevy/pull/7161)
+
+* `FocusPolicy` default has changed from `FocusPolicy::Block` to `FocusPolicy::Pass`
+
+### [Document alignment requirements of `Ptr`, `PtrMut` and `OwningPtr`](https://github.com/bevyengine/bevy/pull/7151)
+
+* Safety invariants on `bevy_ptr` types’ `new` `byte_add` and `byte_offset` methods have been changed. All callers should re-audit for soundness.
+
+### [Remove the `GlobalTransform::translation_mut` method](https://github.com/bevyengine/bevy/pull/7134)
+
+`GlobalTransform::translation_mut` has been removed without alternative,
+if you were relying on this, update the `Transform` instead. If the given entity
+had children or parent, you may need to remove its parent to make its transform
+independent (in which case the new `Commands::set_parent_in_place` and
+`Commands::remove_parent_in_place` may be of interest)
+
+Bevy may add in the future a way to toggle transform propagation on
+an entity basis.
+
+### [Panic on dropping NonSend in non-origin thread.](https://github.com/bevyengine/bevy/pull/6534)
+
+Normal resources and `NonSend` resources no longer share the same backing storage. If `R: Resource`, then `NonSend<R>` and `Res<R>` will return different instances from each other. If you are using both `Res<T>` and `NonSend<T>` (or their mutable variants), to fetch the same resources, it’s strongly advised to use `Res<T>`.
+
+### [reflect: add `insert` and `remove` methods to `List`](https://github.com/bevyengine/bevy/pull/7063)
+
+* Manual implementors of `List` need to implement the new methods `insert` and `remove` and
+consider whether to use the new default implementation of `push` and `pop`.
+
+### [Reduce branching in TrackedRenderPass](https://github.com/bevyengine/bevy/pull/7053)
+
+TODO
+
+### [Remove the `SystemParamState` trait and remove types like `ResState`](https://github.com/bevyengine/bevy/pull/6919)
+
+Note: this replaces the migration guide for #6865.
+This is relative to Bevy 0.9, not main.
+
+The traits `SystemParamState` and `SystemParamFetch` have been removed, and their functionality has been transferred to `SystemParam`.
+
+```rust
+// Before (0.9)
+impl SystemParam for MyParam<'_, '_> {
+    type State = MyParamState;
+}
+unsafe impl SystemParamState for MyParamState {
+    fn init(world: &mut World, system_meta: &mut SystemMeta) -> Self { ... }
+}
+unsafe impl<'w, 's> SystemParamFetch<'w, 's> for MyParamState {
+    type Item = MyParam<'w, 's>;
+    fn get_param(&mut self, ...) -> Self::Item;
+}
+unsafe impl ReadOnlySystemParamFetch for MyParamState { }
+
+// After (0.10)
+unsafe impl SystemParam for MyParam<'_, '_> {
+    type State = MyParamState;
+    type Item<'w, 's> = MyParam<'w, 's>;
+    fn init_state(world: &mut World, system_meta: &mut SystemMeta) -> Self::State { ... }
+    fn get_param<'w, 's>(state: &mut Self::State, ...) -> Self::Item<'w, 's>;
+}
+unsafe impl ReadOnlySystemParam for MyParam<'_, '_> { }
+```
+
+The trait `ReadOnlySystemParamFetch` has been replaced with `ReadOnlySystemParam`.
+
+```rust
+// Before
+unsafe impl ReadOnlySystemParamFetch for MyParamState {}
+
+// After
+unsafe impl ReadOnlySystemParam for MyParam<'_, '_> {}
+```
+
+### [Break `CorePlugin` into `TaskPoolPlugin`, `TypeRegistrationPlugin`, `FrameCountPlugin`.](https://github.com/bevyengine/bevy/pull/7083)
+
+* `CorePlugin` broken into separate plugins.  If not using `DefaultPlugins` or `MinimalPlugins` `PluginGroup`s, the replacement for `CorePlugin` is now to add `TaskPoolPlugin`, `TypeRegistrationPlugin`, and `FrameCountPlugin` to the app.
+
+### [asset: make HandleUntyped::id private](https://github.com/bevyengine/bevy/pull/7076)
+
+* Instead of directly accessing the ID of a `HandleUntyped` as `handle.id`, use the new getter `handle.id()`.
+
+### [Extend EntityLocation with TableId and TableRow](https://github.com/bevyengine/bevy/pull/6681)
+
+A `World` can only hold a maximum of 232 - 1 archetypes and tables now. If your use case requires more than this, please file an issue explaining your use case.
+
+### [Round out the untyped api s](https://github.com/bevyengine/bevy/pull/7009)
+
+* `MutUntyped::into_inner` now marks things as changed.
+
+### [Rename camera "priority" to "order"](https://github.com/bevyengine/bevy/pull/6908)
+
+<!-- TODO -->
+
+### [enum `Visibility` component](https://github.com/bevyengine/bevy/pull/6320)
+
+* evaluation of the `visibility.is_visible` field should now check for `visibility == Visibility::Inherited`.
+* setting the `visibility.is_visible` field should now directly set the value: `*visibility = Visibility::Inherited`.
+* usage of `Visibility::VISIBLE` or `Visibility::INVISIBLE` should now use `Visibility::Inherited` or `Visibility::Hidden` respectively.
+* `ComputedVisibility::INVISIBLE` and `SpatialBundle::VISIBLE_IDENTITY` have been renamed to `ComputedVisibility::HIDDEN` and `SpatialBundle::INHERITED_IDENTITY` respectively.
+
+### [Directly extract joints into SkinnedMeshJoints](https://github.com/bevyengine/bevy/pull/6833)
+
+`ExtractedJoints` has been removed. Read the bound bones from `SkinnedMeshJoints` instead.
+
+### [Move system_commands spans into apply_buffers](https://github.com/bevyengine/bevy/pull/6900)
+
+<!-- TODO -->
+
+### [run clear trackers on render world](https://github.com/bevyengine/bevy/pull/6878)
+
+The call to `clear_trackers` in `App` has been moved from the schedule to App::update for the main world and calls to `clear_trackers` have been added for sub_apps in the same function. This was due to needing stronger guarantees. If clear_trackers isn’t called on a world it can lead to memory leaks in `RemovedComponents`.
+
+### [Simplify trait hierarchy for `SystemParam`](https://github.com/bevyengine/bevy/pull/6865)
+
+_Merged with the guide for #6919._
+
+### [get pixel size from wgpu](https://github.com/bevyengine/bevy/pull/6820)
+
+`PixelInfo` has been removed. `PixelInfo::components` is equivalent to `texture_format.describe().components`. `PixelInfo::type_size` can be gotten from `texture_format.describe().block_size/ texture_format.describe().components`. But note this can yield incorrect results for some texture types like Rg11b10Float.
+
+### [Newtype ArchetypeRow and TableRow](https://github.com/bevyengine/bevy/pull/4878)
+
+<!-- TODO -->
+
+### [Remove `TextError::ExceedMaxTextAtlases(usize)` variant](https://github.com/bevyengine/bevy/pull/6796)
+
+<!-- TODO -->
+
+### [Borrow instead of consuming in `EventReader::clear`](https://github.com/bevyengine/bevy/pull/6851)
+
+`EventReader::clear` now takes a mutable reference instead of consuming the event reader. This means that `clear` now needs explicit mutable access to the reader variable, which previously could have been omitted in some cases:
+
+```rust
+// Old (0.9)
+fn clear_events(reader: EventReader<SomeEvent>) {
+  reader.clear();
+}
+
+// New (0.10)
+fn clear_events(mut reader: EventReader<SomeEvent>) {
+  reader.clear();
+}
+```
+
+### [Allow iterating over with EntityRef over the entire World](https://github.com/bevyengine/bevy/pull/6843)
+
+<!-- TODO -->
+
+### [Make the `SystemParam` derive macro more flexible](https://github.com/bevyengine/bevy/pull/6694)
+
+The lifetime `'s` has been removed from `EventWriter`. Any code that explicitly specified the lifetimes for this type will need to be updated.
+
+```rust
+// Before
+#[derive(SystemParam)]
+struct MessageWriter<'w, 's> {
+    events: EventWriter<'w, 's, Message>,
+}
+
+// After
+#[derive(SystemParam)]
+struct MessageWriter<'w> {
+    events: EventWriter<'w, Message>,
+}
+```
+
+### [Intepret glTF colors as linear instead of sRGB](https://github.com/bevyengine/bevy/pull/6828)
+
+<!-- TODO -->
+
+### [Lock down access to Entities](https://github.com/bevyengine/bevy/pull/6740)
+
+<!-- TODO -->
+
+### [Document and lock down types in bevy_ecs::archetype](https://github.com/bevyengine/bevy/pull/6742)
+
+<!-- TODO -->
+
+### [bevy_reflect: Remove `ReflectSerialize` and `ReflectDeserialize` registrations from most glam types](https://github.com/bevyengine/bevy/pull/6580)
+
+This PR removes `ReflectSerialize` and `ReflectDeserialize` registrations from most glam types. This means any code relying on either of those type data existing for those glam types will need to not do that.
+
+This also means that some serialized glam types will need to be updated. For example, here is `Affine3A`:
+
+```rust
+// BEFORE
+(
+  "glam::f32::affine3a::Affine3A": (1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0),
+
+// AFTER
+  "glam::f32::affine3a::Affine3A": (
+    matrix3: (
+      x_axis: (
+        x: 1.0,
+        y: 0.0,
+        z: 0.0,
+      ),
+      y_axis: (
+        x: 0.0,
+        y: 1.0,
+        z: 0.0,
+      ),
+      z_axis: (
+        x: 0.0,
+        y: 0.0,
+        z: 1.0,
+      ),
+    ),
+    translation: (
+      x: 0.0,
+      y: 0.0,
+      z: 0.0,
+    ),
+  )
+)
+```
+
+### [Remove `BuildWorldChildren` impl from `WorldChildBuilder`](https://github.com/bevyengine/bevy/pull/6727)
+
+Hierarchy editing methods such as `with_children` and `push_children` have been removed from `WorldChildBuilder`.
+You can edit the hierarchy via `EntityMut` instead.
+
+### [Shader defs can now have a value](https://github.com/bevyengine/bevy/pull/5900)
+
+* replace `shader_defs.push(String::from("NAME"));` by `shader_defs.push("NAME".into());`
+* if you used shader def `NO_STORAGE_BUFFERS_SUPPORT`, check how `AVAILABLE_STORAGE_BUFFER_BINDINGS` is now used in Bevy default shaders
+
+### [Add try_* to add_slot_edge, add_node_edge](https://github.com/bevyengine/bevy/pull/6720)
+
+Remove `.unwrap()` from `add_node_edge` and `add_slot_edge`.
+For cases where the error was handled, use `try_add_node_edge` and `try_add_slot_edge` instead.
+
+Remove `.unwrap()` from `input_node`.
+For cases where the option was handled, use `get_input_node` instead.
+
+### [Parallelized transform propagation](https://github.com/bevyengine/bevy/pull/4775)
+
+<!-- TODO -->
+
+### [The `update_frame_count` system should be placed in CorePlugin](https://github.com/bevyengine/bevy/pull/6676)
+
+<!-- TODO -->
+
+### [Split Component Ticks](https://github.com/bevyengine/bevy/pull/6547)
+
+TODO
+
+### [Remove ImageMode](https://github.com/bevyengine/bevy/pull/6674)
+
+<!-- TODO -->
+
+### [Make spawn_dynamic return InstanceId](https://github.com/bevyengine/bevy/pull/6663)
+
+<!-- TODO -->
+
+### [Immutable sparse sets for metadata storage](https://github.com/bevyengine/bevy/pull/4928)
+
+`Table::component_capacity()` has been removed as Tables do not support adding/removing columns after construction.
+
+### [Remove redundant table and sparse set component IDs from Archetype](https://github.com/bevyengine/bevy/pull/4927)
+
+Do I still need to do this? I really hope people were not relying on the public facing APIs changed here.
+
+### [Add AutoMax next to ScalingMode::AutoMin](https://github.com/bevyengine/bevy/pull/6496)
+
+just rename `ScalingMode::Auto` to `ScalingMode::AutoMin` if you are using it.
+
+### [Change `From<Icosphere>` to `TryFrom<Icosphere>`](https://github.com/bevyengine/bevy/pull/6484)
+
+<!-- TODO -->
+
+### [Flip UI image](https://github.com/bevyengine/bevy/pull/6292)
+
+<!-- TODO -->

--- a/content/learn/book/migration-guides/0.9-0.10/_index.md
+++ b/content/learn/book/migration-guides/0.9-0.10/_index.md
@@ -199,7 +199,8 @@ A `World` can only hold a maximum of 2<sup>32</sup> - 1 archetypes and tables no
     <div class="migration-guide-area-tag">ECS</div>
 </div>
 
-Note: this replaces the migration guide for #6865. This is relative to Bevy 0.9, not main.
+Note: this replaces the migration guide for #6865.
+This is relative to Bevy 0.9, not main.
 
 The traits `SystemParamState` and `SystemParamFetch` have been removed, and their functionality has been transferred to `SystemParam`.
 
@@ -384,7 +385,8 @@ where
 { ... }
 ```
 
-For the `ExclusiveSystemParamFunction` trait, the type parameter `Param` has been turned into an associated type. Also, `In` and `Out` associated types have been added, since exclusive systems now support system piping.
+For the `ExclusiveSystemParamFunction` trait, the type parameter `Param` has been turned into an associated type.
+Also, `In` and `Out` associated types have been added, since exclusive systems now support system piping.
 
 ```rust
 // Before
@@ -442,7 +444,8 @@ where
     <div class="migration-guide-area-tag">Hierarchy</div>
 </div>
 
-Hierarchy editing methods such as `with_children` and `push_children` have been removed from `WorldChildBuilder`. You can edit the hierarchy via `EntityMut` instead.
+Hierarchy editing methods such as `with_children` and `push_children` have been removed from `WorldChildBuilder`.
+You can edit the hierarchy via `EntityMut` instead.
 
 ### [Rename dynamic feature](https://github.com/bevyengine/bevy/pull/7340)
 
@@ -583,9 +586,11 @@ just rename `ScalingMode::Auto` to `ScalingMode::AutoMin` if you are using it.
     <div class="migration-guide-area-tag">Rendering</div>
 </div>
 
-Remove `.unwrap()` from `add_node_edge` and `add_slot_edge`. For cases where the error was handled, use `try_add_node_edge` and `try_add_slot_edge` instead.
+Remove `.unwrap()` from `add_node_edge` and `add_slot_edge`.
+For cases where the error was handled, use `try_add_node_edge` and `try_add_slot_edge` instead.
 
-Remove `.unwrap()` from `input_node`. For cases where the option was handled, use `get_input_node` instead.
+Remove `.unwrap()` from `input_node`.
+For cases where the option was handled, use `get_input_node` instead.
 
 ### [Shader defs can now have a value](https://github.com/bevyengine/bevy/pull/5900)
 
@@ -723,7 +728,8 @@ multi.samples()
     <div class="migration-guide-area-tag">Rendering</div>
 </div>
 
-All the examples needed to be updated to initalize the subdivisions field. Also there were two tests in tests/window that need to be updated.
+All the examples needed to be updated to initalize the subdivisions field.
+Also there were two tests in tests/window that need to be updated.
 
 A user would have to update all their uses of shape::Plane to initalize the subdivisions field.
 
@@ -844,9 +850,14 @@ This was changed to enable pipelined rendering. If this breaks your use case ple
     <div class="migration-guide-area-tag">Hierarchy</div>
 </div>
 
-`GlobalTransform::translation_mut` has been removed without alternative, if you were relying on this, update the `Transform` instead. If the given entity had children or parent, you may need to remove its parent to make its transform independent (in which case the new `Commands::set_parent_in_place` and `Commands::remove_parent_in_place` may be of interest)
+`GlobalTransform::translation_mut` has been removed without alternative,
+if you were relying on this, update the `Transform` instead. If the given entity
+had children or parent, you may need to remove its parent to make its transform
+independent (in which case the new `Commands::set_parent_in_place` and
+`Commands::remove_parent_in_place` may be of interest)
 
-Bevy may add in the future a way to toggle transform propagation on an entity basis.
+Bevy may add in the future a way to toggle transform propagation on
+an entity basis.
 
 ### [Flip UI image](https://github.com/bevyengine/bevy/pull/6292)
 
@@ -904,7 +915,8 @@ __Changes for `Text2dBundle`__
     <div class="migration-guide-area-tag">UI</div>
 </div>
 
-The default values for `Size` `width` and `height` have been changed from `Val::Undefined` to `Val::Auto`. It’s unlikely to cause any issues with existing code.
+The default values for `Size` `width` and `height` have been changed from `Val::Undefined` to `Val::Auto`.
+It’s unlikely to cause any issues with existing code.
 
 ### [Fix the `Size` helper functions using the wrong default value and improve the UI examples](https://github.com/bevyengine/bevy/pull/7626)
 
@@ -912,7 +924,8 @@ The default values for `Size` `width` and `height` have been changed from `Val::
     <div class="migration-guide-area-tag">UI</div>
 </div>
 
-The `Size::width` constructor function now sets the `height` to `Val::Auto` instead of `Val::Undefined`. The `Size::height` constructor function now sets the `width` to `Val::Auto` instead of `Val::Undefined`.
+The `Size::width` constructor function now sets the `height` to `Val::Auto` instead of `Val::Undefined`.
+The `Size::height` constructor function now sets the `width` to `Val::Auto` instead of `Val::Undefined`.
 
 ### [The `size` field of `CalculatedSize` should not be a `Size`](https://github.com/bevyengine/bevy/pull/7641)
 

--- a/content/learn/book/migration-guides/0.9-0.10/_index.md
+++ b/content/learn/book/migration-guides/0.9-0.10/_index.md
@@ -411,6 +411,34 @@ where
 
 <!-- TODO -->
 
+### [Deprecate `ChangeTrackers<T>` in favor of `Ref<T>`](https://github.com/bevyengine/bevy/pull/7306)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
+
+`ChangeTrackers<T>` has been deprecated, and will be removed in the next release. Any usage should be replaced with `Ref<T>`.
+
+```rust
+// Before (0.9)
+fn my_system(q: Query<(&MyComponent, ChangeTrackers<MyComponent>)>) {
+    for (value, trackers) in &q {
+        if trackers.is_changed() {
+            // Do something with `value`.
+        }
+    }
+}
+
+// After (0.10)
+fn my_system(q: Query<Ref<MyComponent>>) {
+    for value in &q {
+        if value.is_changed() {
+            // Do something with `value`.
+        }
+    }
+}
+```
+
 ### [Move system_commands spans into apply_buffers](https://github.com/bevyengine/bevy/pull/6900)
 
 <div class="migration-guide-area-tags">

--- a/content/learn/book/migration-guides/0.9-0.10/_index.md
+++ b/content/learn/book/migration-guides/0.9-0.10/_index.md
@@ -15,6 +15,11 @@ As a result, the Minimum Supported Rust Version (MSRV) is "the latest stable rel
 
 ### [bevy_reflect: Pre-parsed paths](https://github.com/bevyengine/bevy/pull/7321)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Animation</div>
+    <div class="migration-guide-area-tag">Reflection</div>
+</div>
+
 `GetPath` methods have been renamed according to the following:
 
 - `path` -> `reflect_path`
@@ -23,6 +28,10 @@ As a result, the Minimum Supported Rust Version (MSRV) is "the latest stable rel
 - `get_path_mut` -> `path_mut`
 
 ### [Remove App::add_sub_app](https://github.com/bevyengine/bevy/pull/7290)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">App</div>
+</div>
 
 `App::add_sub_app` has been removed in favor of `App::insert_sub_app`. Use `SubApp::new` and insert it via `App::add_sub_app`
 
@@ -44,21 +53,41 @@ app.insert_sub_app(MySubAppLabel, SubApp::new(sub_app, extract_fn));
 
 ### [asset: make HandleUntyped::id private](https://github.com/bevyengine/bevy/pull/7076)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Assets</div>
+</div>
+
 - Instead of directly accessing the ID of a `HandleUntyped` as `handle.id`, use the new getter `handle.id()`.
 
 ### [Break `CorePlugin` into `TaskPoolPlugin`, `TypeRegistrationPlugin`, `FrameCountPlugin`.](https://github.com/bevyengine/bevy/pull/7083)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Core</div>
+</div>
 
 - `CorePlugin` broken into separate plugins.  If not using `DefaultPlugins` or `MinimalPlugins` `PluginGroup`s, the replacement for `CorePlugin` is now to add `TaskPoolPlugin`, `TypeRegistrationPlugin`, and `FrameCountPlugin` to the app.
 
 ### [Remove redundant table and sparse set component IDs from Archetype](https://github.com/bevyengine/bevy/pull/4927)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
+
 Do I still need to do this? I really hope people were not relying on the public facing APIs changed here.
 
 ### [Immutable sparse sets for metadata storage](https://github.com/bevyengine/bevy/pull/4928)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
+
 `Table::component_capacity()` has been removed as Tables do not support adding/removing columns after construction.
 
 ### [Split Component Ticks](https://github.com/bevyengine/bevy/pull/6547)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
 
 Various low level APIs interacting with the change detection ticks no longer return `&UnsafeCell<ComponentTicks>`, instead returning `TickCells` which contains two separate `&UnsafeCell<Tick>`s instead.
 
@@ -72,17 +101,29 @@ column.get_ticks(row).changed.deref()
 
 ### [Document and lock down types in bevy_ecs::archetype](https://github.com/bevyengine/bevy/pull/6742)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
+
 `ArchetypeId`, `ArchetypeGeneration`, and `ArchetypeComponentId` are all now opaque IDs and cannot be turned into a numeric value. Please file an issue if this does not work for your use case.
 
 `Archetype` and `Archetypes` are not constructible outside of `bevy_ecs` now. Use `World::archetypes` to get a read-only reference to either of these types.
 
 ### [Lock down access to Entities](https://github.com/bevyengine/bevy/pull/6740)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
+
 `Entities`’s `Default` implementation has been removed. You can fetch a reference to a `World`’s `Entities` via `World::entities` and `World::entities_mut`.
 
 `Entities::alloc_at_without_replacement` and `AllocAtWithoutReplacement` has been made private due to difficulty in using it properly outside of `bevy_ecs`. If you still need use of this API, please file an issue.
 
 ### [Make the `SystemParam` derive macro more flexible](https://github.com/bevyengine/bevy/pull/6694)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
 
 The lifetime `'s` has been removed from `EventWriter`. Any code that explicitly specified the lifetimes for this type will need to be updated.
 
@@ -102,6 +143,10 @@ struct MessageWriter<'w> {
 
 ### [Borrow instead of consuming in `EventReader::clear`](https://github.com/bevyengine/bevy/pull/6851)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
+
 `EventReader::clear` now takes a mutable reference instead of consuming the event reader. This means that `clear` now needs explicit mutable access to the reader variable, which previously could have been omitted in some cases:
 
 ```rust
@@ -118,21 +163,41 @@ fn clear_events(mut reader: EventReader<SomeEvent>) {
 
 ### [Newtype ArchetypeRow and TableRow](https://github.com/bevyengine/bevy/pull/4878)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
+
 `Archetype` indices and `Table` rows have been newtyped as `ArchetypeRow` and `TableRow`.
 
 ### [Simplify trait hierarchy for `SystemParam`](https://github.com/bevyengine/bevy/pull/6865)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
 
 _Merged with the guide for #6919._
 
 ### [Round out the untyped api s](https://github.com/bevyengine/bevy/pull/7009)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
+
 - `MutUntyped::into_inner` now marks things as changed.
 
 ### [Extend EntityLocation with TableId and TableRow](https://github.com/bevyengine/bevy/pull/6681)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
+
 A `World` can only hold a maximum of 2<sup>32</sup> - 1 archetypes and tables now. If your use case requires more than this, please file an issue explaining your use case.
 
 ### [Remove the `SystemParamState` trait and remove types like `ResState`](https://github.com/bevyengine/bevy/pull/6919)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
 
 Note: this replaces the migration guide for #6865. This is relative to Bevy 0.9, not main.
 
@@ -174,17 +239,33 @@ unsafe impl ReadOnlySystemParam for MyParam<'_, '_> {}
 
 ### [Panic on dropping NonSend in non-origin thread.](https://github.com/bevyengine/bevy/pull/6534)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
+
 Normal resources and `NonSend` resources no longer share the same backing storage. If `R: Resource`, then `NonSend<R>` and `Res<R>` will return different instances from each other. If you are using both `Res<T>` and `NonSend<T>` (or their mutable variants), to fetch the same resources, it’s strongly advised to use `Res<T>`.
 
 ### [Document alignment requirements of `Ptr`, `PtrMut` and `OwningPtr`](https://github.com/bevyengine/bevy/pull/7151)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
 
 - Safety invariants on `bevy_ptr` types’ `new` `byte_add` and `byte_offset` methods have been changed. All callers should re-audit for soundness.
 
 ### [Support piping exclusive systems](https://github.com/bevyengine/bevy/pull/7023)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
+
 _Merged with the guide for #7675_.
 
 ### [Basic adaptive batching for parallel query iteration](https://github.com/bevyengine/bevy/pull/4777)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
 
 The `batch_size` parameter for `Query(State)::par_for_each(_mut)` has been removed. These calls will automatically compute a batch size for you. Remove these parameters from all calls to these functions.
 
@@ -210,14 +291,26 @@ fn parallel_system(query: Query<&MyComponent>) {
 
 ### [Added `resource_id` and changed `init_resource` and `init_non_send_resource` to return `ComponentId`](https://github.com/bevyengine/bevy/pull/7284)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
+
 - Changed `World::init_resource` to return the generated `ComponentId`.
 - Changed `World::init_non_send_resource` to return the generated `ComponentId`.
 
 ### [add `UnsafeWorldCell` abstraction](https://github.com/bevyengine/bevy/pull/6404)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
+
 <!-- TODO  no migration required, will remove later -->
 
 ### [Remove `ExclusiveSystemParam::apply`](https://github.com/bevyengine/bevy/pull/7489)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
 
 _Note for maintainers: this migration guide makes more sense if it’s placed above the one for #6919._
 
@@ -225,18 +318,34 @@ The trait method `ExclusiveSystemParamState::apply` has been removed. If you hav
 
 ### [Replace `RemovedComponents<T>` backing with `Events<Entity>`](https://github.com/bevyengine/bevy/pull/5680)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
+
 - Add a `mut` for `removed: RemovedComponents<T>` since we are now modifying an event reader internally.
 - Iterating over removed components now requires `&mut removed_components` or `removed_components.iter()` instead of `&removed_components`.
 
 ### [Remove broken `DoubleEndedIterator` impls on event iterators](https://github.com/bevyengine/bevy/pull/7469)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
+
 `ManualEventIterator` and `ManualEventIteratorWithId` are no longer `DoubleEndedIterator`s.
 
 ### [Rename `Tick::is_older_than` to `Tick::is_newer_than`](https://github.com/bevyengine/bevy/pull/7561)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
+
 - Replace usages of `Tick::is_older_than` with `Tick::is_newer_than`.
 
 ### [Rename `UnsafeWorldCellEntityRef` to `UnsafeEntityCell`](https://github.com/bevyengine/bevy/pull/7568)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
 
 _Note for maintainers:_ This PR has no breaking changes relative to bevy 0.9. Instead of this PR having its own migration guide, we should just edit the changelog for #6404.
 
@@ -244,9 +353,17 @@ The type `UnsafeWorldCellEntityRef` has been renamed to `UnsafeEntityCell`.
 
 ### [Cleanup system sets called labels](https://github.com/bevyengine/bevy/pull/7678)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
+
 `PrepareAssetLabel` is now called `PrepareAssetSet`
 
 ### [Simplify generics for the `SystemParamFunction` trait](https://github.com/bevyengine/bevy/pull/7675)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
 
 _The guide for #7023 has been merged into this one._
 
@@ -286,33 +403,68 @@ where
 
 ### [Cleanup ScheduleBuildSettings](https://github.com/bevyengine/bevy/pull/7721)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
+
 <!-- TODO -->
 
 ### [Move system_commands spans into apply_buffers](https://github.com/bevyengine/bevy/pull/6900)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+    <div class="migration-guide-area-tag">Diagnostics</div>
+</div>
 
 <!-- TODO no migration required, will remove later -->
 
 ### [bevy_ecs: ReflectComponentFns without World](https://github.com/bevyengine/bevy/pull/7206)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+    <div class="migration-guide-area-tag">Reflection</div>
+</div>
+
 - Call `World::entity` before calling into the changed `ReflectComponent` methods, most likely user already has a `EntityRef` or `EntityMut` which was being queried redundantly.
 
 ### [Allow iterating over with EntityRef over the entire World](https://github.com/bevyengine/bevy/pull/6843)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+    <div class="migration-guide-area-tag">Scenes</div>
+</div>
 
 `World::iter_entities` now returns an iterator of `EntityRef` instead of `Entity`. To get the actual ID, use `EntityRef::id` from the returned `EntityRef`s.
 
 ### [Remove `BuildWorldChildren` impl from `WorldChildBuilder`](https://github.com/bevyengine/bevy/pull/6727)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Hierarchy</div>
+</div>
+
 Hierarchy editing methods such as `with_children` and `push_children` have been removed from `WorldChildBuilder`. You can edit the hierarchy via `EntityMut` instead.
 
 ### [Rename dynamic feature](https://github.com/bevyengine/bevy/pull/7340)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Meta</div>
+</div>
 
 - `dynamic` feature was renamed to `dynamic_linking`
 
 ### [reflect: add `insert` and `remove` methods to `List`](https://github.com/bevyengine/bevy/pull/7063)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Reflection</div>
+</div>
+
 - Manual implementors of `List` need to implement the new methods `insert` and `remove` and  consider whether to use the new default implementation of `push` and `pop`.
 
 ### [bevy_reflect: Decouple `List` and `Array` traits](https://github.com/bevyengine/bevy/pull/7467)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Reflection</div>
+</div>
 
 My guess for why we originally made `List` a subtrait of `Array` is that they share a lot of common operations. We could potentially move these overlapping methods to a `Sequence` (name taken from #7059) trait and make that a supertrait of both. This would allow functions to contain logic that simply operates on a sequence rather than “list vs array”.
 
@@ -363,9 +515,18 @@ Some other small tweaks that will need to be made include:
 
 ### [implement `TypeUuid` for primitives and fix multiple-parameter generics having the same `TypeUuid`](https://github.com/bevyengine/bevy/pull/6633)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Reflection</div>
+</div>
+
 <!-- TODO -->
 
 ### [bevy_reflect: Remove `ReflectSerialize` and `ReflectDeserialize` registrations from most glam types](https://github.com/bevyengine/bevy/pull/6580)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Reflection</div>
+    <div class="migration-guide-area-tag">Scenes</div>
+</div>
 
 This PR removes `ReflectSerialize` and `ReflectDeserialize` registrations from most glam types. This means any code relying on either of those type data existing for those glam types will need to not do that.
 
@@ -406,13 +567,25 @@ This also means that some serialized glam types will need to be updated. For exa
 
 ### [Add AutoMax next to ScalingMode::AutoMin](https://github.com/bevyengine/bevy/pull/6496)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+</div>
+
 just rename `ScalingMode::Auto` to `ScalingMode::AutoMin` if you are using it.
 
 ### [Change `From<Icosphere>` to `TryFrom<Icosphere>`](https://github.com/bevyengine/bevy/pull/6484)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+</div>
+
 <!-- TODO -->
 
 ### [Add try_* to add_slot_edge, add_node_edge](https://github.com/bevyengine/bevy/pull/6720)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+</div>
 
 Remove `.unwrap()` from `add_node_edge` and `add_slot_edge`. For cases where the error was handled, use `try_add_node_edge` and `try_add_slot_edge` instead.
 
@@ -420,22 +593,42 @@ Remove `.unwrap()` from `input_node`. For cases where the option was handled, us
 
 ### [Shader defs can now have a value](https://github.com/bevyengine/bevy/pull/5900)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+</div>
+
 - replace `shader_defs.push(String::from("NAME"));` by `shader_defs.push("NAME".into());`
 - if you used shader def `NO_STORAGE_BUFFERS_SUPPORT`, check how `AVAILABLE_STORAGE_BUFFER_BINDINGS` is now used in Bevy default shaders
 
 ### [get pixel size from wgpu](https://github.com/bevyengine/bevy/pull/6820)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+</div>
+
 `PixelInfo` has been removed. `PixelInfo::components` is equivalent to `texture_format.describe().components`. `PixelInfo::type_size` can be gotten from `texture_format.describe().block_size/ texture_format.describe().components`. But note this can yield incorrect results for some texture types like Rg11b10Float.
 
 ### [run clear trackers on render world](https://github.com/bevyengine/bevy/pull/6878)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+</div>
 
 The call to `clear_trackers` in `App` has been moved from the schedule to App::update for the main world and calls to `clear_trackers` have been added for sub_apps in the same function. This was due to needing stronger guarantees. If clear_trackers isn’t called on a world it can lead to memory leaks in `RemovedComponents`. If you were ordering systems with clear_trackers this is no longer possible.
 
 ### [Rename camera "priority" to "order"](https://github.com/bevyengine/bevy/pull/6908)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+</div>
+
 <!-- TODO -->
 
 ### [enum `Visibility` component](https://github.com/bevyengine/bevy/pull/6320)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+</div>
 
 - evaluation of the `visibility.is_visible` field should now check for `visibility == Visibility::Inherited`.
 - setting the `visibility.is_visible` field should now directly set the value: `*visibility = Visibility::Inherited`.
@@ -443,6 +636,10 @@ The call to `clear_trackers` in `App` has been moved from the schedule to App::u
 - `ComputedVisibility::INVISIBLE` and `SpatialBundle::VISIBLE_IDENTITY` have been renamed to `ComputedVisibility::HIDDEN` and `SpatialBundle::INHERITED_IDENTITY` respectively.
 
 ### [Reduce branching in TrackedRenderPass](https://github.com/bevyengine/bevy/pull/7053)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+</div>
 
 `TrackedRenderPass` now requires a `RenderDevice` to construct. To make this easier, use `RenderContext.begin_tracked_render_pass` instead.
 
@@ -462,9 +659,17 @@ render_context.begin_tracked_render_pass(RenderPassDescriptor {
 
 ### [Make PipelineCache internally mutable.](https://github.com/bevyengine/bevy/pull/7205)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+</div>
+
 - Most usages of `resource_mut::<PipelineCache>` and `ResMut<PipelineCache>` can be changed to `resource::<PipelineCache>` and `Res<PipelineCache>` as long as they don’t use any methods requiring mutability - the only public method requiring it is `process_queue`.
 
 ### [Changed Msaa to Enum](https://github.com/bevyengine/bevy/pull/7292)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+</div>
 
 ```rust
 let multi = Msaa { samples: 4 }
@@ -478,9 +683,17 @@ multi.samples()
 
 ### [Support recording multiple CommandBuffers in RenderContext](https://github.com/bevyengine/bevy/pull/7248)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+</div>
+
 `RenderContext`’s fields are now private. Use the accessors on `RenderContext` instead, and construct it with `RenderContext::new`.
 
 ### [Improve `OrthographicCamera` consistency and usability](https://github.com/bevyengine/bevy/pull/6201)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+</div>
 
 - Change `window_origin` to `viewport_origin`; replace `WindowOrigin::Center` with `Vec2::new(0.5, 0.5)` and `WindowOrigin::BottomLeft` with `Vec2::new(0.0, 0.0)`
 - For shadow projections and such, replace `left`, `right`, `bottom`, and `top` with `area: Rect::new(left, bottom, right, top)`
@@ -494,13 +707,25 @@ multi.samples()
 
 ### [Changed &mut PipelineCache to &PipelineCache](https://github.com/bevyengine/bevy/pull/7598)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+</div>
+
 - `SpecializedComputePipelines::specialize` now takes a `&PipelineCache` instead of a `&mut PipelineCache`
 
 ### [Introduce detailed_trace macro, use in TrackedRenderPass](https://github.com/bevyengine/bevy/pull/7639)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+</div>
+
 - Some detailed bevy trace events now require the use of the cargo feature `detailed_trace` in addition to enabling `TRACE` level logging to view. Should you wish to see these logs, please compile your code with the bevy feature `detailed_trace`. Currently, the only logs that are affected are the renderer logs pertaining to `TrackedRenderPass` functions
 
 ### [added subdivisions to shape::Plane](https://github.com/bevyengine/bevy/pull/7546)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+</div>
 
 All the examples needed to be updated to initalize the subdivisions field. Also there were two tests in tests/window that need to be updated.
 
@@ -508,21 +733,46 @@ A user would have to update all their uses of shape::Plane to initalize the subd
 
 ### [Change standard material defaults and update docs](https://github.com/bevyengine/bevy/pull/7664)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+</div>
+
 `StandardMaterial`’s default have now changed to be a fully dielectric material with medium roughness. If you want to use the old defaults, you can set  `perceptual_roughness = 0.089` and `metallic = 0.01` (though metallic should generally only be set to 0.0 or 1.0).
 
 ### [Directly extract joints into SkinnedMeshJoints](https://github.com/bevyengine/bevy/pull/6833)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+    <div class="migration-guide-area-tag">Animation</div>
+</div>
 
 `ExtractedJoints` has been removed. Read the bound bones from `SkinnedMeshJoints` instead.
 
 ### [Intepret glTF colors as linear instead of sRGB](https://github.com/bevyengine/bevy/pull/6828)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+    <div class="migration-guide-area-tag">Assets</div>
+</div>
+
 No api changes are required, but it's possible that your gltf meshes look different
 
 ### [The `update_frame_count` system should be placed in CorePlugin](https://github.com/bevyengine/bevy/pull/6676)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+    <div class="migration-guide-area-tag">Core</div>
+    <div class="migration-guide-area-tag">Time</div>
+</div>
+
 The `FrameCount`  resource was previously only updated when using the `bevy_render` feature. If you are not using this feature but still want the `FrameCount` it will now be updated correctly.
 
 ### [Migrate engine to Schedule v3](https://github.com/bevyengine/bevy/pull/7267)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
 
 - Calls to `.label(MyLabel)` should be replaced with `.in_set(MySet)`
 - Stages have been removed. Replace these with system sets, and then add command flushes using the `apply_system_buffers` exclusive system where needed.
@@ -548,27 +798,55 @@ The `FrameCount`  resource was previously only updated when using the `bevy_rend
 
 ### [Pipelined Rendering](https://github.com/bevyengine/bevy/pull/6503)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+    <div class="migration-guide-area-tag">Tasks</div>
+</div>
+
 __App `runner` and SubApp `extract` functions are now required to be Send__
 
 This was changed to enable pipelined rendering. If this breaks your use case please report it as these new bounds might be able to be relaxed.
 
 ### [Remove ImageMode](https://github.com/bevyengine/bevy/pull/6674)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+    <div class="migration-guide-area-tag">UI</div>
+</div>
+
 `ImageNode` never worked, if you were using it please create an issue.
 
 ### [Rename the `background_color` of 'ExtractedUiNode` to `color`](https://github.com/bevyengine/bevy/pull/7452)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+    <div class="migration-guide-area-tag">UI</div>
+</div>
 
 - The `background_color` field of `ExtractedUiNode` is now named `color`.
 
 ### [Make spawn_dynamic return InstanceId](https://github.com/bevyengine/bevy/pull/6663)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Scenes</div>
+</div>
+
 <!-- TODO no migration required, will remove it later-->
 
 ### [Parallelized transform propagation](https://github.com/bevyengine/bevy/pull/4775)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Transform</div>
+</div>
+
 <!-- TODO no migration required, will remove it later-->
 
 ### [Remove the `GlobalTransform::translation_mut` method](https://github.com/bevyengine/bevy/pull/7134)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Transform</div>
+    <div class="migration-guide-area-tag">Hierarchy</div>
+</div>
 
 `GlobalTransform::translation_mut` has been removed without alternative, if you were relying on this, update the `Transform` instead. If the given entity had children or parent, you may need to remove its parent to make its transform independent (in which case the new `Commands::set_parent_in_place` and `Commands::remove_parent_in_place` may be of interest)
 
@@ -576,17 +854,33 @@ Bevy may add in the future a way to toggle transform propagation on an entity ba
 
 ### [Flip UI image](https://github.com/bevyengine/bevy/pull/6292)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">UI</div>
+</div>
+
 <!-- TODO -->
 
 ### [Remove `TextError::ExceedMaxTextAtlases(usize)` variant](https://github.com/bevyengine/bevy/pull/6796)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">UI</div>
+</div>
 
 TextError::ExceedMaxTextAtlases(usize)` was never thrown so if you were matching on this variant you can simply remove it.
 
 ### [Change default FocusPolicy to Pass](https://github.com/bevyengine/bevy/pull/7161)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">UI</div>
+</div>
+
 - `FocusPolicy` default has changed from `FocusPolicy::Block` to `FocusPolicy::Pass`
 
 ### [Remove VerticalAlign from TextAlignment](https://github.com/bevyengine/bevy/pull/6807)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">UI</div>
+</div>
 
 The `alignment` field of `Text` now only affects the text’s internal alignment.
 
@@ -602,21 +896,41 @@ __Changes for `Text2dBundle`__
 
 ### [Remove `QueuedText`](https://github.com/bevyengine/bevy/pull/7414)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">UI</div>
+</div>
+
 `QueuedText` was never meant to be user facing. If you relied on it, please make an issue.
 
 ### [change the default `width` and `height` of `Size` to `Val::Auto`](https://github.com/bevyengine/bevy/pull/7475)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">UI</div>
+</div>
 
 The default values for `Size` `width` and `height` have been changed from `Val::Undefined` to `Val::Auto`. It’s unlikely to cause any issues with existing code.
 
 ### [Fix the `Size` helper functions using the wrong default value and improve the UI examples](https://github.com/bevyengine/bevy/pull/7626)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">UI</div>
+</div>
+
 The `Size::width` constructor function now sets the `height` to `Val::Auto` instead of `Val::Undefined`. The `Size::height` constructor function now sets the `width` to `Val::Auto` instead of `Val::Undefined`.
 
 ### [The `size` field of `CalculatedSize` should not be a `Size`](https://github.com/bevyengine/bevy/pull/7641)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">UI</div>
+</div>
+
 - The size field of `CalculatedSize` has been changed to a `Vec2`.
 
 ### [Windows as Entities](https://github.com/bevyengine/bevy/pull/5589)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Windowing</div>
+</div>
 
 - Replace `WindowDescriptor` with `Window`.
   - Change `width` and `height` fields in a `WindowResolution`, either by doing
@@ -636,9 +950,17 @@ commands.entity(window).despawn(); // close window
 
 ### [Allow not preventing default event behaviors on wasm](https://github.com/bevyengine/bevy/pull/7304)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Windowing</div>
+</div>
+
 <!-- TODO I'm not sure this needs a guide, I assume most people would be using the ..default() anyway and the ones that aren't doing that will just have a clear compile error -->
 
 ### [update winit to 0.28](https://github.com/bevyengine/bevy/pull/7480)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Windowing</div>
+</div>
 
 before:
 

--- a/content/learn/book/migration-guides/0.9-0.10/_index.md
+++ b/content/learn/book/migration-guides/0.9-0.10/_index.md
@@ -217,7 +217,7 @@ unsafe impl ReadOnlySystemParam for MyParam<'_, '_> {}
     <div class="migration-guide-area-tag">ECS</div>
 </div>
 
-A `World` can only hold a maximum of 232 - 1 archetypes and tables now. If your use case requires more than this, please file an issue explaining your use case.
+A `World` can only hold a maximum of 2<sup>32</sup> - 1 archetypes and tables now. If your use case requires more than this, please file an issue explaining your use case.
 
 ### [Round out the untyped api s](https://github.com/bevyengine/bevy/pull/7009)
 

--- a/content/learn/book/migration-guides/0.9-0.10/_index.md
+++ b/content/learn/book/migration-guides/0.9-0.10/_index.md
@@ -33,14 +33,15 @@ As a result, the Minimum Supported Rust Version (MSRV) is "the latest stable rel
     <div class="migration-guide-area-tag">App</div>
 </div>
 
-`App::add_sub_app` has been removed in favor of `App::insert_sub_app`. Use `SubApp::new` and insert it via `App::add_sub_app`
+`App::add_sub_app` has been removed in favor of `App::insert_sub_app`. Use `SubApp::new` and insert it via `App::insert_sub_app`
+
 
 Old:
 
 ```rust
 let mut sub_app = App::new()
 // Build subapp here
-app.add_sub_app(MySubAppLabel, sub_app);
+app.add_sub_app(MySubAppLabel, sub_app, extract_fn);
 ```
 
 New:
@@ -66,14 +67,6 @@ app.insert_sub_app(MySubAppLabel, SubApp::new(sub_app, extract_fn));
 </div>
 
 - `CorePlugin` broken into separate plugins.  If not using `DefaultPlugins` or `MinimalPlugins` `PluginGroup`s, the replacement for `CorePlugin` is now to add `TaskPoolPlugin`, `TypeRegistrationPlugin`, and `FrameCountPlugin` to the app.
-
-### [Remove redundant table and sparse set component IDs from Archetype](https://github.com/bevyengine/bevy/pull/4927)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">ECS</div>
-</div>
-
-Do I still need to do this? I really hope people were not relying on the public facing APIs changed here.
 
 ### [Immutable sparse sets for metadata storage](https://github.com/bevyengine/bevy/pull/4928)
 
@@ -105,7 +98,7 @@ column.get_ticks(row).changed.deref()
     <div class="migration-guide-area-tag">ECS</div>
 </div>
 
-`ArchetypeId`, `ArchetypeGeneration`, and `ArchetypeComponentId` are all now opaque IDs and cannot be turned into a numeric value. Please file an issue if this does not work for your use case.
+`ArchetypeId`, `ArchetypeGeneration`, and `ArchetypeComponentId` are all now opaque IDs and cannot be turned into a numeric value. Please file an issue if this does not work for your use case or check [bevy_ecs is excessively public](https://github.com/bevyengine/bevy/issues/3362) for more info.
 
 `Archetype` and `Archetypes` are not constructible outside of `bevy_ecs` now. Use `World::archetypes` to get a read-only reference to either of these types.
 
@@ -117,7 +110,7 @@ column.get_ticks(row).changed.deref()
 
 `Entities`’s `Default` implementation has been removed. You can fetch a reference to a `World`’s `Entities` via `World::entities` and `World::entities_mut`.
 
-`Entities::alloc_at_without_replacement` and `AllocAtWithoutReplacement` has been made private due to difficulty in using it properly outside of `bevy_ecs`. If you still need use of this API, please file an issue.
+`Entities::alloc_at_without_replacement` and `AllocAtWithoutReplacement` has been made private due to difficulty in using it properly outside of `bevy_ecs`. If you still need use of this API, please file an issue or check [bevy_ecs is excessively public](https://github.com/bevyengine/bevy/issues/3362) for more info.
 
 ### [Make the `SystemParam` derive macro more flexible](https://github.com/bevyengine/bevy/pull/6694)
 
@@ -169,14 +162,6 @@ fn clear_events(mut reader: EventReader<SomeEvent>) {
 
 `Archetype` indices and `Table` rows have been newtyped as `ArchetypeRow` and `TableRow`.
 
-### [Simplify trait hierarchy for `SystemParam`](https://github.com/bevyengine/bevy/pull/6865)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">ECS</div>
-</div>
-
-_Merged with the guide for #6919._
-
 ### [Round out the untyped api s](https://github.com/bevyengine/bevy/pull/7009)
 
 <div class="migration-guide-area-tags">
@@ -192,15 +177,19 @@ _Merged with the guide for #6919._
 </div>
 
 A `World` can only hold a maximum of 2<sup>32</sup> - 1 archetypes and tables now. If your use case requires more than this, please file an issue explaining your use case.
+### [Remove `ExclusiveSystemParam::apply`](https://github.com/bevyengine/bevy/pull/7489)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
+
+The trait method `ExclusiveSystemParamState::apply` has been removed. If you have an exclusive system with buffers that must be applied, you should apply them within the body of the exclusive system.
 
 ### [Remove the `SystemParamState` trait and remove types like `ResState`](https://github.com/bevyengine/bevy/pull/6919)
 
 <div class="migration-guide-area-tags">
     <div class="migration-guide-area-tag">ECS</div>
 </div>
-
-Note: this replaces the migration guide for #6865.
-This is relative to Bevy 0.9, not main.
 
 The traits `SystemParamState` and `SystemParamFetch` have been removed, and their functionality has been transferred to `SystemParam`.
 
@@ -246,14 +235,6 @@ Normal resources and `NonSend` resources no longer share the same backing storag
 
 - Safety invariants on `bevy_ptr` types’ `new` `byte_add` and `byte_offset` methods have been changed. All callers should re-audit for soundness.
 
-### [Support piping exclusive systems](https://github.com/bevyengine/bevy/pull/7023)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">ECS</div>
-</div>
-
-_Merged with the guide for #7675_.
-
 ### [Basic adaptive batching for parallel query iteration](https://github.com/bevyengine/bevy/pull/4777)
 
 <div class="migration-guide-area-tags">
@@ -287,7 +268,7 @@ fn parallel_system(query: Query<&MyComponent>) {
 <div class="migration-guide-area-tags">
     <div class="migration-guide-area-tag">ECS</div>
 </div>
-
+- Added `Components::resource_id`.
 - Changed `World::init_resource` to return the generated `ComponentId`.
 - Changed `World::init_non_send_resource` to return the generated `ComponentId`.
 
@@ -297,17 +278,7 @@ fn parallel_system(query: Query<&MyComponent>) {
     <div class="migration-guide-area-tag">ECS</div>
 </div>
 
-<!-- TODO  no migration required, will remove later -->
-
-### [Remove `ExclusiveSystemParam::apply`](https://github.com/bevyengine/bevy/pull/7489)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">ECS</div>
-</div>
-
-_Note for maintainers: this migration guide makes more sense if it’s placed above the one for #6919._
-
-The trait method `ExclusiveSystemParamState::apply` has been removed. If you have an exclusive system with buffers that must be applied, you should apply them within the body of the exclusive system.
+The type UnsafeWorldCellEntityRef has been renamed to UnsafeEntityCell
 
 ### [Replace `RemovedComponents<T>` backing with `Events<Entity>`](https://github.com/bevyengine/bevy/pull/5680)
 
@@ -324,7 +295,7 @@ The trait method `ExclusiveSystemParamState::apply` has been removed. If you hav
     <div class="migration-guide-area-tag">ECS</div>
 </div>
 
-`ManualEventIterator` and `ManualEventIteratorWithId` are no longer `DoubleEndedIterator`s.
+`ManualEventIterator` and `ManualEventIteratorWithId` are no longer `DoubleEndedIterator`s since the impls didn't work correctly, and any code using this was likely broken.
 
 ### [Rename `Tick::is_older_than` to `Tick::is_newer_than`](https://github.com/bevyengine/bevy/pull/7561)
 
@@ -333,16 +304,6 @@ The trait method `ExclusiveSystemParamState::apply` has been removed. If you hav
 </div>
 
 - Replace usages of `Tick::is_older_than` with `Tick::is_newer_than`.
-
-### [Rename `UnsafeWorldCellEntityRef` to `UnsafeEntityCell`](https://github.com/bevyengine/bevy/pull/7568)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">ECS</div>
-</div>
-
-_Note for maintainers:_ This PR has no breaking changes relative to bevy 0.9. Instead of this PR having its own migration guide, we should just edit the changelog for #6404.
-
-The type `UnsafeWorldCellEntityRef` has been renamed to `UnsafeEntityCell`.
 
 ### [Cleanup system sets called labels](https://github.com/bevyengine/bevy/pull/7678)
 
@@ -357,8 +318,6 @@ The type `UnsafeWorldCellEntityRef` has been renamed to `UnsafeEntityCell`.
 <div class="migration-guide-area-tags">
     <div class="migration-guide-area-tag">ECS</div>
 </div>
-
-_The guide for #7023 has been merged into this one._
 
 For the `SystemParamFunction` trait, the type parameters `In`, `Out`, and `Param` have been turned into associated types.
 
@@ -394,14 +353,6 @@ where
     T: ExclusiveSystemParamFunction<Marker>,
 { ... }
 ```
-
-### [Cleanup ScheduleBuildSettings](https://github.com/bevyengine/bevy/pull/7721)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">ECS</div>
-</div>
-
-<!-- TODO -->
 
 ### [Deprecate `ChangeTrackers<T>` in favor of `Ref<T>`](https://github.com/bevyengine/bevy/pull/7306)
 
@@ -468,15 +419,6 @@ fn clear_children(parent: Entity, world: &mut World) {
     }
 }
 ```
-
-### [Move system_commands spans into apply_buffers](https://github.com/bevyengine/bevy/pull/6900)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">ECS</div>
-    <div class="migration-guide-area-tag">Diagnostics</div>
-</div>
-
-<!-- TODO no migration required, will remove later -->
 
 ### [bevy_ecs: ReflectComponentFns without World](https://github.com/bevyengine/bevy/pull/7206)
 
@@ -571,14 +513,6 @@ Some other small tweaks that will need to be made include:
 - Use `ListIter` for `List::iter` instead of `ArrayIter` (the return type from `Array::iter`)
 - Replace `array_hash` with `list_hash` in `Reflect::reflect_hash` for implementors of `List`
 
-### [implement `TypeUuid` for primitives and fix multiple-parameter generics having the same `TypeUuid`](https://github.com/bevyengine/bevy/pull/6633)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">Reflection</div>
-</div>
-
-<!-- TODO -->
-
 ### [bevy_reflect: Remove `ReflectSerialize` and `ReflectDeserialize` registrations from most glam types](https://github.com/bevyengine/bevy/pull/6580)
 
 <div class="migration-guide-area-tags">
@@ -629,7 +563,7 @@ This also means that some serialized glam types will need to be updated. For exa
     <div class="migration-guide-area-tag">Rendering</div>
 </div>
 
-just rename `ScalingMode::Auto` to `ScalingMode::AutoMin` if you are using it.
+ - Rename `ScalingMode::Auto` to `ScalingMode::AutoMin` if you are using it.
 
 ### [Change `From<Icosphere>` to `TryFrom<Icosphere>`](https://github.com/bevyengine/bevy/pull/6484)
 
@@ -673,7 +607,7 @@ For cases where the option was handled, use `get_input_node` instead.
 </div>
 
 - replace `shader_defs.push(String::from("NAME"));` by `shader_defs.push("NAME".into());`
-- if you used shader def `NO_STORAGE_BUFFERS_SUPPORT`, check how `AVAILABLE_STORAGE_BUFFER_BINDINGS` is now used in Bevy default shaders
+- if you used shader def `NO_STORAGE_BUFFERS_SUPPORT`, check how `AVAILABLE_STORAGE_BUFFER_BINDINGS` is now used in [Bevy default shaders](https://github.com/bevyengine/bevy/blob/3ec87e49ca49767fad658e72fbae353f6687198c/crates/bevy_pbr/src/render/mesh_view_bindings.wgsl#L28)
 
 ### [get pixel size from wgpu](https://github.com/bevyengine/bevy/pull/6820)
 
@@ -689,7 +623,7 @@ For cases where the option was handled, use `get_input_node` instead.
     <div class="migration-guide-area-tag">Rendering</div>
 </div>
 
-The call to `clear_trackers` in `App` has been moved from the schedule to App::update for the main world and calls to `clear_trackers` have been added for sub_apps in the same function. This was due to needing stronger guarantees. If clear_trackers isn’t called on a world it can lead to memory leaks in `RemovedComponents`. If you were ordering systems with clear_trackers this is no longer possible.
+The call to `clear_trackers` in `App` has been moved from the schedule to `App::update` for the main world and calls to `clear_trackers` have been added for `sub_apps` in the same function. This was due to needing stronger guarantees. If `clear_trackers` isn’t called on a world it can lead to memory leaks in `RemovedComponents`. If you were ordering systems with `clear_trackers` this is no longer possible.
 
 ### [Rename camera "priority" to "order"](https://github.com/bevyengine/bevy/pull/6908)
 
@@ -697,7 +631,7 @@ The call to `clear_trackers` in `App` has been moved from the schedule to App::u
     <div class="migration-guide-area-tag">Rendering</div>
 </div>
 
-<!-- TODO -->
+- Rename `priority` to `order` in usage of `Camera`.
 
 ### [enum `Visibility` component](https://github.com/bevyengine/bevy/pull/6320)
 
@@ -802,10 +736,7 @@ multi.samples()
     <div class="migration-guide-area-tag">Rendering</div>
 </div>
 
-All the examples needed to be updated to initalize the subdivisions field.
-Also there were two tests in tests/window that need to be updated.
-
-A user would have to update all their uses of shape::Plane to initalize the subdivisions field.
+- `shape::Plane` now takes an additional `subdivisions` parameter so users should provide it or use the new `shape::Plane::from_size`.
 
 ### [Change standard material defaults and update docs](https://github.com/bevyengine/bevy/pull/7664)
 
@@ -864,7 +795,8 @@ The `FrameCount`  resource was previously only updated when using the `bevy_rend
   - Systems are no longer added to `CoreSet::Update` by default. Add systems manually if this behavior is needed, although you should consider adding your game logic systems to `CoreSchedule::FixedTimestep` instead for more reliable framerate-independent behavior.
   - Similarly, startup systems are no longer part of `StartupSet::Startup` by default. In most cases, this won’t matter to you.
   - For example, `add_system_to_stage(CoreStage::PostUpdate, my_system)` should be replaced with
-  - `add_system(my_system.in_set(CoreSet::PostUpdate)`
+  - `add_system(my_system.in_base_set(CoreSet::PostUpdate)`
+
 
 - When testing systems or otherwise running them in a headless fashion, simply construct and run a schedule using `Schedule::new()` and `World::run_schedule` rather than constructing stages
 - Run criteria have been renamed to run conditions. These can now be combined with each other and with states.
@@ -877,7 +809,8 @@ The `FrameCount`  resource was previously only updated when using the `bevy_rend
 - `App::add_state` now takes 0 arguments: the starting state is set based on the `Default` impl.
 - Instead of creating `SystemSet` containers for systems that run in stages, simply use `.on_enter::<State::Variant>()` or its `on_exit` or `on_update` siblings.
 - `SystemLabel` derives should be replaced with `SystemSet`. You will also need to add the `Debug`, `PartialEq`, `Eq`, and `Hash` traits to satisfy the new trait bounds.
-- `with_run_criteria` has been renamed to `run_if`. Run criteria have been renamed to run conditions for clarity, and should now simply return a bool.
+- `with_run_criteria` has been renamed to `run_if`. Run criteria have been renamed to run conditions for clarity, and should now simply return a `bool` instead of `schedule::ShouldRun`.
+
 - States have been dramatically simplified: there is no longer a “state stack”. To queue a transition to the next state, call `NextState::set`
 - Strings can no longer be used as a `SystemLabel` or `SystemSet`. Use a type, or use the system function instead.
 
@@ -910,22 +843,6 @@ This was changed to enable pipelined rendering. If this breaks your use case ple
 
 - The `background_color` field of `ExtractedUiNode` is now named `color`.
 
-### [Make spawn_dynamic return InstanceId](https://github.com/bevyengine/bevy/pull/6663)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">Scenes</div>
-</div>
-
-<!-- TODO no migration required, will remove it later-->
-
-### [Parallelized transform propagation](https://github.com/bevyengine/bevy/pull/4775)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">Transform</div>
-</div>
-
-<!-- TODO no migration required, will remove it later-->
-
 ### [Remove the `GlobalTransform::translation_mut` method](https://github.com/bevyengine/bevy/pull/7134)
 
 <div class="migration-guide-area-tags">
@@ -948,7 +865,8 @@ an entity basis.
     <div class="migration-guide-area-tag">UI</div>
 </div>
 
-<!-- TODO -->
+- `UiImage` is a struct now, so use `UiImage::new(handler)` instead of `UiImage(handler)`
+- `UiImage` no longer implements `Deref` and `DereftMut`, so use `&image.texture` or ``&mut image.texture` instead
 
 ### [Remove `TextError::ExceedMaxTextAtlases(usize)` variant](https://github.com/bevyengine/bevy/pull/6796)
 
@@ -984,6 +902,7 @@ __Changes for `Text2dBundle`__
 
 `Text2dBundle` has a new field ‘text_anchor’ that takes an `Anchor` component that controls its position relative to its transform.
 
+`Text2dSize` was removed. Use `TextLayoutInfo` instead.
 ### [Remove `QueuedText`](https://github.com/bevyengine/bevy/pull/7414)
 
 <div class="migration-guide-area-tags">
@@ -1039,14 +958,6 @@ WindowResolution::new(width, height) // Explicitly
 let window = commands.spawn(Window { ... }).id(); // open window
 commands.entity(window).despawn(); // close window
 ```
-
-### [Allow not preventing default event behaviors on wasm](https://github.com/bevyengine/bevy/pull/7304)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">Windowing</div>
-</div>
-
-<!-- TODO I'm not sure this needs a guide, I assume most people would be using the ..default() anyway and the ones that aren't doing that will just have a clear compile error -->
 
 ### [update winit to 0.28](https://github.com/bevyengine/bevy/pull/7480)
 

--- a/content/learn/book/migration-guides/0.9-0.10/_index.md
+++ b/content/learn/book/migration-guides/0.9-0.10/_index.md
@@ -118,7 +118,7 @@ fn clear_events(mut reader: EventReader<SomeEvent>) {
 
 ### [Newtype ArchetypeRow and TableRow](https://github.com/bevyengine/bevy/pull/4878)
 
-<!-- TODO -->
+`Archetype` indices and `Table` rows have been newtyped as `ArchetypeRow` and `TableRow`.
 
 ### [Simplify trait hierarchy for `SystemParam`](https://github.com/bevyengine/bevy/pull/6865)
 
@@ -130,7 +130,7 @@ _Merged with the guide for #6919._
 
 ### [Extend EntityLocation with TableId and TableRow](https://github.com/bevyengine/bevy/pull/6681)
 
-A `World` can only hold a maximum of 232 - 1 archetypes and tables now. If your use case requires more than this, please file an issue explaining your use case.
+A `World` can only hold a maximum of 2<sup>32</sup> - 1 archetypes and tables now. If your use case requires more than this, please file an issue explaining your use case.
 
 ### [Remove the `SystemParamState` trait and remove types like `ResState`](https://github.com/bevyengine/bevy/pull/6919)
 
@@ -210,11 +210,12 @@ fn parallel_system(query: Query<&MyComponent>) {
 
 ### [Added `resource_id` and changed `init_resource` and `init_non_send_resource` to return `ComponentId`](https://github.com/bevyengine/bevy/pull/7284)
 
-<!-- TODO -->
+- Changed `World::init_resource` to return the generated `ComponentId`.
+- Changed `World::init_non_send_resource` to return the generated `ComponentId`.
 
 ### [add `UnsafeWorldCell` abstraction](https://github.com/bevyengine/bevy/pull/6404)
 
-<!-- TODO -->
+<!-- TODO  no migration required, will remove later -->
 
 ### [Remove `ExclusiveSystemParam::apply`](https://github.com/bevyengine/bevy/pull/7489)
 
@@ -289,7 +290,7 @@ where
 
 ### [Move system_commands spans into apply_buffers](https://github.com/bevyengine/bevy/pull/6900)
 
-<!-- TODO -->
+<!-- TODO no migration required, will remove later -->
 
 ### [bevy_ecs: ReflectComponentFns without World](https://github.com/bevyengine/bevy/pull/7206)
 
@@ -515,11 +516,11 @@ A user would have to update all their uses of shape::Plane to initalize the subd
 
 ### [Intepret glTF colors as linear instead of sRGB](https://github.com/bevyengine/bevy/pull/6828)
 
-<!-- TODO -->
+No api changes are required, but it's possible that your gltf meshes look different
 
 ### [The `update_frame_count` system should be placed in CorePlugin](https://github.com/bevyengine/bevy/pull/6676)
 
-<!-- TODO -->
+The `FrameCount`  resource was previously only updated when using the `bevy_render` feature. If you are not using this feature but still want the `FrameCount` it will now be updated correctly.
 
 ### [Migrate engine to Schedule v3](https://github.com/bevyengine/bevy/pull/7267)
 
@@ -530,7 +531,6 @@ A user would have to update all their uses of shape::Plane to initalize the subd
   - Similarly, startup systems are no longer part of `StartupSet::Startup` by default. In most cases, this won’t matter to you.
   - For example, `add_system_to_stage(CoreStage::PostUpdate, my_system)` should be replaced with
   - `add_system(my_system.in_set(CoreSet::PostUpdate)`
-
 - When testing systems or otherwise running them in a headless fashion, simply construct and run a schedule using `Schedule::new()` and `World::run_schedule` rather than constructing stages
 - Run criteria have been renamed to run conditions. These can now be combined with each other and with states.
 - Looping run criteria and state stacks have been removed. Use an exclusive system that runs a schedule if you need this level of control over system control flow.
@@ -554,7 +554,7 @@ This was changed to enable pipelined rendering. If this breaks your use case ple
 
 ### [Remove ImageMode](https://github.com/bevyengine/bevy/pull/6674)
 
-<!-- TODO -->
+`ImageNode` never worked, if you were using it please create an issue.
 
 ### [Rename the `background_color` of 'ExtractedUiNode` to `color`](https://github.com/bevyengine/bevy/pull/7452)
 
@@ -562,11 +562,11 @@ This was changed to enable pipelined rendering. If this breaks your use case ple
 
 ### [Make spawn_dynamic return InstanceId](https://github.com/bevyengine/bevy/pull/6663)
 
-<!-- TODO -->
+<!-- TODO no migration required, will remove it later-->
 
 ### [Parallelized transform propagation](https://github.com/bevyengine/bevy/pull/4775)
 
-<!-- TODO -->
+<!-- TODO no migration required, will remove it later-->
 
 ### [Remove the `GlobalTransform::translation_mut` method](https://github.com/bevyengine/bevy/pull/7134)
 
@@ -580,7 +580,7 @@ Bevy may add in the future a way to toggle transform propagation on an entity ba
 
 ### [Remove `TextError::ExceedMaxTextAtlases(usize)` variant](https://github.com/bevyengine/bevy/pull/6796)
 
-<!-- TODO -->
+TextError::ExceedMaxTextAtlases(usize)` was never thrown so if you were matching on this variant you can simply remove it.
 
 ### [Change default FocusPolicy to Pass](https://github.com/bevyengine/bevy/pull/7161)
 
@@ -602,7 +602,7 @@ __Changes for `Text2dBundle`__
 
 ### [Remove `QueuedText`](https://github.com/bevyengine/bevy/pull/7414)
 
-<!-- TODO -->
+`QueuedText` was never meant to be user facing. If you relied on it, please make an issue.
 
 ### [change the default `width` and `height` of `Size` to `Val::Auto`](https://github.com/bevyengine/bevy/pull/7475)
 
@@ -636,7 +636,7 @@ commands.entity(window).despawn(); // close window
 
 ### [Allow not preventing default event behaviors on wasm](https://github.com/bevyengine/bevy/pull/7304)
 
-<!-- TODO -->
+<!-- TODO I'm not sure this needs a guide, I assume most people would be using the ..default() anyway and the ones that aren't doing that will just have a clear compile error -->
 
 ### [update winit to 0.28](https://github.com/bevyengine/bevy/pull/7480)
 

--- a/content/learn/book/migration-guides/0.9-0.10/_index.md
+++ b/content/learn/book/migration-guides/0.9-0.10/_index.md
@@ -578,7 +578,22 @@ just rename `ScalingMode::Auto` to `ScalingMode::AutoMin` if you are using it.
     <div class="migration-guide-area-tag">Rendering</div>
 </div>
 
-<!-- TODO -->
+```rust
+// 0.9
+shape::Icosphere {
+    radius: 0.5,
+    subdivisions: 5,
+}
+.into()
+
+// 0.10
+shape::Icosphere {
+    radius: 0.5,
+    subdivisions: 5,
+}
+.try_into()
+.unwrap()
+```
 
 ### [Add try_* to add_slot_edge, add_node_edge](https://github.com/bevyengine/bevy/pull/6720)
 

--- a/content/learn/book/migration-guides/0.9-0.10/_index.md
+++ b/content/learn/book/migration-guides/0.9-0.10/_index.md
@@ -466,10 +466,6 @@ Hierarchy editing methods such as `with_children` and `push_children` have been 
     <div class="migration-guide-area-tag">Reflection</div>
 </div>
 
-My guess for why we originally made `List` a subtrait of `Array` is that they share a lot of common operations. We could potentially move these overlapping methods to a `Sequence` (name taken from #7059) trait and make that a supertrait of both. This would allow functions to contain logic that simply operates on a sequence rather than “list vs array”.
-
-However, this means that we’d need to add methods for converting to a `dyn Sequence`. It also might be confusing since we wouldn’t add a `ReflectRef::Sequence` or anything like that. Is such a trait worth adding (either in this PR or a followup one)?
-
 The `List` trait is no longer dependent on `Array`. Implementors of `List` can remove the `Array` impl and move its methods into the `List` impl (with only a couple tweaks).
 
 ```rust

--- a/content/learn/book/migration-guides/0.9-0.10/_index.md
+++ b/content/learn/book/migration-guides/0.9-0.10/_index.md
@@ -981,7 +981,7 @@ app.new()
         ..default()
     }));
 
-// 0.9
+// 0.10
 app.new()
     .add_plugins(DefaultPlugins.set(WindowPlugin {
         primary_window: Some(Window {

--- a/content/learn/book/migration-guides/0.9-0.10/_index.md
+++ b/content/learn/book/migration-guides/0.9-0.10/_index.md
@@ -798,7 +798,8 @@ The `FrameCount`  resource was previously only updated when using the `bevy_rend
 
 #### Multiple fixed timesteps
 
-Only one fixed timestep is supported. If you were relying on this functionality, you should swap to using timers, via the on_timer(MY_PERIOD) run condition.
+Apps may now only have one unified fixed timestep. If you were relying on this functionality, you should swap to using timers, via the `on_timer(MY_PERIOD)` run condition.
+
 
 ### [Pipelined Rendering](https://github.com/bevyengine/bevy/pull/6503)
 

--- a/content/learn/book/migration-guides/0.9-0.10/_index.md
+++ b/content/learn/book/migration-guides/0.9-0.10/_index.md
@@ -35,29 +35,25 @@ As a result, the Minimum Supported Rust Version (MSRV) is "the latest stable rel
 
 `App::add_sub_app` has been removed in favor of `App::insert_sub_app`. Use `SubApp::new` and insert it via `App::add_sub_app`
 
-Old:
-
 ```rust
+// 0.9
 let mut sub_app = App::new()
 // Build subapp here
 app.add_sub_app(MySubAppLabel, sub_app);
-```
 
-New:
-
-```rust
+// 0.10
 let mut sub_app = App::new()
 // Build subapp here
 app.insert_sub_app(MySubAppLabel, SubApp::new(sub_app, extract_fn));
 ```
 
-### [asset: make HandleUntyped::id private](https://github.com/bevyengine/bevy/pull/7076)
+### [Make HandleUntyped::id private](https://github.com/bevyengine/bevy/pull/7076)
 
 <div class="migration-guide-area-tags">
     <div class="migration-guide-area-tag">Assets</div>
 </div>
 
-- Instead of directly accessing the ID of a `HandleUntyped` as `handle.id`, use the new getter `handle.id()`.
+Instead of directly accessing the ID of a `HandleUntyped` as `handle.id`, use the new getter `handle.id()`.
 
 ### [Break `CorePlugin` into `TaskPoolPlugin`, `TypeRegistrationPlugin`, `FrameCountPlugin`.](https://github.com/bevyengine/bevy/pull/7083)
 
@@ -65,7 +61,15 @@ app.insert_sub_app(MySubAppLabel, SubApp::new(sub_app, extract_fn));
     <div class="migration-guide-area-tag">Core</div>
 </div>
 
-- `CorePlugin` broken into separate plugins.  If not using `DefaultPlugins` or `MinimalPlugins` `PluginGroup`s, the replacement for `CorePlugin` is now to add `TaskPoolPlugin`, `TypeRegistrationPlugin`, and `FrameCountPlugin` to the app.
+`CorePlugin` broken into separate plugins.  If not using `DefaultPlugins` or `MinimalPlugins` `PluginGroup`s, the replacement for `CorePlugin` is now to add `TaskPoolPlugin`, `TypeRegistrationPlugin`, and `FrameCountPlugin` to the app.
+
+### [Remove broken `DoubleEndedIterator` impls on event iterators](https://github.com/bevyengine/bevy/pull/7469)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
+
+`ManualEventIterator` and `ManualEventIteratorWithId` are no longer `DoubleEndedIterator`s.
 
 ### [Replace `RemovedComponents<T>` backing with `Events<Entity>`](https://github.com/bevyengine/bevy/pull/5680)
 
@@ -82,17 +86,18 @@ app.insert_sub_app(MySubAppLabel, SubApp::new(sub_app, extract_fn));
     <div class="migration-guide-area-tag">ECS</div>
 </div>
 
+<!-- TODO -->
 _Note for maintainers: this migration guide makes more sense if it’s placed above the one for #6919._
 
 The trait method `ExclusiveSystemParamState::apply` has been removed. If you have an exclusive system with buffers that must be applied, you should apply them within the body of the exclusive system.
 
-### [add `UnsafeWorldCell` abstraction](https://github.com/bevyengine/bevy/pull/6404)
+### [Add `UnsafeWorldCell` abstraction](https://github.com/bevyengine/bevy/pull/6404)
 
 <div class="migration-guide-area-tags">
     <div class="migration-guide-area-tag">ECS</div>
 </div>
 
-<!-- TODO -->
+<!-- TODO no migration required, will remove later -->
 
 ### [Added `resource_id` and changed `init_resource` and `init_non_send_resource` to return `ComponentId`](https://github.com/bevyengine/bevy/pull/7284)
 
@@ -100,7 +105,8 @@ The trait method `ExclusiveSystemParamState::apply` has been removed. If you hav
     <div class="migration-guide-area-tag">ECS</div>
 </div>
 
-<!-- TODO -->
+- Changed `World::init_resource` to return the generated `ComponentId`.
+- Changed `World::init_non_send_resource` to return the generated `ComponentId`.
 
 ### [Basic adaptive batching for parallel query iteration](https://github.com/bevyengine/bevy/pull/4777)
 
@@ -110,19 +116,15 @@ The trait method `ExclusiveSystemParamState::apply` has been removed. If you hav
 
 The `batch_size` parameter for `Query(State)::par_for_each(_mut)` has been removed. These calls will automatically compute a batch size for you. Remove these parameters from all calls to these functions.
 
-Before:
-
 ```rust
+// 0.9
 fn parallel_system(query: Query<&MyComponent>) {
    query.par_for_each(32, |comp| {
         ...
    });
 }
-```
 
-After:
-
-```rust
+// 0.10
 fn parallel_system(query: Query<&MyComponent>) {
    query.par_iter().for_each(|comp| {
         ...
@@ -139,12 +141,12 @@ fn parallel_system(query: Query<&MyComponent>) {
 Exclusive systems (systems that access `&mut World`) now support system piping, so the `ExclusiveSystemParamFunction` trait now has generics for the `In`put and `Out`put types.
 
 ```rust
-// Before
+// 0.9
 fn my_generic_system<T, Param>(system_function: T)
 where T: ExclusiveSystemParamFunction<Param>
 { ... }
 
-// After
+// 0.10
 fn my_generic_system<T, In, Out, Param>(system_function: T)
 where T: ExclusiveSystemParamFunction<In, Out, Param>
 { ... }
@@ -156,7 +158,7 @@ where T: ExclusiveSystemParamFunction<In, Out, Param>
     <div class="migration-guide-area-tag">ECS</div>
 </div>
 
-- Safety invariants on `bevy_ptr` types’ `new` `byte_add` and `byte_offset` methods have been changed. All callers should re-audit for soundness.
+Safety invariants on `bevy_ptr` types’ `new` `byte_add` and `byte_offset` methods have been changed. All callers should re-audit for soundness.
 
 ### [Panic on dropping NonSend in non-origin thread.](https://github.com/bevyengine/bevy/pull/6534)
 
@@ -178,7 +180,7 @@ This is relative to Bevy 0.9, not main.
 The traits `SystemParamState` and `SystemParamFetch` have been removed, and their functionality has been transferred to `SystemParam`.
 
 ```rust
-// Before (0.9)
+// 0.9
 impl SystemParam for MyParam<'_, '_> {
     type State = MyParamState;
 }
@@ -191,7 +193,7 @@ unsafe impl<'w, 's> SystemParamFetch<'w, 's> for MyParamState {
 }
 unsafe impl ReadOnlySystemParamFetch for MyParamState { }
 
-// After (0.10)
+// 0.10
 unsafe impl SystemParam for MyParam<'_, '_> {
     type State = MyParamState;
     type Item<'w, 's> = MyParam<'w, 's>;
@@ -204,10 +206,10 @@ unsafe impl ReadOnlySystemParam for MyParam<'_, '_> { }
 The trait `ReadOnlySystemParamFetch` has been replaced with `ReadOnlySystemParam`.
 
 ```rust
-// Before
+// 0.9
 unsafe impl ReadOnlySystemParamFetch for MyParamState {}
 
-// After
+// 0.10
 unsafe impl ReadOnlySystemParam for MyParam<'_, '_> {}
 ```
 
@@ -225,7 +227,7 @@ A `World` can only hold a maximum of 2<sup>32</sup> - 1 archetypes and tables no
     <div class="migration-guide-area-tag">ECS</div>
 </div>
 
-- `MutUntyped::into_inner` now marks things as changed.
+`MutUntyped::into_inner` now marks things as changed.
 
 ### [Simplify trait hierarchy for `SystemParam`](https://github.com/bevyengine/bevy/pull/6865)
 
@@ -241,7 +243,7 @@ _Merged with the guide for #6919._
     <div class="migration-guide-area-tag">ECS</div>
 </div>
 
-<!-- TODO -->
+`Archetype` indices and `Table` rows have been newtyped as `ArchetypeRow` and `TableRow`.
 
 ### [Borrow instead of consuming in `EventReader::clear`](https://github.com/bevyengine/bevy/pull/6851)
 
@@ -252,12 +254,12 @@ _Merged with the guide for #6919._
 `EventReader::clear` now takes a mutable reference instead of consuming the event reader. This means that `clear` now needs explicit mutable access to the reader variable, which previously could have been omitted in some cases:
 
 ```rust
-// Old (0.9)
+// 0.9
 fn clear_events(reader: EventReader<SomeEvent>) {
   reader.clear();
 }
 
-// New (0.10)
+// 0.10
 fn clear_events(mut reader: EventReader<SomeEvent>) {
   reader.clear();
 }
@@ -272,13 +274,13 @@ fn clear_events(mut reader: EventReader<SomeEvent>) {
 The lifetime `'s` has been removed from `EventWriter`. Any code that explicitly specified the lifetimes for this type will need to be updated.
 
 ```rust
-// Before
+// 0.9
 #[derive(SystemParam)]
 struct MessageWriter<'w, 's> {
     events: EventWriter<'w, 's, Message>,
 }
 
-// After
+// 0.10
 #[derive(SystemParam)]
 struct MessageWriter<'w> {
     events: EventWriter<'w, Message>,
@@ -291,7 +293,9 @@ struct MessageWriter<'w> {
     <div class="migration-guide-area-tag">ECS</div>
 </div>
 
-<!-- TODO -->
+`Entities`’s `Default` implementation has been removed. You can fetch a reference to a `World`’s `Entities` via `World::entities` and `World::entities_mut`.
+
+`Entities::alloc_at_without_replacement` and `AllocAtWithoutReplacement` has been made private due to difficulty in using it properly outside of `bevy_ecs`. If you still need use of this API, please file an issue.
 
 ### [Document and lock down types in bevy_ecs::archetype](https://github.com/bevyengine/bevy/pull/6742)
 
@@ -299,7 +303,9 @@ struct MessageWriter<'w> {
     <div class="migration-guide-area-tag">ECS</div>
 </div>
 
-<!-- TODO -->
+`ArchetypeId`, `ArchetypeGeneration`, and `ArchetypeComponentId` are all now opaque IDs and cannot be turned into a numeric value. Please file an issue if this does not work for your use case.
+
+`Archetype` and `Archetypes` are not constructible outside of `bevy_ecs` now. Use `World::archetypes` to get a read-only reference to either of these types.
 
 ### [Split Component Ticks](https://github.com/bevyengine/bevy/pull/6547)
 
@@ -307,7 +313,15 @@ struct MessageWriter<'w> {
     <div class="migration-guide-area-tag">ECS</div>
 </div>
 
-TODO
+Various low level APIs interacting with the change detection ticks no longer return `&UnsafeCell<ComponentTicks>`, instead returning `TickCells` which contains two separate `&UnsafeCell<Tick>`s instead.
+
+```rust
+// 0.9
+column.get_ticks(row).deref().changed
+
+// 0.10
+column.get_ticks(row).changed.deref()
+```
 
 ### [Immutable sparse sets for metadata storage](https://github.com/bevyengine/bevy/pull/4928)
 
@@ -332,16 +346,16 @@ Do I still need to do this? I really hope people were not relying on the public 
     <div class="migration-guide-area-tag">Diagnostics</div>
 </div>
 
-<!-- TODO -->
+<!-- TODO no migration required, will remove later-->
 
-### [bevy_ecs: ReflectComponentFns without World](https://github.com/bevyengine/bevy/pull/7206)
+### [ReflectComponentFns without World](https://github.com/bevyengine/bevy/pull/7206)
 
 <div class="migration-guide-area-tags">
     <div class="migration-guide-area-tag">ECS</div>
     <div class="migration-guide-area-tag">Reflection</div>
 </div>
 
-- Call `World::entity` before calling into the changed `ReflectComponent` methods, most likely user already has a `EntityRef` or `EntityMut` which was being queried redundantly.
+Call `World::entity` before calling into the changed `ReflectComponent` methods, most likely user already has a `EntityRef` or `EntityMut` which was being queried redundantly.
 
 ### [Allow iterating over with EntityRef over the entire World](https://github.com/bevyengine/bevy/pull/6843)
 
@@ -350,7 +364,7 @@ Do I still need to do this? I really hope people were not relying on the public 
     <div class="migration-guide-area-tag">Scenes</div>
 </div>
 
-<!-- TODO -->
+`World::iter_entities` now returns an iterator of `EntityRef` instead of `Entity`. To get the actual ID, use `EntityRef::id` from the returned `EntityRef`s.
 
 ### [Remove `BuildWorldChildren` impl from `WorldChildBuilder`](https://github.com/bevyengine/bevy/pull/6727)
 
@@ -358,8 +372,7 @@ Do I still need to do this? I really hope people were not relying on the public 
     <div class="migration-guide-area-tag">Hierarchy</div>
 </div>
 
-Hierarchy editing methods such as `with_children` and `push_children` have been removed from `WorldChildBuilder`.
-You can edit the hierarchy via `EntityMut` instead.
+Hierarchy editing methods such as `with_children` and `push_children` have been removed from `WorldChildBuilder`. You can edit the hierarchy via `EntityMut` instead.
 
 ### [Rename dynamic feature](https://github.com/bevyengine/bevy/pull/7340)
 
@@ -367,18 +380,17 @@ You can edit the hierarchy via `EntityMut` instead.
     <div class="migration-guide-area-tag">Meta</div>
 </div>
 
-- `dynamic` feature was renamed to `dynamic_linking`
+`dynamic` feature was renamed to `dynamic_linking`
 
-### [reflect: add `insert` and `remove` methods to `List`](https://github.com/bevyengine/bevy/pull/7063)
+### [Add `insert` and `remove` methods to `List`](https://github.com/bevyengine/bevy/pull/7063)
 
 <div class="migration-guide-area-tags">
     <div class="migration-guide-area-tag">Reflection</div>
 </div>
 
-- Manual implementors of `List` need to implement the new methods `insert` and `remove` and
-consider whether to use the new default implementation of `push` and `pop`.
+Manual implementors of `List` need to implement the new methods `insert` and `remove` and consider whether to use the new default implementation of `push` and `pop`.
 
-### [bevy_reflect: Remove `ReflectSerialize` and `ReflectDeserialize` registrations from most glam types](https://github.com/bevyengine/bevy/pull/6580)
+### [Remove `ReflectSerialize` and `ReflectDeserialize` registrations from most glam types](https://github.com/bevyengine/bevy/pull/6580)
 
 <div class="migration-guide-area-tags">
     <div class="migration-guide-area-tag">Reflection</div>
@@ -390,11 +402,11 @@ This PR removes `ReflectSerialize` and `ReflectDeserialize` registrations from m
 This also means that some serialized glam types will need to be updated. For example, here is `Affine3A`:
 
 ```rust
-// BEFORE
+// 0.9
 (
   "glam::f32::affine3a::Affine3A": (1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0),
 
-// AFTER
+// 0.10
   "glam::f32::affine3a::Affine3A": (
     matrix3: (
       x_axis: (
@@ -437,12 +449,12 @@ This also means that some serialized glam types will need to be updated. For exa
 </div>
 
 ```rust
+// 0.9
 let multi = Msaa { samples: 4 }
-// is now
-let multi = Msaa::Sample4
-
 multi.samples
-// is now
+
+// 0.10
+let multi = Msaa::Sample4
 multi.samples()
 ```
 
@@ -452,7 +464,7 @@ multi.samples()
     <div class="migration-guide-area-tag">Rendering</div>
 </div>
 
-- Most usages of `resource_mut::<PipelineCache>` and `ResMut<PipelineCache>` can be changed to `resource::<PipelineCache>` and `Res<PipelineCache>` as long as they don’t use any methods requiring mutability - the only public method requiring it is `process_queue`.
+Most usages of `resource_mut::<PipelineCache>` and `ResMut<PipelineCache>` can be changed to `resource::<PipelineCache>` and `Res<PipelineCache>` as long as they don’t use any methods requiring mutability - the only public method requiring it is `process_queue`.
 
 ### [Reduce branching in TrackedRenderPass](https://github.com/bevyengine/bevy/pull/7053)
 
@@ -460,7 +472,21 @@ multi.samples()
     <div class="migration-guide-area-tag">Rendering</div>
 </div>
 
-TODO
+`TrackedRenderPass` now requires a `RenderDevice` to construct. To make this easier, use `RenderContext.begin_tracked_render_pass` instead.
+
+```rust
+// 0.9
+TrackedRenderPass::new(render_context.command_encoder.begin_render_pass(
+  &RenderPassDescriptor {
+    ...
+  },
+));
+
+// 0.10
+render_context.begin_tracked_render_pass(RenderPassDescriptor {
+  ...
+});
+```
 
 ### [Rename camera "priority" to "order"](https://github.com/bevyengine/bevy/pull/6908)
 
@@ -468,9 +494,27 @@ TODO
     <div class="migration-guide-area-tag">Rendering</div>
 </div>
 
-<!-- TODO -->
+```rust
+// 0.9
+Camera2dBundle {
+    camera: Camera {
+        priority: 1,
+        ..default()
+    },
+    ..default()
+}
 
-### [enum `Visibility` component](https://github.com/bevyengine/bevy/pull/6320)
+// 0.10
+Camera2dBundle {
+    camera: Camera {
+        order: 1,
+        ..default()
+    },
+    ..default()
+}
+```
+
+### [Enum `Visibility` component](https://github.com/bevyengine/bevy/pull/6320)
 
 <div class="migration-guide-area-tags">
     <div class="migration-guide-area-tag">Rendering</div>
@@ -481,7 +525,7 @@ TODO
 - usage of `Visibility::VISIBLE` or `Visibility::INVISIBLE` should now use `Visibility::Inherited` or `Visibility::Hidden` respectively.
 - `ComputedVisibility::INVISIBLE` and `SpatialBundle::VISIBLE_IDENTITY` have been renamed to `ComputedVisibility::HIDDEN` and `SpatialBundle::INHERITED_IDENTITY` respectively.
 
-### [run clear trackers on render world](https://github.com/bevyengine/bevy/pull/6878)
+### [Run clear trackers on render world](https://github.com/bevyengine/bevy/pull/6878)
 
 <div class="migration-guide-area-tags">
     <div class="migration-guide-area-tag">Rendering</div>
@@ -489,7 +533,7 @@ TODO
 
 The call to `clear_trackers` in `App` has been moved from the schedule to App::update for the main world and calls to `clear_trackers` have been added for sub_apps in the same function. This was due to needing stronger guarantees. If clear_trackers isn’t called on a world it can lead to memory leaks in `RemovedComponents`.
 
-### [get pixel size from wgpu](https://github.com/bevyengine/bevy/pull/6820)
+### [Get pixel size from wgpu](https://github.com/bevyengine/bevy/pull/6820)
 
 <div class="migration-guide-area-tags">
     <div class="migration-guide-area-tag">Rendering</div>
@@ -512,11 +556,9 @@ The call to `clear_trackers` in `App` has been moved from the schedule to App::u
     <div class="migration-guide-area-tag">Rendering</div>
 </div>
 
-Remove `.unwrap()` from `add_node_edge` and `add_slot_edge`.
-For cases where the error was handled, use `try_add_node_edge` and `try_add_slot_edge` instead.
+Remove `.unwrap()` from `add_node_edge` and `add_slot_edge`. For cases where the error was handled, use `try_add_node_edge` and `try_add_slot_edge` instead.
 
-Remove `.unwrap()` from `input_node`.
-For cases where the option was handled, use `get_input_node` instead.
+Remove `.unwrap()` from `input_node`. For cases where the option was handled, use `get_input_node` instead.
 
 ### [Add AutoMax next to ScalingMode::AutoMin](https://github.com/bevyengine/bevy/pull/6496)
 
@@ -524,7 +566,7 @@ For cases where the option was handled, use `get_input_node` instead.
     <div class="migration-guide-area-tag">Rendering</div>
 </div>
 
-just rename `ScalingMode::Auto` to `ScalingMode::AutoMin` if you are using it.
+Rename `ScalingMode::Auto` to `ScalingMode::AutoMin` if you are using it.
 
 ### [Change `From<Icosphere>` to `TryFrom<Icosphere>`](https://github.com/bevyengine/bevy/pull/6484)
 
@@ -532,7 +574,22 @@ just rename `ScalingMode::Auto` to `ScalingMode::AutoMin` if you are using it.
     <div class="migration-guide-area-tag">Rendering</div>
 </div>
 
-<!-- TODO -->
+```rust
+// 0.9
+shape::Icosphere {
+    radius: 0.5,
+    subdivisions: 5,
+}
+.into()
+
+// 0.10
+shape::Icosphere {
+    radius: 0.5,
+    subdivisions: 5,
+}
+.try_into()
+.unwrap()
+```
 
 ### [Directly extract joints into SkinnedMeshJoints](https://github.com/bevyengine/bevy/pull/6833)
 
@@ -550,7 +607,7 @@ just rename `ScalingMode::Auto` to `ScalingMode::AutoMin` if you are using it.
     <div class="migration-guide-area-tag">Assets</div>
 </div>
 
-<!-- TODO -->
+No api changes are required, but it's possible that your gltf meshes look different
 
 ### [The `update_frame_count` system should be placed in CorePlugin](https://github.com/bevyengine/bevy/pull/6676)
 
@@ -560,7 +617,36 @@ just rename `ScalingMode::Auto` to `ScalingMode::AutoMin` if you are using it.
     <div class="migration-guide-area-tag">Time</div>
 </div>
 
-<!-- TODO -->
+The `FrameCount`  resource was previously only updated when using the `bevy_render` feature. If you are not using this feature but still want the `FrameCount` it will now be updated correctly.
+
+### [Migrate engine to Schedule v3](https://github.com/bevyengine/bevy/pull/7267)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
+
+- Calls to `.label(MyLabel)` should be replaced with `.in_set(MySet)`
+- Stages have been removed. Replace these with system sets, and then add command flushes using the `apply_system_buffers` exclusive system where needed.
+- The `CoreStage`, `StartupStage,`RenderStage`and`AssetStage`enums have been replaced with`CoreSet`,`StartupSet, `RenderSet` and `AssetSet`. The same scheduling guarantees have been preserved.
+  - Systems are no longer added to `CoreSet::Update` by default. Add systems manually if this behavior is needed, although you should consider adding your game logic systems to `CoreSchedule::FixedTimestep` instead for more reliable framerate-independent behavior.
+  - Similarly, startup systems are no longer part of `StartupSet::Startup` by default. In most cases, this won’t matter to you.
+  - For example, `add_system_to_stage(CoreStage::PostUpdate, my_system)` should be replaced with
+  - `add_system(my_system.in_set(CoreSet::PostUpdate)`
+- When testing systems or otherwise running them in a headless fashion, simply construct and run a schedule using `Schedule::new()` and `World::run_schedule` rather than constructing stages
+- Run criteria have been renamed to run conditions. These can now be combined with each other and with states.
+- Looping run criteria and state stacks have been removed. Use an exclusive system that runs a schedule if you need this level of control over system control flow.
+- For app-level control flow over which schedules get run when (such as for rollback networking), create your own schedule and insert it under the `CoreSchedule::Outer` label.
+- Fixed timesteps are now evaluated in a schedule, rather than controlled via run criteria. The `run_fixed_timestep` system runs this schedule between `CoreSet::First` and `CoreSet::PreUpdate` by default.
+- Command flush points introduced by `AssetStage` have been removed. If you were relying on these, add them back manually.
+- the `calculate_bounds` system, with the `CalculateBounds` label, is now in `CoreSet::Update`, rather than in `CoreSet::PostUpdate` before commands are applied. You may need to order your movement systems to occur before this system in order to avoid system order ambiguities in culling behavior.
+- the `RenderLabel` `AppLabel` was renamed to `RenderApp` for clarity
+- `App::add_state` now takes 0 arguments: the starting state is set based on the `Default` impl.
+- Instead of creating `SystemSet` containers for systems that run in stages, simply use `.on_enter::<State::Variant>()` or its `on_exit` or `on_update` siblings.
+- `SystemLabel` derives should be replaced with `SystemSet`. You will also need to add the `Debug`, `PartialEq`, `Eq`, and `Hash` traits to satisfy the new trait bounds.
+- `with_run_criteria` has been renamed to `run_if`. Run criteria have been renamed to run conditions for clarity, and should now simply return a bool.
+- States have been dramatically simplified: there is no longer a “state stack”. To queue a transition to the next state, call `NextState::set`
+- Strings can no longer be used as a `SystemLabel` or `SystemSet`. Use a type, or use the system function instead.
 
 ### [Pipelined Rendering](https://github.com/bevyengine/bevy/pull/6503)
 
@@ -569,6 +655,10 @@ just rename `ScalingMode::Auto` to `ScalingMode::AutoMin` if you are using it.
     <div class="migration-guide-area-tag">Tasks</div>
 </div>
 
+__App `runner` and SubApp `extract` functions are now required to be Send__
+
+This was changed to enable pipelined rendering. If this breaks your use case please report it as these new bounds might be able to be relaxed.
+
 ### [Rename the `background_color` of 'ExtractedUiNode` to `color`](https://github.com/bevyengine/bevy/pull/7452)
 
 <div class="migration-guide-area-tags">
@@ -576,7 +666,7 @@ just rename `ScalingMode::Auto` to `ScalingMode::AutoMin` if you are using it.
     <div class="migration-guide-area-tag">UI</div>
 </div>
 
-- The `background_color` field of `ExtractedUiNode` is now named `color`.
+The `background_color` field of `ExtractedUiNode` is now named `color`.
 
 ### [Remove ImageMode](https://github.com/bevyengine/bevy/pull/6674)
 
@@ -585,15 +675,15 @@ just rename `ScalingMode::Auto` to `ScalingMode::AutoMin` if you are using it.
     <div class="migration-guide-area-tag">UI</div>
 </div>
 
-<!-- TODO -->
+`ImageNode` never worked, if you were using it please create an issue.
 
-### [Make spawn_dynamic return InstanceId](https://github.com/bevyengine/bevy/pull/6663)
+### [Make `spawn_dynamic` return InstanceId](https://github.com/bevyengine/bevy/pull/6663)
 
 <div class="migration-guide-area-tags">
     <div class="migration-guide-area-tag">Scenes</div>
 </div>
 
-<!-- TODO -->
+<!-- TODO no migration required, will remove it later-->
 
 ### [Parallelized transform propagation](https://github.com/bevyengine/bevy/pull/4775)
 
@@ -601,7 +691,7 @@ just rename `ScalingMode::Auto` to `ScalingMode::AutoMin` if you are using it.
     <div class="migration-guide-area-tag">Transform</div>
 </div>
 
-<!-- TODO -->
+<!-- TODO no migration required, will remove it later-->
 
 ### [Remove the `GlobalTransform::translation_mut` method](https://github.com/bevyengine/bevy/pull/7134)
 
@@ -610,14 +700,9 @@ just rename `ScalingMode::Auto` to `ScalingMode::AutoMin` if you are using it.
     <div class="migration-guide-area-tag">Hierarchy</div>
 </div>
 
-`GlobalTransform::translation_mut` has been removed without alternative,
-if you were relying on this, update the `Transform` instead. If the given entity
-had children or parent, you may need to remove its parent to make its transform
-independent (in which case the new `Commands::set_parent_in_place` and
-`Commands::remove_parent_in_place` may be of interest)
+`GlobalTransform::translation_mut` has been removed without alternative, if you were relying on this, update the `Transform` instead. If the given entity had children or parent, you may need to remove its parent to make its transform independent (in which case the new `Commands::set_parent_in_place` and `Commands::remove_parent_in_place` may be of interest)
 
-Bevy may add in the future a way to toggle transform propagation on
-an entity basis.
+Bevy may add in the future a way to toggle transform propagation on an entity basis.
 
 ### [change the default `width` and `height` of `Size` to `Val::Auto`](https://github.com/bevyengine/bevy/pull/7475)
 
@@ -625,8 +710,7 @@ an entity basis.
     <div class="migration-guide-area-tag">UI</div>
 </div>
 
-The default values for `Size` `width` and `height` have been changed from `Val::Undefined` to `Val::Auto`.
-It’s unlikely to cause any issues with existing code.
+The default values for `Size` `width` and `height` have been changed from `Val::Undefined` to `Val::Auto`. It’s unlikely to cause any issues with existing code.
 
 ### [Remove `QueuedText`](https://github.com/bevyengine/bevy/pull/7414)
 
@@ -634,7 +718,7 @@ It’s unlikely to cause any issues with existing code.
     <div class="migration-guide-area-tag">UI</div>
 </div>
 
-<!-- TODO -->
+`QueuedText` was never meant to be user facing. If you relied on it, please make an issue.
 
 ### [Remove VerticalAlign from TextAlignment](https://github.com/bevyengine/bevy/pull/6807)
 
@@ -644,13 +728,23 @@ It’s unlikely to cause any issues with existing code.
 
 The `alignment` field of `Text` now only affects the text’s internal alignment.
 
+__Change `TextAlignment` to TextAlignment` which is now an enum. Replace:__
+
+- `TextAlignment::TOP_LEFT`, `TextAlignment::CENTER_LEFT`, `TextAlignment::BOTTOM_LEFT` with `TextAlignment::Left`
+- `TextAlignment::TOP_CENTER`, `TextAlignment::CENTER_LEFT`, `TextAlignment::BOTTOM_CENTER` with `TextAlignment::Center`
+- `TextAlignment::TOP_RIGHT`, `TextAlignment::CENTER_RIGHT`, `TextAlignment::BOTTOM_RIGHT` with `TextAlignment::Right`
+
+__Changes for `Text2dBundle`__
+
+`Text2dBundle` has a new field ‘text_anchor’ that takes an `Anchor` component that controls its position relative to its transform.
+
 ### [Change default FocusPolicy to Pass](https://github.com/bevyengine/bevy/pull/7161)
 
 <div class="migration-guide-area-tags">
     <div class="migration-guide-area-tag">UI</div>
 </div>
 
-- `FocusPolicy` default has changed from `FocusPolicy::Block` to `FocusPolicy::Pass`
+`FocusPolicy` default has changed from `FocusPolicy::Block` to `FocusPolicy::Pass`
 
 ### [Remove `TextError::ExceedMaxTextAtlases(usize)` variant](https://github.com/bevyengine/bevy/pull/6796)
 
@@ -658,7 +752,7 @@ The `alignment` field of `Text` now only affects the text’s internal alignment
     <div class="migration-guide-area-tag">UI</div>
 </div>
 
-<!-- TODO -->
+`TextError::ExceedMaxTextAtlases(usize)` was never thrown so if you were matching on this variant you can simply remove it.
 
 ### [Flip UI image](https://github.com/bevyengine/bevy/pull/6292)
 
@@ -666,33 +760,43 @@ The `alignment` field of `Text` now only affects the text’s internal alignment
     <div class="migration-guide-area-tag">UI</div>
 </div>
 
-<!-- TODO -->
+```rust
+// 0.9
+commands.spawn(ImageBundle {
+    style: button_icon_style.clone(),
+    image: UiImage(icon),
+    ..default()
+});
 
-### [update winit to 0.28](https://github.com/bevyengine/bevy/pull/7480)
+// 0.10
+commands.spawn(ImageBundle {
+    style: button_icon_style.clone(),
+    image: UiImage::new(icon),
+    ..default()
+});
+```
+
+### [Update winit to 0.28](https://github.com/bevyengine/bevy/pull/7480)
 
 <div class="migration-guide-area-tags">
     <div class="migration-guide-area-tag">Windowing</div>
 </div>
 
-before:
-
 ```rust
-    app.new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
+// 0.9
+app.new()
+    .add_plugins(DefaultPlugins.set(WindowPlugin {
+        primary_window: Some(Window {
                 always_on_top: true,
                 ..default()
-            }),
-            ..default()
-        }));
-```
+        }),
+        ..default()
+    }));
 
-after:
-
-```rust
-    app.new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
+// 0.10
+app.new()
+    .add_plugins(DefaultPlugins.set(WindowPlugin {
+        primary_window: Some(Window {
                 window_level: bevy::window::WindowLevel::AlwaysOnTop,
                 ..default()
             }),
@@ -706,7 +810,7 @@ after:
     <div class="migration-guide-area-tag">Windowing</div>
 </div>
 
-<!-- TODO -->
+<!-- TODO I'm not sure this needs a guide, I assume most people would be using the ..default() anyway and the ones that aren't doing that will just have a clear compile error -->
 
 ### [Windows as Entities](https://github.com/bevyengine/bevy/pull/5589)
 

--- a/content/learn/book/migration-guides/0.9-0.10/_index.md
+++ b/content/learn/book/migration-guides/0.9-0.10/_index.md
@@ -11,68 +11,27 @@ long_title = "Migration Guide: 0.9 to 0.10"
 
 Bevy relies heavily on improvements in the Rust language and compiler.
 As a result, the Minimum Supported Rust Version (MSRV) is "the latest stable release" of Rust.
+<div class="migration-guide">
 
-### [Replace `RemovedComponents<T>` backing with `Events<Entity>`](https://github.com/bevyengine/bevy/pull/5680)
+### [bevy_reflect: Pre-parsed paths](https://github.com/bevyengine/bevy/pull/7321)
 
-* Add a `mut` for `removed: RemovedComponents<T>` since we are now modifying an event reader internally.
-* Iterating over removed components now requires `&mut removed_components` or `removed_components.iter()` instead of `&removed_components`.
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Animation</div>
+    <div class="migration-guide-area-tag">Reflection</div>
+</div>
 
-### [Remove `ExclusiveSystemParam::apply`](https://github.com/bevyengine/bevy/pull/7489)
+`GetPath` methods have been renamed according to the following:
 
-_Note for maintainers: this migration guide makes more sense if it’s placed above the one for #6919._
-
-The trait method `ExclusiveSystemParamState::apply` has been removed. If you have an exclusive system with buffers that must be applied, you should apply them within the body of the exclusive system.
-
-### [update winit to 0.28](https://github.com/bevyengine/bevy/pull/7480)
-
-before:
-
-```rust
-    app.new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                always_on_top: true,
-                ..default()
-            }),
-            ..default()
-        }));
-```
-
-after:
-
-```rust
-    app.new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                window_level: bevy::window::WindowLevel::AlwaysOnTop,
-                ..default()
-            }),
-            ..default()
-        }));
-```
-
-### [bevy_ecs: ReflectComponentFns without World](https://github.com/bevyengine/bevy/pull/7206)
-
-* Call `World::entity` before calling into the changed `ReflectComponent` methods, most likely user already has a `EntityRef` or `EntityMut` which was being queried redundantly.
-
-### [change the default `width` and `height` of `Size` to `Val::Auto`](https://github.com/bevyengine/bevy/pull/7475)
-
-The default values for `Size` `width` and `height` have been changed from `Val::Undefined` to `Val::Auto`.
-It’s unlikely to cause any issues with existing code.
-
-### [Rename the `background_color` of 'ExtractedUiNode` to `color`](https://github.com/bevyengine/bevy/pull/7452)
-
-* The `background_color` field of `ExtractedUiNode` is now named `color`.
-
-### [Remove `QueuedText`](https://github.com/bevyengine/bevy/pull/7414)
-
-<!-- TODO -->
-
-### [add `UnsafeWorldCell` abstraction](https://github.com/bevyengine/bevy/pull/6404)
-
-<!-- TODO -->
+- `path` -> `reflect_path`
+- `path_mut` -> `reflect_path_mut`
+- `get_path` -> `path`
+- `get_path_mut` -> `path_mut`
 
 ### [Remove App::add_sub_app](https://github.com/bevyengine/bevy/pull/7290)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">App</div>
+</div>
 
 `App::add_sub_app` has been removed in favor of `App::insert_sub_app`. Use `SubApp::new` and insert it via `App::add_sub_app`
 
@@ -92,44 +51,62 @@ let mut sub_app = App::new()
 app.insert_sub_app(MySubAppLabel, SubApp::new(sub_app, extract_fn));
 ```
 
-### [Rename dynamic feature](https://github.com/bevyengine/bevy/pull/7340)
+### [asset: make HandleUntyped::id private](https://github.com/bevyengine/bevy/pull/7076)
 
-* `dynamic` feature was renamed to `dynamic_linking`
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Assets</div>
+</div>
 
-### [bevy_reflect: Pre-parsed paths](https://github.com/bevyengine/bevy/pull/7321)
+- Instead of directly accessing the ID of a `HandleUntyped` as `handle.id`, use the new getter `handle.id()`.
 
-`GetPath` methods have been renamed according to the following:
+### [Break `CorePlugin` into `TaskPoolPlugin`, `TypeRegistrationPlugin`, `FrameCountPlugin`.](https://github.com/bevyengine/bevy/pull/7083)
 
-* `path` -> `reflect_path`
-* `path_mut` -> `reflect_path_mut`
-* `get_path` -> `path`
-* `get_path_mut` -> `path_mut`
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Core</div>
+</div>
 
-### [Allow not preventing default event behaviors on wasm](https://github.com/bevyengine/bevy/pull/7304)
+- `CorePlugin` broken into separate plugins.  If not using `DefaultPlugins` or `MinimalPlugins` `PluginGroup`s, the replacement for `CorePlugin` is now to add `TaskPoolPlugin`, `TypeRegistrationPlugin`, and `FrameCountPlugin` to the app.
+
+### [Replace `RemovedComponents<T>` backing with `Events<Entity>`](https://github.com/bevyengine/bevy/pull/5680)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
+
+- Add a `mut` for `removed: RemovedComponents<T>` since we are now modifying an event reader internally.
+- Iterating over removed components now requires `&mut removed_components` or `removed_components.iter()` instead of `&removed_components`.
+
+### [Remove `ExclusiveSystemParam::apply`](https://github.com/bevyengine/bevy/pull/7489)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
+
+_Note for maintainers: this migration guide makes more sense if it’s placed above the one for #6919._
+
+The trait method `ExclusiveSystemParamState::apply` has been removed. If you have an exclusive system with buffers that must be applied, you should apply them within the body of the exclusive system.
+
+### [add `UnsafeWorldCell` abstraction](https://github.com/bevyengine/bevy/pull/6404)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
 
 <!-- TODO -->
-
-### [Support recording multiple CommandBuffers in RenderContext](https://github.com/bevyengine/bevy/pull/7248)
-
-`RenderContext`’s fields are now private. Use the accessors on `RenderContext` instead, and construct it with `RenderContext::new`.
 
 ### [Added `resource_id` and changed `init_resource` and `init_non_send_resource` to return `ComponentId`](https://github.com/bevyengine/bevy/pull/7284)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
+
 <!-- TODO -->
 
-### [Changed Msaa to Enum](https://github.com/bevyengine/bevy/pull/7292)
-
-```rust
-let multi = Msaa { samples: 4 }
-// is now
-let multi = Msaa::Sample4
-
-multi.samples
-// is now
-multi.samples()
-```
-
 ### [Basic adaptive batching for parallel query iteration](https://github.com/bevyengine/bevy/pull/4777)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
 
 The `batch_size` parameter for `Query(State)::par_for_each(_mut)` has been removed. These calls will automatically compute a batch size for you. Remove these parameters from all calls to these functions.
 
@@ -153,35 +130,11 @@ fn parallel_system(query: Query<&MyComponent>) {
 }
 ```
 
-### [Pipelined Rendering](https://github.com/bevyengine/bevy/pull/6503)
-
-### [Windows as Entities](https://github.com/bevyengine/bevy/pull/5589)
-
-* Replace `WindowDescriptor` with `Window`.
-* Change `width` and `height` fields in a `WindowResolution`, either by doing
-
-```rust
-WindowResolution::new(width, height) // Explicitly
-// or using From<_> for tuples for convenience
-(1920., 1080.).into()
-```
-
-* Replace any `WindowCommand` code to just modify the `Window`’s fields directly  and creating/closing windows is now by spawning/despawning an entity with a `Window` component like so:
-
-```rust
-let window = commands.spawn(Window { ... }).id(); // open window
-commands.entity(window).despawn(); // close window
-```
-
-### [Remove VerticalAlign from TextAlignment](https://github.com/bevyengine/bevy/pull/6807)
-
-The `alignment` field of `Text` now only affects the text’s internal alignment.
-
-### [Make PipelineCache internally mutable.](https://github.com/bevyengine/bevy/pull/7205)
-
-* Most usages of `resource_mut::<PipelineCache>` and `ResMut<PipelineCache>` can be changed to `resource::<PipelineCache>` and `Res<PipelineCache>` as long as they don’t use any methods requiring mutability - the only public method requiring it is `process_queue`.
-
 ### [Support piping exclusive systems](https://github.com/bevyengine/bevy/pull/7023)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
 
 Exclusive systems (systems that access `&mut World`) now support system piping, so the `ExclusiveSystemParamFunction` trait now has generics for the `In`put and `Out`put types.
 
@@ -197,39 +150,27 @@ where T: ExclusiveSystemParamFunction<In, Out, Param>
 { ... }
 ```
 
-### [Change default FocusPolicy to Pass](https://github.com/bevyengine/bevy/pull/7161)
-
-* `FocusPolicy` default has changed from `FocusPolicy::Block` to `FocusPolicy::Pass`
-
 ### [Document alignment requirements of `Ptr`, `PtrMut` and `OwningPtr`](https://github.com/bevyengine/bevy/pull/7151)
 
-* Safety invariants on `bevy_ptr` types’ `new` `byte_add` and `byte_offset` methods have been changed. All callers should re-audit for soundness.
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
 
-### [Remove the `GlobalTransform::translation_mut` method](https://github.com/bevyengine/bevy/pull/7134)
-
-`GlobalTransform::translation_mut` has been removed without alternative,
-if you were relying on this, update the `Transform` instead. If the given entity
-had children or parent, you may need to remove its parent to make its transform
-independent (in which case the new `Commands::set_parent_in_place` and
-`Commands::remove_parent_in_place` may be of interest)
-
-Bevy may add in the future a way to toggle transform propagation on
-an entity basis.
+- Safety invariants on `bevy_ptr` types’ `new` `byte_add` and `byte_offset` methods have been changed. All callers should re-audit for soundness.
 
 ### [Panic on dropping NonSend in non-origin thread.](https://github.com/bevyengine/bevy/pull/6534)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
+
 Normal resources and `NonSend` resources no longer share the same backing storage. If `R: Resource`, then `NonSend<R>` and `Res<R>` will return different instances from each other. If you are using both `Res<T>` and `NonSend<T>` (or their mutable variants), to fetch the same resources, it’s strongly advised to use `Res<T>`.
 
-### [reflect: add `insert` and `remove` methods to `List`](https://github.com/bevyengine/bevy/pull/7063)
-
-* Manual implementors of `List` need to implement the new methods `insert` and `remove` and
-consider whether to use the new default implementation of `push` and `pop`.
-
-### [Reduce branching in TrackedRenderPass](https://github.com/bevyengine/bevy/pull/7053)
-
-TODO
-
 ### [Remove the `SystemParamState` trait and remove types like `ResState`](https://github.com/bevyengine/bevy/pull/6919)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
 
 Note: this replaces the migration guide for #6865.
 This is relative to Bevy 0.9, not main.
@@ -270,62 +211,43 @@ unsafe impl ReadOnlySystemParamFetch for MyParamState {}
 unsafe impl ReadOnlySystemParam for MyParam<'_, '_> {}
 ```
 
-### [Break `CorePlugin` into `TaskPoolPlugin`, `TypeRegistrationPlugin`, `FrameCountPlugin`.](https://github.com/bevyengine/bevy/pull/7083)
-
-* `CorePlugin` broken into separate plugins.  If not using `DefaultPlugins` or `MinimalPlugins` `PluginGroup`s, the replacement for `CorePlugin` is now to add `TaskPoolPlugin`, `TypeRegistrationPlugin`, and `FrameCountPlugin` to the app.
-
-### [asset: make HandleUntyped::id private](https://github.com/bevyengine/bevy/pull/7076)
-
-* Instead of directly accessing the ID of a `HandleUntyped` as `handle.id`, use the new getter `handle.id()`.
-
 ### [Extend EntityLocation with TableId and TableRow](https://github.com/bevyengine/bevy/pull/6681)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
 
 A `World` can only hold a maximum of 232 - 1 archetypes and tables now. If your use case requires more than this, please file an issue explaining your use case.
 
 ### [Round out the untyped api s](https://github.com/bevyengine/bevy/pull/7009)
 
-* `MutUntyped::into_inner` now marks things as changed.
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
 
-### [Rename camera "priority" to "order"](https://github.com/bevyengine/bevy/pull/6908)
-
-<!-- TODO -->
-
-### [enum `Visibility` component](https://github.com/bevyengine/bevy/pull/6320)
-
-* evaluation of the `visibility.is_visible` field should now check for `visibility == Visibility::Inherited`.
-* setting the `visibility.is_visible` field should now directly set the value: `*visibility = Visibility::Inherited`.
-* usage of `Visibility::VISIBLE` or `Visibility::INVISIBLE` should now use `Visibility::Inherited` or `Visibility::Hidden` respectively.
-* `ComputedVisibility::INVISIBLE` and `SpatialBundle::VISIBLE_IDENTITY` have been renamed to `ComputedVisibility::HIDDEN` and `SpatialBundle::INHERITED_IDENTITY` respectively.
-
-### [Directly extract joints into SkinnedMeshJoints](https://github.com/bevyengine/bevy/pull/6833)
-
-`ExtractedJoints` has been removed. Read the bound bones from `SkinnedMeshJoints` instead.
-
-### [Move system_commands spans into apply_buffers](https://github.com/bevyengine/bevy/pull/6900)
-
-<!-- TODO -->
-
-### [run clear trackers on render world](https://github.com/bevyengine/bevy/pull/6878)
-
-The call to `clear_trackers` in `App` has been moved from the schedule to App::update for the main world and calls to `clear_trackers` have been added for sub_apps in the same function. This was due to needing stronger guarantees. If clear_trackers isn’t called on a world it can lead to memory leaks in `RemovedComponents`.
+- `MutUntyped::into_inner` now marks things as changed.
 
 ### [Simplify trait hierarchy for `SystemParam`](https://github.com/bevyengine/bevy/pull/6865)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
+
 _Merged with the guide for #6919._
-
-### [get pixel size from wgpu](https://github.com/bevyengine/bevy/pull/6820)
-
-`PixelInfo` has been removed. `PixelInfo::components` is equivalent to `texture_format.describe().components`. `PixelInfo::type_size` can be gotten from `texture_format.describe().block_size/ texture_format.describe().components`. But note this can yield incorrect results for some texture types like Rg11b10Float.
 
 ### [Newtype ArchetypeRow and TableRow](https://github.com/bevyengine/bevy/pull/4878)
 
-<!-- TODO -->
-
-### [Remove `TextError::ExceedMaxTextAtlases(usize)` variant](https://github.com/bevyengine/bevy/pull/6796)
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
 
 <!-- TODO -->
 
 ### [Borrow instead of consuming in `EventReader::clear`](https://github.com/bevyengine/bevy/pull/6851)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
 
 `EventReader::clear` now takes a mutable reference instead of consuming the event reader. This means that `clear` now needs explicit mutable access to the reader variable, which previously could have been omitted in some cases:
 
@@ -341,11 +263,11 @@ fn clear_events(mut reader: EventReader<SomeEvent>) {
 }
 ```
 
-### [Allow iterating over with EntityRef over the entire World](https://github.com/bevyengine/bevy/pull/6843)
-
-<!-- TODO -->
-
 ### [Make the `SystemParam` derive macro more flexible](https://github.com/bevyengine/bevy/pull/6694)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
 
 The lifetime `'s` has been removed from `EventWriter`. Any code that explicitly specified the lifetimes for this type will need to be updated.
 
@@ -363,19 +285,105 @@ struct MessageWriter<'w> {
 }
 ```
 
-### [Intepret glTF colors as linear instead of sRGB](https://github.com/bevyengine/bevy/pull/6828)
-
-<!-- TODO -->
-
 ### [Lock down access to Entities](https://github.com/bevyengine/bevy/pull/6740)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
 
 <!-- TODO -->
 
 ### [Document and lock down types in bevy_ecs::archetype](https://github.com/bevyengine/bevy/pull/6742)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
+
 <!-- TODO -->
 
+### [Split Component Ticks](https://github.com/bevyengine/bevy/pull/6547)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
+
+TODO
+
+### [Immutable sparse sets for metadata storage](https://github.com/bevyengine/bevy/pull/4928)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
+
+`Table::component_capacity()` has been removed as Tables do not support adding/removing columns after construction.
+
+### [Remove redundant table and sparse set component IDs from Archetype](https://github.com/bevyengine/bevy/pull/4927)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+</div>
+
+Do I still need to do this? I really hope people were not relying on the public facing APIs changed here.
+
+### [Move system_commands spans into apply_buffers](https://github.com/bevyengine/bevy/pull/6900)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+    <div class="migration-guide-area-tag">Diagnostics</div>
+</div>
+
+<!-- TODO -->
+
+### [bevy_ecs: ReflectComponentFns without World](https://github.com/bevyengine/bevy/pull/7206)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+    <div class="migration-guide-area-tag">Reflection</div>
+</div>
+
+- Call `World::entity` before calling into the changed `ReflectComponent` methods, most likely user already has a `EntityRef` or `EntityMut` which was being queried redundantly.
+
+### [Allow iterating over with EntityRef over the entire World](https://github.com/bevyengine/bevy/pull/6843)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">ECS</div>
+    <div class="migration-guide-area-tag">Scenes</div>
+</div>
+
+<!-- TODO -->
+
+### [Remove `BuildWorldChildren` impl from `WorldChildBuilder`](https://github.com/bevyengine/bevy/pull/6727)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Hierarchy</div>
+</div>
+
+Hierarchy editing methods such as `with_children` and `push_children` have been removed from `WorldChildBuilder`.
+You can edit the hierarchy via `EntityMut` instead.
+
+### [Rename dynamic feature](https://github.com/bevyengine/bevy/pull/7340)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Meta</div>
+</div>
+
+- `dynamic` feature was renamed to `dynamic_linking`
+
+### [reflect: add `insert` and `remove` methods to `List`](https://github.com/bevyengine/bevy/pull/7063)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Reflection</div>
+</div>
+
+- Manual implementors of `List` need to implement the new methods `insert` and `remove` and
+consider whether to use the new default implementation of `push` and `pop`.
+
 ### [bevy_reflect: Remove `ReflectSerialize` and `ReflectDeserialize` registrations from most glam types](https://github.com/bevyengine/bevy/pull/6580)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Reflection</div>
+    <div class="migration-guide-area-tag">Scenes</div>
+</div>
 
 This PR removes `ReflectSerialize` and `ReflectDeserialize` registrations from most glam types. This means any code relying on either of those type data existing for those glam types will need to not do that.
 
@@ -414,17 +422,95 @@ This also means that some serialized glam types will need to be updated. For exa
 )
 ```
 
-### [Remove `BuildWorldChildren` impl from `WorldChildBuilder`](https://github.com/bevyengine/bevy/pull/6727)
+### [Support recording multiple CommandBuffers in RenderContext](https://github.com/bevyengine/bevy/pull/7248)
 
-Hierarchy editing methods such as `with_children` and `push_children` have been removed from `WorldChildBuilder`.
-You can edit the hierarchy via `EntityMut` instead.
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+</div>
+
+`RenderContext`’s fields are now private. Use the accessors on `RenderContext` instead, and construct it with `RenderContext::new`.
+
+### [Changed Msaa to Enum](https://github.com/bevyengine/bevy/pull/7292)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+</div>
+
+```rust
+let multi = Msaa { samples: 4 }
+// is now
+let multi = Msaa::Sample4
+
+multi.samples
+// is now
+multi.samples()
+```
+
+### [Make PipelineCache internally mutable.](https://github.com/bevyengine/bevy/pull/7205)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+</div>
+
+- Most usages of `resource_mut::<PipelineCache>` and `ResMut<PipelineCache>` can be changed to `resource::<PipelineCache>` and `Res<PipelineCache>` as long as they don’t use any methods requiring mutability - the only public method requiring it is `process_queue`.
+
+### [Reduce branching in TrackedRenderPass](https://github.com/bevyengine/bevy/pull/7053)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+</div>
+
+TODO
+
+### [Rename camera "priority" to "order"](https://github.com/bevyengine/bevy/pull/6908)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+</div>
+
+<!-- TODO -->
+
+### [enum `Visibility` component](https://github.com/bevyengine/bevy/pull/6320)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+</div>
+
+- evaluation of the `visibility.is_visible` field should now check for `visibility == Visibility::Inherited`.
+- setting the `visibility.is_visible` field should now directly set the value: `*visibility = Visibility::Inherited`.
+- usage of `Visibility::VISIBLE` or `Visibility::INVISIBLE` should now use `Visibility::Inherited` or `Visibility::Hidden` respectively.
+- `ComputedVisibility::INVISIBLE` and `SpatialBundle::VISIBLE_IDENTITY` have been renamed to `ComputedVisibility::HIDDEN` and `SpatialBundle::INHERITED_IDENTITY` respectively.
+
+### [run clear trackers on render world](https://github.com/bevyengine/bevy/pull/6878)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+</div>
+
+The call to `clear_trackers` in `App` has been moved from the schedule to App::update for the main world and calls to `clear_trackers` have been added for sub_apps in the same function. This was due to needing stronger guarantees. If clear_trackers isn’t called on a world it can lead to memory leaks in `RemovedComponents`.
+
+### [get pixel size from wgpu](https://github.com/bevyengine/bevy/pull/6820)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+</div>
+
+`PixelInfo` has been removed. `PixelInfo::components` is equivalent to `texture_format.describe().components`. `PixelInfo::type_size` can be gotten from `texture_format.describe().block_size/ texture_format.describe().components`. But note this can yield incorrect results for some texture types like Rg11b10Float.
 
 ### [Shader defs can now have a value](https://github.com/bevyengine/bevy/pull/5900)
 
-* replace `shader_defs.push(String::from("NAME"));` by `shader_defs.push("NAME".into());`
-* if you used shader def `NO_STORAGE_BUFFERS_SUPPORT`, check how `AVAILABLE_STORAGE_BUFFER_BINDINGS` is now used in Bevy default shaders
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+</div>
+
+- replace `shader_defs.push(String::from("NAME"));` by `shader_defs.push("NAME".into());`
+- if you used shader def `NO_STORAGE_BUFFERS_SUPPORT`, check how `AVAILABLE_STORAGE_BUFFER_BINDINGS` is now used in Bevy default shaders
 
 ### [Add try_* to add_slot_edge, add_node_edge](https://github.com/bevyengine/bevy/pull/6720)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+</div>
 
 Remove `.unwrap()` from `add_node_edge` and `add_slot_edge`.
 For cases where the error was handled, use `try_add_node_edge` and `try_add_slot_edge` instead.
@@ -432,42 +518,216 @@ For cases where the error was handled, use `try_add_node_edge` and `try_add_slot
 Remove `.unwrap()` from `input_node`.
 For cases where the option was handled, use `get_input_node` instead.
 
-### [Parallelized transform propagation](https://github.com/bevyengine/bevy/pull/4775)
-
-<!-- TODO -->
-
-### [The `update_frame_count` system should be placed in CorePlugin](https://github.com/bevyengine/bevy/pull/6676)
-
-<!-- TODO -->
-
-### [Split Component Ticks](https://github.com/bevyengine/bevy/pull/6547)
-
-TODO
-
-### [Remove ImageMode](https://github.com/bevyengine/bevy/pull/6674)
-
-<!-- TODO -->
-
-### [Make spawn_dynamic return InstanceId](https://github.com/bevyengine/bevy/pull/6663)
-
-<!-- TODO -->
-
-### [Immutable sparse sets for metadata storage](https://github.com/bevyengine/bevy/pull/4928)
-
-`Table::component_capacity()` has been removed as Tables do not support adding/removing columns after construction.
-
-### [Remove redundant table and sparse set component IDs from Archetype](https://github.com/bevyengine/bevy/pull/4927)
-
-Do I still need to do this? I really hope people were not relying on the public facing APIs changed here.
-
 ### [Add AutoMax next to ScalingMode::AutoMin](https://github.com/bevyengine/bevy/pull/6496)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+</div>
 
 just rename `ScalingMode::Auto` to `ScalingMode::AutoMin` if you are using it.
 
 ### [Change `From<Icosphere>` to `TryFrom<Icosphere>`](https://github.com/bevyengine/bevy/pull/6484)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+</div>
+
+<!-- TODO -->
+
+### [Directly extract joints into SkinnedMeshJoints](https://github.com/bevyengine/bevy/pull/6833)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+    <div class="migration-guide-area-tag">Animation</div>
+</div>
+
+`ExtractedJoints` has been removed. Read the bound bones from `SkinnedMeshJoints` instead.
+
+### [Intepret glTF colors as linear instead of sRGB](https://github.com/bevyengine/bevy/pull/6828)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+    <div class="migration-guide-area-tag">Assets</div>
+</div>
+
+<!-- TODO -->
+
+### [The `update_frame_count` system should be placed in CorePlugin](https://github.com/bevyengine/bevy/pull/6676)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+    <div class="migration-guide-area-tag">Core</div>
+    <div class="migration-guide-area-tag">Time</div>
+</div>
+
+<!-- TODO -->
+
+### [Pipelined Rendering](https://github.com/bevyengine/bevy/pull/6503)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+    <div class="migration-guide-area-tag">Tasks</div>
+</div>
+
+### [Rename the `background_color` of 'ExtractedUiNode` to `color`](https://github.com/bevyengine/bevy/pull/7452)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+    <div class="migration-guide-area-tag">UI</div>
+</div>
+
+- The `background_color` field of `ExtractedUiNode` is now named `color`.
+
+### [Remove ImageMode](https://github.com/bevyengine/bevy/pull/6674)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+    <div class="migration-guide-area-tag">UI</div>
+</div>
+
+<!-- TODO -->
+
+### [Make spawn_dynamic return InstanceId](https://github.com/bevyengine/bevy/pull/6663)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Scenes</div>
+</div>
+
+<!-- TODO -->
+
+### [Parallelized transform propagation](https://github.com/bevyengine/bevy/pull/4775)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Transform</div>
+</div>
+
+<!-- TODO -->
+
+### [Remove the `GlobalTransform::translation_mut` method](https://github.com/bevyengine/bevy/pull/7134)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Transform</div>
+    <div class="migration-guide-area-tag">Hierarchy</div>
+</div>
+
+`GlobalTransform::translation_mut` has been removed without alternative,
+if you were relying on this, update the `Transform` instead. If the given entity
+had children or parent, you may need to remove its parent to make its transform
+independent (in which case the new `Commands::set_parent_in_place` and
+`Commands::remove_parent_in_place` may be of interest)
+
+Bevy may add in the future a way to toggle transform propagation on
+an entity basis.
+
+### [change the default `width` and `height` of `Size` to `Val::Auto`](https://github.com/bevyengine/bevy/pull/7475)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">UI</div>
+</div>
+
+The default values for `Size` `width` and `height` have been changed from `Val::Undefined` to `Val::Auto`.
+It’s unlikely to cause any issues with existing code.
+
+### [Remove `QueuedText`](https://github.com/bevyengine/bevy/pull/7414)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">UI</div>
+</div>
+
+<!-- TODO -->
+
+### [Remove VerticalAlign from TextAlignment](https://github.com/bevyengine/bevy/pull/6807)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">UI</div>
+</div>
+
+The `alignment` field of `Text` now only affects the text’s internal alignment.
+
+### [Change default FocusPolicy to Pass](https://github.com/bevyengine/bevy/pull/7161)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">UI</div>
+</div>
+
+- `FocusPolicy` default has changed from `FocusPolicy::Block` to `FocusPolicy::Pass`
+
+### [Remove `TextError::ExceedMaxTextAtlases(usize)` variant](https://github.com/bevyengine/bevy/pull/6796)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">UI</div>
+</div>
+
 <!-- TODO -->
 
 ### [Flip UI image](https://github.com/bevyengine/bevy/pull/6292)
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">UI</div>
+</div>
+
 <!-- TODO -->
+
+### [update winit to 0.28](https://github.com/bevyengine/bevy/pull/7480)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Windowing</div>
+</div>
+
+before:
+
+```rust
+    app.new()
+        .add_plugins(DefaultPlugins.set(WindowPlugin {
+            primary_window: Some(Window {
+                always_on_top: true,
+                ..default()
+            }),
+            ..default()
+        }));
+```
+
+after:
+
+```rust
+    app.new()
+        .add_plugins(DefaultPlugins.set(WindowPlugin {
+            primary_window: Some(Window {
+                window_level: bevy::window::WindowLevel::AlwaysOnTop,
+                ..default()
+            }),
+            ..default()
+        }));
+```
+
+### [Allow not preventing default event behaviors on wasm](https://github.com/bevyengine/bevy/pull/7304)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Windowing</div>
+</div>
+
+<!-- TODO -->
+
+### [Windows as Entities](https://github.com/bevyengine/bevy/pull/5589)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Windowing</div>
+</div>
+
+- Replace `WindowDescriptor` with `Window`.
+- Change `width` and `height` fields in a `WindowResolution`, either by doing
+
+```rust
+WindowResolution::new(width, height) // Explicitly
+// or using From<_> for tuples for convenience
+(1920., 1080.).into()
+```
+
+- Replace any `WindowCommand` code to just modify the `Window`’s fields directly  and creating/closing windows is now by spawning/despawning an entity with a `Window` component like so:
+
+```rust
+let window = commands.spawn(Window { ... }).id(); // open window
+commands.entity(window).despawn(); // close window
+```
+
+</div>

--- a/content/learn/book/migration-guides/0.9-0.10/_index.md
+++ b/content/learn/book/migration-guides/0.9-0.10/_index.md
@@ -319,7 +319,7 @@ For the `SystemParamFunction` trait, the type parameters `In`, `Out`, and `Param
 fn my_generic_system<T, In, Out, Param, Marker>(system_function: T)
 where
     T: SystemParamFunction<In, Out, Param, Marker>,
-    T: Param: SystemParam,
+    Param: SystemParam,
 { ... }
 
 // 0.10

--- a/content/learn/book/migration-guides/0.9-0.10/_index.md
+++ b/content/learn/book/migration-guides/0.9-0.10/_index.md
@@ -35,7 +35,6 @@ As a result, the Minimum Supported Rust Version (MSRV) is "the latest stable rel
 
 `App::add_sub_app` has been removed in favor of `App::insert_sub_app`. Use `SubApp::new` and insert it via `App::insert_sub_app`
 
-
 Old:
 
 ```rust
@@ -177,6 +176,7 @@ fn clear_events(mut reader: EventReader<SomeEvent>) {
 </div>
 
 A `World` can only hold a maximum of 2<sup>32</sup> - 1 archetypes and tables now. If your use case requires more than this, please file an issue explaining your use case.
+
 ### [Remove `ExclusiveSystemParam::apply`](https://github.com/bevyengine/bevy/pull/7489)
 
 <div class="migration-guide-area-tags">
@@ -563,7 +563,7 @@ This also means that some serialized glam types will need to be updated. For exa
     <div class="migration-guide-area-tag">Rendering</div>
 </div>
 
- - Rename `ScalingMode::Auto` to `ScalingMode::AutoMin` if you are using it.
+- Rename `ScalingMode::Auto` to `ScalingMode::AutoMin` if you are using it.
 
 ### [Change `From<Icosphere>` to `TryFrom<Icosphere>`](https://github.com/bevyengine/bevy/pull/6484)
 
@@ -797,7 +797,6 @@ The `FrameCount`  resource was previously only updated when using the `bevy_rend
   - For example, `add_system_to_stage(CoreStage::PostUpdate, my_system)` should be replaced with
   - `add_system(my_system.in_base_set(CoreSet::PostUpdate)`
 
-
 - When testing systems or otherwise running them in a headless fashion, simply construct and run a schedule using `Schedule::new()` and `World::run_schedule` rather than constructing stages
 - Run criteria have been renamed to run conditions. These can now be combined with each other and with states.
 - Looping run criteria and state stacks have been removed. Use an exclusive system that runs a schedule if you need this level of control over system control flow.
@@ -903,6 +902,7 @@ __Changes for `Text2dBundle`__
 `Text2dBundle` has a new field ‘text_anchor’ that takes an `Anchor` component that controls its position relative to its transform.
 
 `Text2dSize` was removed. Use `TextLayoutInfo` instead.
+
 ### [Remove `QueuedText`](https://github.com/bevyengine/bevy/pull/7414)
 
 <div class="migration-guide-area-tags">
@@ -957,6 +957,26 @@ WindowResolution::new(width, height) // Explicitly
 ```rust
 let window = commands.spawn(Window { ... }).id(); // open window
 commands.entity(window).despawn(); // close window
+```
+
+Now that windows are components on entity, you should use `Query` instead of `Res` to access windows.
+
+```rust
+// 0.9
+fn count_pixels(windows: Res<Windows>) {
+    let Some(primary) = windows.get_primary() else {
+        return;
+    };
+    println!("{}", primary.width() * primary.height());
+}
+
+// 0.10
+fn count_pixels(primary_query: Query<&Window, With<PrimaryWindow>>) {
+    let Ok(primary) = primary_query.get_single() else {
+        return;
+    };
+    println!("{}", primary.width() * primary.height());
+}
 ```
 
 ### [update winit to 0.28](https://github.com/bevyengine/bevy/pull/7480)

--- a/content/learn/book/migration-guides/0.9-0.10/_index.md
+++ b/content/learn/book/migration-guides/0.9-0.10/_index.md
@@ -21,25 +21,19 @@ As a result, the Minimum Supported Rust Version (MSRV) is "the latest stable rel
 </div>
 
 - Calls to `.label(MyLabel)` should be replaced with `.in_set(MySet)`
+- `SystemLabel` derives should be replaced with `SystemSet`. You will also need to add the `Debug`, `PartialEq`, `Eq`, and `Hash` traits to satisfy the new trait bounds.
 - Stages have been removed. Replace these with system sets, and then add command flushes using the `apply_system_buffers` exclusive system where needed.
-- The `CoreStage`, `StartupStage,`RenderStage`and`AssetStage`enums have been replaced with`CoreSet`,`StartupSet, `RenderSet` and `AssetSet`. The same scheduling guarantees have been preserved.
-  - Systems are no longer added to `CoreSet::Update` by default. Add systems manually if this behavior is needed, although you should consider adding your game logic systems to `CoreSchedule::FixedTimestep` instead for more reliable framerate-independent behavior.
-  - Similarly, startup systems are no longer part of `StartupSet::Startup` by default. In most cases, this won’t matter to you.
-  - For example, `add_system_to_stage(CoreStage::PostUpdate, my_system)` should be replaced with
-  - `add_system(my_system.in_base_set(CoreSet::PostUpdate)`
-
-- When testing systems or otherwise running them in a headless fashion, simply construct and run a schedule using `Schedule::new()` and `World::run_schedule` rather than constructing stages
-- Run criteria have been renamed to run conditions. These can now be combined with each other and with states.
+- The `CoreStage`, `StartupStage`, `RenderStage`, and `AssetStage` enums have been replaced with `CoreSet`, `StartupSet`, `RenderSet` and `AssetSet`. The same scheduling guarantees have been preserved.
+- `with_run_criteria` has been renamed to `run_if`. Run criteria have been renamed to run conditions for clarity, and should now simply return a `bool` instead of `schedule::ShouldRun`.
 - Looping run criteria and state stacks have been removed. Use an exclusive system that runs a schedule if you need this level of control over system control flow.
+- `App::add_state` now takes 0 arguments: the starting state is set based on the `Default` impl.
+- Instead of creating `SystemSet` containers for systems that run in stages, simply use `.on_enter::<State::Variant>()` or its `on_exit` sibling.
 - For app-level control flow over which schedules get run when (such as for rollback networking), create your own schedule and insert it under the `CoreSchedule::Outer` label.
 - Fixed timesteps are now evaluated in a schedule, rather than controlled via run criteria. The `run_fixed_timestep` system runs this schedule between `CoreSet::First` and `CoreSet::PreUpdate` by default.
 - Command flush points introduced by `AssetStage` have been removed. If you were relying on these, add them back manually.
 - the `calculate_bounds` system, with the `CalculateBounds` label, is now in `CoreSet::Update`, rather than in `CoreSet::PostUpdate` before commands are applied. You may need to order your movement systems to occur before this system in order to avoid system order ambiguities in culling behavior.
 - the `RenderLabel` `AppLabel` was renamed to `RenderApp` for clarity
-- `App::add_state` now takes 0 arguments: the starting state is set based on the `Default` impl.
-- Instead of creating `SystemSet` containers for systems that run in stages, simply use `.on_enter::<State::Variant>()` or its `on_exit` or `on_update` siblings.
-- `SystemLabel` derives should be replaced with `SystemSet`. You will also need to add the `Debug`, `PartialEq`, `Eq`, and `Hash` traits to satisfy the new trait bounds.
-- `with_run_criteria` has been renamed to `run_if`. Run criteria have been renamed to run conditions for clarity, and should now simply return a `bool` instead of `schedule::ShouldRun`.
+- When testing systems or otherwise running them in a headless fashion, simply construct and run a schedule using `Schedule::new()` and `World::run_schedule` rather than constructing stages
 
 - States have been dramatically simplified: there is no longer a “state stack”. To queue a transition to the next state, call `NextState::set`
 - Strings can no longer be used as a `SystemLabel` or `SystemSet`. Use a type, or use the system function instead.

--- a/sass/pages/_migration_guide.scss
+++ b/sass/pages/_migration_guide.scss
@@ -1,7 +1,24 @@
 .migration-guide {
-    > h3 {
+    h3 {
+        margin-top: 3rem;
         margin-bottom: 0.2rem;
+        padding-bottom: 0.1rem;
+        border-bottom: solid darken($color-white, 60%) 0.15rem;
     }
+
+    p, ul, li, code {
+        font-size: 1rem;
+    }
+
+    // a {
+    //     color: $color-white;
+    //     // font-weight: normal;
+    //     &:hover{
+    //         // font-weight: 500;
+    //         color: $link-color;
+    //         text-shadow: 0 0 0.9px $link-hover-shadow-color, 0 0 0.9px $link-hover-shadow-color;
+    //     }
+    // }
 }
 
 .migration-guide-area-tags {
@@ -18,6 +35,8 @@
     padding-right: 0.2rem;
     padding-top: 0.2rem;
     padding-bottom: 0.2rem;
+    margin-top: 0.3rem;
+    margin-bottom: 0.3rem;
     line-height: 1;
     border-radius: 0.3rem;
     border-style: solid;

--- a/sass/pages/_migration_guide.scss
+++ b/sass/pages/_migration_guide.scss
@@ -1,24 +1,14 @@
 .migration-guide {
     h3 {
-        margin-top: 3rem;
-        margin-bottom: 0.2rem;
-        padding-bottom: 0.1rem;
-        border-bottom: solid darken($color-white, 60%) 0.15rem;
+        margin-top: 2rem;
+        padding-top: 2rem;
+        margin-bottom: 0.1rem;
+        border-top: solid darken($color-white, 60%) 1px;
     }
 
     p, ul, li, code {
         font-size: 1rem;
     }
-
-    // a {
-    //     color: $color-white;
-    //     // font-weight: normal;
-    //     &:hover{
-    //         // font-weight: 500;
-    //         color: $link-color;
-    //         text-shadow: 0 0 0.9px $link-hover-shadow-color, 0 0 0.9px $link-hover-shadow-color;
-    //     }
-    // }
 }
 
 .migration-guide-area-tags {


### PR DESCRIPTION
First draft of the 0.10 migration guide.

This is generated by https://github.com/bevyengine/bevy-website/pull/469 and then modified manually

Since this is easy to generate, I will re-generate it multiple time before release so changing the contents of guides is encouraged, but changing ordering should be done closer to release to avoid dealing with multiple conflicts.

For this migration guide, I added tags for areas of each PR, added a bit of spacing and a line for each heading
![image](https://user-images.githubusercontent.com/8348954/216899165-6f99a25f-e32d-42a4-bad4-8e23c7aac366.png)

This is why there are some css files in this pr.
