### PR TITLE
Fix example canvas growing on resize

### DIFF
--- a/templates/example-webgpu.html
+++ b/templates/example-webgpu.html
@@ -54,6 +54,22 @@
     import init from 'https://wasm-examples.pages.dev/{{ category.title }}/{{ page.extra.technical_name }}/wasm_example.js'
 
     const canvasEl = document.getElementById('bevy');
+
+    let once = false;
+    const observer_callback = (_mutations, _observer) => {
+        if (!once) {
+            // Lock the canvas aspect ratio to prevent the fit_canvas_to_parent setting from creating a feedback loop causing the canvas to grow on resize
+            canvasEl.style.aspectRatio = canvasEl.attributes.width.value / canvasEl.attributes.height.value;
+            once = true;
+        }
+    };
+
+    const observer = new MutationObserver(observer_callback);
+
+    const config = { attributeFilter: ['width', 'height'] };
+
+    observer.observe(canvasEl, config);
+
     const progressStatusEl = document.querySelector('[data-progress-status]');
     const progressFileEl = document.querySelector('[data-progress-file]');
     const progressBarEl = document.querySelector('[data-progress-bar]');

--- a/templates/example.html
+++ b/templates/example.html
@@ -42,10 +42,6 @@
     import init from './{{ page.title }}.js';
 
     const canvasEl = document.getElementById('bevy');
-    const progressStatusEl = document.querySelector('[data-progress-status]');
-    const progressFileEl = document.querySelector('[data-progress-file]');
-    const progressBarEl = document.querySelector('[data-progress-bar]');
-    let hideProgressTimeoutId;
 
     let once = false;
     const observer_callback = (_mutations, _observer) => {
@@ -58,9 +54,14 @@
 
     const observer = new MutationObserver(observer_callback);
 
-    const config = { attributeFilter: ["width", "height"] };
+    const config = { attributeFilter: ['width', 'height'] };
 
     observer.observe(canvasEl, config);
+
+    const progressStatusEl = document.querySelector('[data-progress-status]');
+    const progressFileEl = document.querySelector('[data-progress-file]');
+    const progressBarEl = document.querySelector('[data-progress-bar]');
+    let hideProgressTimeoutId;
 
     async function loadingBarFetch(resource) {
         return progressiveFetch(resource, {

--- a/templates/example.html
+++ b/templates/example.html
@@ -47,6 +47,21 @@
     const progressBarEl = document.querySelector('[data-progress-bar]');
     let hideProgressTimeoutId;
 
+    let once = false;
+    const observer_callback = (_mutations, _observer) => {
+        if (!once) {
+            // Lock the canvas aspect ratio to prevent the fit_canvas_to_parent setting from creating a feedback loop causing the canvas to grow on resize
+            canvasEl.style.aspectRatio = canvasEl.attributes.width.value / canvasEl.attributes.height.value;
+            once = true;
+        }
+    };
+
+    const observer = new MutationObserver(observer_callback);
+
+    const config = { attributeFilter: ["width", "height"] };
+
+    observer.observe(canvasEl, config);
+
     async function loadingBarFetch(resource) {
         return progressiveFetch(resource, {
             start: ({ filename }) => {


### PR DESCRIPTION
Prevent the `fit_canvas_to_parent` setting from growing the canvas by locking the aspect ratio to that of the initial resolution of the bevy `Window`.

Fixes #432.