### PR TITLE
Simpler / clearer titles

### DIFF
--- a/content/community/_index.md
+++ b/content/community/_index.md
@@ -1,5 +1,5 @@
 +++
-title = "Community"
+title = "Bevy Community"
 template = "community.html"
 [extra]
 header_message = "Community"

--- a/content/faq/index.md
+++ b/content/faq/index.md
@@ -1,5 +1,5 @@
 +++
-title = "FAQ"
+title = "Bevy FAQ"
 template = "faq.html"
 aliases = ["learn/book/faq"]
 +++

--- a/content/learn/index.md
+++ b/content/learn/index.md
@@ -1,5 +1,5 @@
 +++
-title = "Bevy Learn"
+title = "Learn Bevy"
 template = "learn.html"
 [extra]
 header_message = "Learn"

--- a/content/learn/index.md
+++ b/content/learn/index.md
@@ -1,5 +1,5 @@
 +++
-title = "Learn"
+title = "Bevy Learn"
 template = "learn.html"
 [extra]
 header_message = "Learn"

--- a/content/news/_index.md
+++ b/content/news/_index.md
@@ -1,5 +1,5 @@
 +++
-title = "News"
+title = "Bevy News"
 sort_by = "date"
 template = "news.html"
 page_template = "news-page.html"

--- a/content/sponsorship-pledge/_index.md
+++ b/content/sponsorship-pledge/_index.md
@@ -1,5 +1,5 @@
 +++
-title = "Sponsorship Pledge"
+title = "Bevy Sponsorship Pledge"
 template = "sponsorship-pledge.html"
 [extra]
 header_message = "Sponsorship Pledge"

--- a/generate-wasm-examples/generate_wasm_examples.sh
+++ b/generate-wasm-examples/generate_wasm_examples.sh
@@ -81,7 +81,7 @@ weight = $category_weight
 cp -r assets/ ../../static/assets/examples/
 
 echo "+++
-title = \"Bevy Examples in WebGL2\"
+title = \"Examples in WebGL2\"
 template = \"examples.html\"
 sort_by = \"weight\"
 

--- a/templates/assets.html
+++ b/templates/assets.html
@@ -1,7 +1,7 @@
 {% extends "layouts/page-with-menu.html" %}
 {% import "macros/assets.html" as assets_macros %}
 
-{% block page_name %}Assets{% endblock %}
+{% block page_name %}Bevy Assets{% endblock %}
 
 {% block mobile_page_menu %}
     {{assets_macros::assets_menu(prefix="mobile-menu", root=section)}}

--- a/templates/layouts/base.html
+++ b/templates/layouts/base.html
@@ -1,11 +1,17 @@
 {% import "macros/header.html" as header_macros %}
 
 {% if section and section.title %}
-    {% set page_title = "Bevy - " ~ section.title %}
+    {% if section.path is starting_with("/learn/book/") %}
+        {% set page_title = "Bevy Book: " ~ section.title %}
+    {% elif section.path is starting_with("/assets") %}
+        {% set page_title = "Bevy Assets" %}
+    {% else %}
+        {% set page_title = section.title %}
+    {% endif %}
 {% elif page and page.title %}
-    {% set page_title = "Bevy - " ~ page.title %}
+        {% set page_title = page.title %}
 {% else %}
-    {% set page_title = "Bevy - A data-driven game engine built in Rust "%}
+    {% set page_title = "Bevy Engine"%}
 {% endif %}
 
 {% if section and section.path %}


### PR DESCRIPTION
The titles on some pages are a bit messy. The most heinous being news articles like "Bevy - Bevy 0.10" and "Bevy - Bevy + WebGPU".

This PR favors "direct" section titles in more places and changes the formatting in a couple of other places (ex: "Bevy - Community" is now "Bevy Community") .