### PR TITLE
Add rel="me" support to community links and enable for Mastodon

### DIFF
--- a/content/community/links.toml
+++ b/content/community/links.toml
@@ -67,3 +67,4 @@ url = "https://mastodon.social/@bevy"
 image = "/assets/mastodon-logo-purple.svg"
 image_alt = "Mastodon logo"
 description = "News, boosted community creations and chatter on the short-form Fediverse network."
+rel_me = true

--- a/templates/community.html
+++ b/templates/community.html
@@ -4,7 +4,11 @@
 {% set community_links = load_data(path="content/community/links.toml") %}
 <div class="padded-content item-grid item-grid--two-cols">
     {% for link in community_links.links %}
+        {% if link.rel_me %}
+        <a rel="me" class="link-card" href="{{ link.url }}">
+        {% else %}
         <a class="link-card" href="{{ link.url }}">
+        {% endif %}
             <div class="link-card__img-wrapper">
                 <img class="link-card__img link-card__img--small" src="{{ link.image }}" alt="{{ link.image_alt }}" />
             </div>


### PR DESCRIPTION
Gives us the option to label links as "rel=me" and enables it for our mastodon link.