### PR TITLE
Fix missing Clone and Hash derives in blog post

### DIFF
--- a/content/learn/migration-guides/0.9-0.10/_index.md
+++ b/content/learn/migration-guides/0.9-0.10/_index.md
@@ -254,7 +254,6 @@ Before:
 
 ```rust
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
-
 enum AppState {
     Menu,
     InGame,

--- a/content/news/2023-03-06-bevy-0.10/index.md
+++ b/content/news/2023-03-06-bevy-0.10/index.md
@@ -311,7 +311,7 @@ Bevy 0.10 is shipping with a lovely collection of built-in [common run condition
 You define [`States`] like this:
 
 ```rust
-#[derive(States, PartialEq, Eq, Debug, Default)]
+#[derive(States, PartialEq, Eq, Debug, Clone, Hash, Default)]
 enum AppState {
     #[default]
     MainMenu,


### PR DESCRIPTION
Fixes a missing `Clone` and `Hash` derives in the Bevy 0.10 blog post.

Spotted by user `jengamon` on Discord.

This also fixes a rogue linebreak I noticed in the migration guide while looking at this.