### PR TITLE
Sponsorship Pledge

### DIFF
--- a/content/sponsorship-pledge/_index.md
+++ b/content/sponsorship-pledge/_index.md
@@ -1,0 +1,6 @@
++++
+title = "Sponsorship Pledge"
+template = "sponsorship-pledge.html"
+[extra]
+header_message = "Sponsorship Pledge"
++++

--- a/templates/index.html
+++ b/templates/index.html
@@ -190,7 +190,8 @@
     <div class="features-sponsors">
         <h3 class="media-content">A big thanks to Bevy's generous <a
                 href="https://github.com/sponsors/cart/">Sponsors</a> for making our work
-            sustainable:</h3>
+            sustainable. Note that all Bevy leaders accepting sponsorships have signed this <a href="/sponsorship-pledge">Sponsorship Pledge</a> to ensure that Bevy remains a community-first project.
+        </h3>
         <div class="sponsors sponsors--platinum">
             <h2 class="sponsors__title">Platinum Sponsors</h2>
             <h3 class="sponsors__amount">$1,000 / month</h3>

--- a/templates/sponsorship-pledge.html
+++ b/templates/sponsorship-pledge.html
@@ -1,0 +1,59 @@
+{% extends "layouts/base.html" %}
+
+{% block content %}
+<div class="media-content">
+
+<h1>Bevy's Sponsorship Model</h1>
+
+Bevy is a community-driven people-first project. We do not have a business model. We don't sell anything. For now, we don't even have a centralized legal organization. Instead, our work is fully supported by sponsorships from generous individuals and companies. But introducing money into the equation creates concerns about power dynamics and incentives. And some companies require contracts as a part of their sponsorship programs. Bevy leaders (Project Leads and Maintainers) <i>must serve the community's interests above all else</i>. Therefore leaders that accept any money within the context of Bevy must abide by the following pledge:
+
+<h2>The Pledge</h2>
+
+<ol>
+    <li>
+        <b>The needs of the <i>people</i> in the Bevy community come first</b>. Everything we do should be in the interest of the <i>individuals in the Bevy community</i>. Yes ... companies use (and support) Bevy. This is a good thing. But companies are <i>not</i> people. Companies <i>consist of people</i>. The voice of an individual in a company should be weighted exactly the same as every other voice in our community. No more. No less.
+    </li> 
+    <li>
+        <b>Money can <i>never</i> buy project direction</b>. Bevy's design direction must always be determined by community needs and (as much as possible) consensus. For example: a company can never directly pay us to adopt a feature that goes against the community's interests. Nor can they indirectly pull the strings via financial pressure, such as threat of un-sponsoring.
+    </li>
+    <li>
+        <b>Money can <i>never</i> buy project priority</b>. We must always do the work that we believe is best for the Bevy community at a given moment. We cannot be paid to bump a company's pet feature up in our priority list. Our time (within the context of what we commit to the Bevy community) is not for sale. If we are "full time" Bevy leaders, none of our time can be bought. If we are "part time Bevy leaders", only the remaining time can be bought. 
+    </li>
+    <li>
+        <b>Bevy leaders must be able to speak their mind</b>. We will never sign away our right to disclose our thoughts or opinions about entities we receive money from. This means no "non-disparagement agreements". "Non-disclosure agreements" are only ok within the context of protecting private information (that does not directly relate to Bevy). 
+    </li> 
+    <li>
+        <b>Bevy leaders must be open about who supports them (within the context of Bevy)</b>. No hidden entities behind the scenes. If we receive $2,400 a year or more from an entity or have a financial stake in one that relates to the Bevy project in any reasonable way, we must disclose it within 6 months of receiving the money or stake.
+    </li>
+    <li>
+        <b>Bevy leaders will hold each other accountable</b>. If any of us suspects a violation of the pledge, we will immediately seek to rectify it. First amongst ourselves if there is reasonable doubt, and then publicly if the situation demands it.
+    </li>
+    <li>
+        <b>The pledge and the Bevy Community come first ... always</b>. If we are confronted with the choice of upholding the pledge or losing the financial support of an entity, we will choose the pledge every time. The amount of money on the table has no bearing on this. We must be honest with ourselves and each other. If we can't say no to large sums of money with pledge-violating strings attached, we don't deserve to be Bevy leaders.
+    </li>
+</ol>
+
+<p>
+The Bevy project (and the financial support we receive) is constantly growing. We must be certain we don't lose ourselves, our purpose, or the trust of the community as we continue on this wild ride. This is also a living document. If you believe we missed something important, please let us know. Removing items from the list would almost certainly be a violation of The Pledge, so unless we've seriously messed something up, consider this append-only.
+</p>
+
+<p>
+Currently, this agreement operates on the honor system. We believe all of our maintainers have won the trust of the community, but we will be putting together a legal organization to uphold this agreement and help fairly collect and distribute funds later this year.
+</p>
+
+<p>
+Also note that this only applies to Bevy leadership. We welcome and encourage companies to fund development efforts that improve Bevy in whatever way they want. However Bevy leadership <i>cannot be involved in any way that violates The Pledge</i>. Bevy leadership must always be the filter that protects the community from changes that go against their interests. Companies should do their best to collaborate with the Bevy community (and Bevy leaders) to ensure their changes are acceptable.
+</p>
+
+<h2>Pledge Signers</h2>
+<ul>
+    <li>
+        <a href="https://github.com/sponsors/cart">Carter Anderson (@cart)</a> 
+        <ul>
+            <li>Work Status: Full-time Project Lead / Maintainer</li>
+            <li>Sponsors (above $2,400 / year threshold): Foresight Mining Software Corporation ($2,000 / month), Embark ($1,000 / month), MeetKai ($1,000 / month), Encultured ($1,000 / month), Striked ($200 / month), storytold ($200 / month), Metabuild ($100 / month), Keygen ($100 / month), VPSServer ($100 / month), @joshuajbouw ($200 / month), @CleanCut ($200 / month), @rozgo ($100 / month)</li>
+        </ul>
+    </li>
+</ul>
+</div>
+{% endblock content %}


### PR DESCRIPTION
Bevy is a community-driven people-first project. We do not have a business model. We don't sell anything. For now, we don't even have a centralized legal organization. Instead, our work is fully supported by sponsorships from generous individuals and companies. But introducing money into the equation creates concerns about power dynamics and incentives. And some companies require contracts as a part of their sponsorship programs. Bevy leaders (Project Leads and Maintainers) _must serve the community's interests above all else_. Therefore leaders that accept any money within the context of Bevy must abide by the following pledge:

(see sponsorship-pledge.html for pledge contents)

The @bevyengine/maintainer-team has agreed to (and helped iterate on) this pledge. Maintainers, please create a new PR after this one is merged to sign this and add relevant disclosures. I'll be following up with a couple of changes to my entry as well (as I have an exciting announcement to make).