### PR TITLE
[Merged by Bors] - Code in title: don't overwrite the font size

### DIFF
--- a/sass/pages/_content.scss
+++ b/sass/pages/_content.scss
@@ -12,11 +12,19 @@ $content-font-size: 1.22rem;
     h2 {
         margin-top: 3.0rem;
         font-size: 2.2rem;
+
+        code {
+            font-size: inherit;
+        }
     }
 
     h3 {
         font-size: 1.5rem;
         margin-bottom: 1rem;
+
+        code {
+            font-size: inherit;
+        }
     }
 
     h4 {


### PR DESCRIPTION
titles with code don't look pretty because of the changed font-size:

<img width="938" alt="Screenshot 2023-03-04 at 01 03 24" src="https://user-images.githubusercontent.com/8672791/222857529-af0f3a49-750b-401f-b68d-a3383dc143e5.png">
