### PR TITLE
Use two columns for Learn section

### DIFF
--- a/templates/learn.html
+++ b/templates/learn.html
@@ -1,8 +1,8 @@
 {% extends "layouts/base.html" %}
 
 {% block content %}
-<div class="padded-content">
-  <a class="card" href="/learn/book/introduction">
+<div class="padded-content community-grid">
+  <a class="card community-card" href="/learn/book/introduction">
     <div class="card-image">
       <img src="/assets/book.svg" class="centered-card-image" alt="Bevy book" />
     </div>
@@ -15,7 +15,7 @@
       </div>
     </div>
   </a>
-  <a class="card" href="/learn/migration-guides/introduction">
+  <a class="card community-card" href="/learn/migration-guides/introduction">
     <div class="card-image">
       <img src="/assets/migration-guides.svg" class="centered-card-image" alt="Migration guides" />
     </div>
@@ -28,7 +28,7 @@
       </div>
     </div>
   </a>
-  <a class="card" href="https://docs.rs/bevy">
+  <a class="card community-card" href="https://docs.rs/bevy">
     <div class="card-image">
       <img src="/assets/rust-logo-light.svg" class="centered-card-image" alt="Rust logo" />
     </div>
@@ -41,7 +41,7 @@
       </div>
     </div>
   </a>
-  <a class="card" href="https://github.com/bevyengine/bevy/tree/latest/examples#examples">
+  <a class="card community-card" href="https://github.com/bevyengine/bevy/tree/latest/examples#examples">
     <div class="card-image">
       <img src="/assets/github.svg" class="centered-card-image" alt="Github logo" />
     </div>
@@ -54,7 +54,7 @@
       </div>
     </div>
   </a>
-  <a class="card" href="/assets">
+  <a class="card community-card" href="/assets">
     <div class="card-image">
       <img src="/assets/bevy_icon_dark.svg" class="centered-card-image" alt="Bevy logo" />
     </div>
@@ -68,7 +68,7 @@
       </div>
     </div>
   </a>
-  <a class="card" href="/examples">
+  <a class="card community-card" href="/examples">
     <div class="card-image">
       <img src="/assets/bevy_icon_dark.svg" class="centered-card-image" alt="Bevy logo" />
     </div>
@@ -81,7 +81,7 @@
       </div>
     </div>
   </a>
-  <a class="card" href="/faq">
+  <a class="card community-card" href="/faq">
     <div class="card-image">
       <img src="/assets/bevy_icon_dark.svg" class="centered-card-image" alt="Bevy logo" />
     </div>


### PR DESCRIPTION
This just slaps `.community-card` and `.community-grid` on the learn section.

We can't really change the cards globally because this probably won't work well / is not what we want for the news section.

But if anyone has some suggestions for reorganizing the styles I'd be happy to execute them (ping @doup).

Desktop:
![localhost_1111_learn](https://user-images.githubusercontent.com/200550/225648014-46312dc4-e0d5-4e52-ad36-c48ef8707566.png)
Mobile:
![localhost_1111_learn (1)](https://user-images.githubusercontent.com/200550/225648020-efcde977-f077-44e2-a5c9-db6b8d711ac2.png)
