### PR TITLE
[Merged by Bors] - Use the correct syntax for `NextState`

### DIFF
--- a/content/news/2023-03-06-bevy-0.10/index.md
+++ b/content/news/2023-03-06-bevy-0.10/index.md
@@ -359,7 +359,7 @@ app
 ```rust
 fn start_game(
     button_query: Query<&Interaction, With<StartGameButton>>,
-    next_state: ResMut<NextState<AppState>>,
+    mut next_state: ResMut<NextState<AppState>>,
 ){
     if button_query.single() == Interaction::Pressed {
         next_state.set(AppState::InGame);

--- a/content/news/2023-03-06-bevy-0.10/index.md
+++ b/content/news/2023-03-06-bevy-0.10/index.md
@@ -362,7 +362,7 @@ fn start_game(
     next_state: ResMut<NextState<AppState>>,
 ){
     if button_query.single() == Interaction::Pressed {
-        *next_state = NextState(AppState::InGame);
+        next_state.set(AppState::InGame);
     }
 }
 ```


### PR DESCRIPTION
Pointed out by `maciek_glowa` on [Discord](https://discord.com/channels/691052431525675048/1078336814034718730/1082398729081991238).

I chose to use the `.set` syntax rather than adding a `Some` because it's prettier :p