### PR TITLE
Filter out unavoidable winit control flow exception in WebGPU examples

### DIFF
--- a/templates/example-webgpu.html
+++ b/templates/example-webgpu.html
@@ -106,6 +106,16 @@
         })
     }
     window.bevyLoadingBarFetch = loadingBarFetch;
-    init();
+
+    {#
+    // The following .catch() is a simple filter to remove an exception thrown by winit in
+    // its normal control flow. This exception will always be thrown and is not an error.
+    // Details here: https://github.com/rust-windowing/winit/blob/master/src/platform_impl/web/event_loop/mod.rs
+    #}
+    init().catch((error) => {
+        if (!error.message.startsWith("Using exceptions for control flow, don't mind me. This isn't actually an error!")) {
+            throw error;
+        }
+    });
 </script>
 {% endblock content %}


### PR DESCRIPTION
During startup winit is using an exception as a part of its control flow. This is exception is "normal" and not a error but will end up in the browsers error console like this:

<img width="735" alt="image" src="https://github.com/bevyengine/bevy-website/assets/644930/c5a1e368-da59-4421-9427-74f5b5e69c70">


This PR adds a simple exception handler that will silently drop this specific exception and propagate all other exceptions.