### PR TITLE
[Merged by Bors] - Fix wrong email link on donate page

### DIFF
--- a/templates/donate.html
+++ b/templates/donate.html
@@ -59,7 +59,7 @@
             </ul>
 
             If a maintainer offers these roles in their sponsors page, that counts! If you are interested in Patron sponsorship, contact us directly.
-            Reach out to us <a href="bevyengine@gmail.com">here</a> if you have any questions about sponsorship or you would like to claim a sponsorship reward.
+            Reach out to us <a href="mailto:bevyengine@gmail.com">here</a> if you have any questions about sponsorship or you would like to claim a sponsorship reward.
         </p>
         <p>
             All Bevy leaders sign our <a href="/sponsorship-pledge">Sponsorship Pledge</a> to ensure the needs of the Bevy Community always come first.


### PR DESCRIPTION
Fix wrong email link `https://bevyengine.org/community/donate/bevyengine@gmail.com`.