### PR TITLE
[Merged by Bors] - keep the font color white for a button in the main content

### DIFF
--- a/sass/pages/_content.scss
+++ b/sass/pages/_content.scss
@@ -73,6 +73,10 @@ $content-font-size: 1.22rem;
         background-color: $syntax-theme-background-hover;
     }
 
+    a.button {
+        color: $color-white;
+    }
+
     a {
         text-decoration: none;
         color: $link-color;


### PR DESCRIPTION
Inside the content, the font color of a link is changed to blue. This doesn't work well with our buttons

<img width="875" alt="Screenshot 2023-03-04 at 11 14 50" src="https://user-images.githubusercontent.com/8672791/222894271-b727d505-829a-438a-b9f6-39da7d2941b3.png">

