### PR TITLE
[Merged by Bors] - 0.10 News: fix the author for `EntityCommand`s

### DIFF
--- a/content/news/2023-03-06-bevy-0.10/index.md
+++ b/content/news/2023-03-06-bevy-0.10/index.md
@@ -1636,7 +1636,7 @@ Color::Lcha {
 
 ## `EntityCommand`s
 
-<div class="release-feature-authors">authors: @targrub</div>
+<div class="release-feature-authors">authors: @JoJoJet</div>
 
 [`Commands`] are "deferred ECS" operations. They enable developers to define custom ECS operations that are applied after a parallel system has finished running. Many [`Commands`] ran on individual entities, but this pattern was a bit cumbersome:
 


### PR DESCRIPTION
The 0.10 blog post gives credit to the wrong author for `EntityCommand`s.