### PR TITLE
Add mastodon verification to index.html

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -2,6 +2,7 @@
 {% block head_extensions %}
 <meta name="description"
     content="A refreshingly simple data-driven game engine built in Rust. Free and Open Source Forever!" />
+<link href="https://mastodon.social/@bevy" rel="me" />
 {% endblock head_extensions %}
 
 {% block content %}


### PR DESCRIPTION
Adds a `<link rel="me"` to the site so that the official account can be [verified](https://docs.joinmastodon.org/user/profile/#verification).

![Screenshot of @bevy@mastodon.social with a green checkmark next to bevyengine.org](https://user-images.githubusercontent.com/39150378/235332381-dfc93bee-4122-403b-9860-d4f09c543e55.png)