### PR TITLE
Removing outdated note about Windows support for dynamic_linking

### DIFF
--- a/content/learn/book/getting-started/setup/_index.md
+++ b/content/learn/book/getting-started/setup/_index.md
@@ -145,7 +145,7 @@ You might think to simply develop in release mode instead, but we recommend agai
 
 Bevy can be built just fine using default configuration on stable Rust. However for maximally fast iterative compiles, we recommend the following configuration:
 
-* **Enable Bevy's Dynamic Linking Feature**: This is the most impactful compilation time decrease! If `bevy` is a dependency, you can compile the binary with the "dynamic" feature flag (enables dynamic linking). Note that right now, this doesn't work on Windows.
+* **Enable Bevy's Dynamic Linking Feature**: This is the most impactful compilation time decrease! If `bevy` is a dependency, you can compile the binary with the "dynamic" feature flag (enables dynamic linking).
 
   ```sh
   cargo run --features bevy/dynamic_linking

--- a/content/learn/book/getting-started/setup/_index.md
+++ b/content/learn/book/getting-started/setup/_index.md
@@ -145,7 +145,7 @@ You might think to simply develop in release mode instead, but we recommend agai
 
 Bevy can be built just fine using default configuration on stable Rust. However for maximally fast iterative compiles, we recommend the following configuration:
 
-* **Enable Bevy's Dynamic Linking Feature**: This is the most impactful compilation time decrease! If `bevy` is a dependency, you can compile the binary with the "dynamic" feature flag (enables dynamic linking).
+* **Enable Bevy's Dynamic Linking Feature**: This is the most impactful compilation time decrease! If `bevy` is a dependency, you can compile the binary with the "dynamic_linking" feature flag (enables dynamic linking). **Important!** On Windows you _must_ also enable the [perfomance optimizations](#compile-with-performance-optimizations) or you will get a [`too many exported symbols`](https://github.com/bevyengine/bevy/issues/1110#issuecomment-1312926923) error.
 
   ```sh
   cargo run --features bevy/dynamic_linking


### PR DESCRIPTION
I tested the dynamic linking on Windows 11 and it works. I also heard from others in the Discord chats that it seems to be a resolved issue. Thus a small PR to update the docs to reflect that.

Here is the relevant discussion with Alice in the General room on Discord where they call out that they believe it is fixed: https://discord.com/channels/691052431525675048/691052431974465548/1103445630237540362