### PR TITLE
Fix import confusion in Learn > Book > Getting Started > ECS

### DIFF
--- a/content/learn/book/getting-started/ecs/_index.md
+++ b/content/learn/book/getting-started/ecs/_index.md
@@ -55,7 +55,7 @@ fn hello_world() {
 This will be our first system. The only remaining step is to add it to our App!
 
 ```rs
-use bevy::app::App;
+use bevy::prelude::*;
 
 fn main() {
     App::new()


### PR DESCRIPTION
This is a very minor change.

I noticed at least two people on the Bevy discord (example, not to shame just to illustrate: https://discord.com/channels/691052431525675048/1111845037035225118) who got confused following the current Book because the example at https://bevyengine.org/learn/book/getting-started/ecs/ doesn't repeat `use bevy::prelude::*`.
Even though the page tells them to add the code to their main.rs file (which, if they followed the book in order should contain the import: https://bevyengine.org/learn/book/getting-started/apps/), it looks like a standalone code because of the `use bevy::app::App` and they just copy-paste it, and it doesn't work.
This can lead to a frustrating first experience, and can easily be fixed by adding the correct import again (which contains `App` anyway).