### PR TITLE
Improve setup instructions for Windows

### DIFF
--- a/content/learn/book/getting-started/setup/_index.md
+++ b/content/learn/book/getting-started/setup/_index.md
@@ -24,9 +24,21 @@ Once this is done, you should have the ```rustc``` compiler and the ```cargo``` 
 
 ### Install OS dependencies
 
-* [Linux](https://github.com/bevyengine/bevy/blob/main/docs/linux_dependencies.md)
-* Windows: Make sure to install [VS2019 build tools](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=16)
-* MacOS: Install the Xcode command line tools with `xcode-select --install` or the [Xcode app](https://apps.apple.com/en/app/xcode/id497799835)
+#### Linux
+Follow the instructions at [Linux Dependencies](https://github.com/bevyengine/bevy/blob/main/docs/linux_dependencies.md)
+
+#### Windows
+* Run the [Visual Studio 2019 build tools installer](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=16)
+* For easy setup, select the ```Desktop development with C++``` workload in the installer.
+* For a mimimal setup, follow these steps:
+    1. In the installer, navigate to ```Individual components```
+    2. Select the latest ```MSVC``` for your architecture and version of Windows
+    4. Select the latest ```Windows SDK``` for your version of Windows
+    5. Select the ```C++ CMake tools``` for Windows component
+    5. Install the components
+
+#### MacOS
+Install the Xcode command line tools with `xcode-select --install` or the [Xcode app](https://apps.apple.com/en/app/xcode/id497799835)
 
 ### Code Editor / IDE
 

--- a/content/learn/book/getting-started/setup/_index.md
+++ b/content/learn/book/getting-started/setup/_index.md
@@ -33,10 +33,10 @@ Follow the instructions at [Linux Dependencies](https://github.com/bevyengine/be
 * Run the [Visual Studio 2019 build tools installer](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=16)
 * For easy setup, select the ```Desktop development with C++``` workload in the installer.
 * For a mimimal setup, follow these steps:
-    1. In the installer, navigate to ```Individual components```
-    2. Select the latest ```MSVC``` for your architecture and version of Windows
-    3. Select the latest ```Windows SDK``` for your version of Windows
-    4. Select the ```C++ CMake tools``` for Windows component
+    1. In the installer, navigate to `Individual components`
+    2. Select the latest `MSVC` for your architecture and version of Windows
+    3. Select the latest `Windows SDK` for your version of Windows
+    4. Select the `C++ CMake tools` for Windows component
     5. Install the components
 
 #### MacOS

--- a/content/learn/book/getting-started/setup/_index.md
+++ b/content/learn/book/getting-started/setup/_index.md
@@ -25,9 +25,11 @@ Once this is done, you should have the ```rustc``` compiler and the ```cargo``` 
 ### Install OS dependencies
 
 #### Linux
+
 Follow the instructions at [Linux Dependencies](https://github.com/bevyengine/bevy/blob/main/docs/linux_dependencies.md)
 
 #### Windows
+
 * Run the [Visual Studio 2019 build tools installer](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=16)
 * For easy setup, select the ```Desktop development with C++``` workload in the installer.
 * For a mimimal setup, follow these steps:
@@ -38,6 +40,7 @@ Follow the instructions at [Linux Dependencies](https://github.com/bevyengine/be
     5. Install the components
 
 #### MacOS
+
 Install the Xcode command line tools with `xcode-select --install` or the [Xcode app](https://apps.apple.com/en/app/xcode/id497799835)
 
 ### Code Editor / IDE

--- a/content/learn/book/getting-started/setup/_index.md
+++ b/content/learn/book/getting-started/setup/_index.md
@@ -35,8 +35,8 @@ Follow the instructions at [Linux Dependencies](https://github.com/bevyengine/be
 * For a mimimal setup, follow these steps:
     1. In the installer, navigate to ```Individual components```
     2. Select the latest ```MSVC``` for your architecture and version of Windows
-    4. Select the latest ```Windows SDK``` for your version of Windows
-    5. Select the ```C++ CMake tools``` for Windows component
+    3. Select the latest ```Windows SDK``` for your version of Windows
+    4. Select the ```C++ CMake tools``` for Windows component
     5. Install the components
 
 #### MacOS


### PR DESCRIPTION
# Introduction
This pull request enhances the setup instructions for installing OS dependencies for Windows, located at https://bevyengine.org/learn/book/getting-started/setup/#install-os-dependencies

This fixes the issue I raised here: https://github.com/bevyengine/bevy-website/issues/622

## Before
 
![before_bevy](https://user-images.githubusercontent.com/14301322/232303540-40b875a3-6c8d-4e8c-8c0a-6eb9cf839448.PNG)

## After
![after_bevy](https://user-images.githubusercontent.com/14301322/232303702-cbf01a44-da6d-4947-ae52-c1151e98f389.PNG)

# Environment
**Operating System**: Windows 10 Pro 64-Bit (10.0, Build 19045)
**Processor**: AMD Ryzen 7 1800X Eight-Core Processor
