### PR TITLE
Add redirects for migration guides

### DIFF
--- a/content/learn/migration-guides/0.4-0.5/_index.md
+++ b/content/learn/migration-guides/0.4-0.5/_index.md
@@ -3,6 +3,7 @@ title = "0.4 to 0.5"
 weight = 7
 template = "docs-section.html"
 insert_anchor_links = "right"
+aliases = ["learn/book/migration-guides/0.4-0.5"]
 [extra]
 long_title = "Migration Guide: 0.4 to 0.5"
 +++

--- a/content/learn/migration-guides/0.5-0.6/_index.md
+++ b/content/learn/migration-guides/0.5-0.6/_index.md
@@ -3,6 +3,7 @@ title = "0.5 to 0.6"
 weight = 6
 template = "docs-section.html"
 insert_anchor_links = "right"
+aliases = ["learn/book/migration-guides/0.5-0.6"]
 [extra]
 long_title = "Migration Guide: 0.5 to 0.6"
 +++

--- a/content/learn/migration-guides/0.6-0.7/_index.md
+++ b/content/learn/migration-guides/0.6-0.7/_index.md
@@ -3,6 +3,7 @@ title = "0.6 to 0.7"
 weight = 5
 template = "docs-section.html"
 insert_anchor_links = "right"
+aliases = ["learn/book/migration-guides/0.6-0.7"]
 [extra]
 long_title = "Migration Guide: 0.6 to 0.7"
 +++

--- a/content/learn/migration-guides/0.7-0.8/_index.md
+++ b/content/learn/migration-guides/0.7-0.8/_index.md
@@ -3,6 +3,7 @@ title = "0.7 to 0.8"
 weight = 4
 template = "docs-section.html"
 insert_anchor_links = "right"
+aliases = ["learn/book/migration-guides/0.7-0.8"]
 [extra]
 long_title = "Migration Guide: 0.7 to 0.8"
 +++

--- a/content/learn/migration-guides/0.8-0.9/_index.md
+++ b/content/learn/migration-guides/0.8-0.9/_index.md
@@ -3,6 +3,7 @@ title = "0.8 to 0.9"
 weight = 3
 template = "docs-section.html"
 insert_anchor_links = "right"
+aliases = ["learn/book/migration-guides/0.8-0.9"]
 [extra]
 long_title = "Migration Guide: 0.8 to 0.9"
 +++

--- a/content/learn/migration-guides/0.9-0.10/_index.md
+++ b/content/learn/migration-guides/0.9-0.10/_index.md
@@ -3,6 +3,7 @@ title = "0.9 to 0.10"
 weight = 2
 template = "docs-section.html"
 insert_anchor_links = "right"
+aliases = ["learn/book/migration-guides/0.9-0.10"]
 [extra]
 long_title = "Migration Guide: 0.9 to 0.10"
 +++

--- a/content/learn/migration-guides/_index.md
+++ b/content/learn/migration-guides/_index.md
@@ -3,5 +3,6 @@ title = "Migration Guides"
 sort_by = "weight"
 page_template = "docs-section.html"
 redirect_to = "learn/migration-guides/introduction"
+aliases = ["learn/book/migration-guides"]
 insert_anchor_links = "right"
 +++

--- a/content/learn/migration-guides/introduction/_index.md
+++ b/content/learn/migration-guides/introduction/_index.md
@@ -3,6 +3,7 @@ title = "Introduction"
 weight = 1
 template = "docs-section.html"
 insert_anchor_links = "right"
+aliases = ["learn/book/migration-guides/introduction"]
 +++
 
 Bevy is still in the "experimentation phase", which means each release has its fair share of breaking changes. We provide migration guides for major releases to help users migrate their apps to the latest and greatest Bevy release.


### PR DESCRIPTION
We moved our migration guides and left a bunch of broken links in our wake.

Zola's `aliases` can apparently help us with this.

This adds aliases for the old urls: `learn/book/migration-guides/0.8-0.9/` to the new migration guide pages and section.
