### PR TITLE
[Merged by Bors] - Remove a non-breaking change from the 0.10 migration guide

### DIFF
--- a/content/learn/book/migration-guides/0.9-0.10/_index.md
+++ b/content/learn/book/migration-guides/0.9-0.10/_index.md
@@ -348,14 +348,6 @@ Safety invariants on `bevy_ptr` types’ `new` `byte_add` and `byte_offset` meth
 - Changed `World::init_resource` to return the generated `ComponentId`.
 - Changed `World::init_non_send_resource` to return the generated `ComponentId`.
 
-### [Add `UnsafeWorldCell` abstraction](https://github.com/bevyengine/bevy/pull/6404)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">ECS</div>
-</div>
-
-The type `UnsafeWorldCellEntityRef` has been renamed to UnsafeEntityCell
-
 ### [Replace `RemovedComponents<T>` backing with `Events<Entity>`](https://github.com/bevyengine/bevy/pull/5680)
 
 <div class="migration-guide-area-tags">


### PR DESCRIPTION
The type `UnsafeWorldCellEntityRef` was introduced after 0.9 and renamed before 0.10, so this was not a breaking change.