### PR TITLE
resume audio context in wasm examples

### DIFF
--- a/static/restart-audio-context.js
+++ b/static/restart-audio-context.js
@@ -1,0 +1,57 @@
+// taken from https://developer.chrome.com/blog/web-audio-autoplay/#moving-forward
+(function () {
+    // An array of all contexts to resume on the page
+    const audioContextList = [];
+
+    // An array of various user interaction events we should listen for
+    const userInputEventNames = [
+        'click',
+        'contextmenu',
+        'auxclick',
+        'dblclick',
+        'mousedown',
+        'mouseup',
+        'pointerup',
+        'touchend',
+        'keydown',
+        'keyup',
+    ];
+
+    // A proxy object to intercept AudioContexts and
+    // add them to the array for tracking and resuming later
+    self.AudioContext = new Proxy(self.AudioContext, {
+        construct(target, args) {
+            const result = new target(...args);
+            audioContextList.push(result);
+            return result;
+        },
+    });
+
+    // To resume all AudioContexts being tracked
+    function resumeAllContexts(event) {
+        let count = 0;
+
+        audioContextList.forEach(context => {
+            if (context.state !== 'running') {
+                context.resume();
+            } else {
+                count++;
+            }
+        });
+
+        // If all the AudioContexts have now resumed then we
+        // unbind all the event listeners from the page to prevent
+        // unnecessary resume attempts
+        if (count == audioContextList.length) {
+            userInputEventNames.forEach(eventName => {
+                document.removeEventListener(eventName, resumeAllContexts);
+            });
+        }
+    }
+
+    // We bind the resume function for each user interaction
+    // event on the page
+    userInputEventNames.forEach(eventName => {
+        document.addEventListener(eventName, resumeAllContexts);
+    });
+})();

--- a/templates/example-webgpu.html
+++ b/templates/example-webgpu.html
@@ -50,7 +50,7 @@
     // https://github.com/bevyengine/bevy-website/pull/355
     #}
     import { progressiveFetch } from '/tools.js';
-    // import init from './{{ page.title }}.js';
+    import '/restart-audio-context.js'
     import init from 'https://wasm-examples.pages.dev/{{ category.title }}/{{ page.extra.technical_name }}/wasm_example.js'
 
     const canvasEl = document.getElementById('bevy');

--- a/templates/example.html
+++ b/templates/example.html
@@ -38,6 +38,7 @@
     // https://github.com/bevyengine/bevy-website/pull/355
     #}
     import { progressiveFetch } from '/tools.js';
+    import '/restart-audio-context.js'
     import init from './{{ page.title }}.js';
 
     const canvasEl = document.getElementById('bevy');

--- a/templates/examples-webgpu.html
+++ b/templates/examples-webgpu.html
@@ -45,19 +45,6 @@
 
                 {{ assets_macros::card(post=post) }}
 
-            <!-- <a class="card" href="/examples/{{ section.title | slugify }}/{{ post.title | slugify }}/"
-                id="{{ post.title | slugify }}">
-                {% if post.extra.image %}
-                <div class="card-image card-image-default">
-                    <img src="{{ get_url(path=post.extra.image) }}" />
-                </div>
-                {% endif %}
-                <div class="card-text">
-                    <div class="card-title">{{ post.title }}</div>
-                </div>
-            </a> -->
-
-
             {% endfor %}
         </div>
         {% endif %}


### PR DESCRIPTION
in browsers, audio doesn't start unless the user interacted with the page first.

This adds the workaround to resume the audio context after an interaction.

Fix taken from https://github.com/bevyengine/bevy_github_ci_template/pull/30

Also, some light cleanup of comments I forgot to remove