### PR TITLE
master -> main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
         env:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_MARKDOWN: true
-          DEFAULT_BRANCH: master
+          DEFAULT_BRANCH: main
 
   build-website:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   schedule:
     - cron:  '0 0 * * *'
   workflow_dispatch:

--- a/templates/book-section.html
+++ b/templates/book-section.html
@@ -90,7 +90,7 @@
                 {% endif %}
             </nav>
             <div class="book-footer__edit-wrapper">
-                <a class="book-footer__edit" href="https://github.com/bevyengine/bevy-website/edit/master/content/{{ section.relative_path }}">
+                <a class="book-footer__edit" href="https://github.com/bevyengine/bevy-website/edit/main/content/{{ section.relative_path }}">
                     <i class="icon icon--pencil"></i>
                     Improve this page
                 </a>


### PR DESCRIPTION
We're using the `main` naming convention everywhere else in the Bevy Org. We should use it here too. 