### PR TITLE
Properly handle plurals and code blocks

### DIFF
--- a/content/learn/book/contributing/docs/_index.md
+++ b/content/learn/book/contributing/docs/_index.md
@@ -42,9 +42,6 @@ We made an extension to the markdown syntax that makes linking to Rust API docs 
 * Short Type: {{rust_type(type="struct", crate="std" mod="collections", name="HashMap", no_mod=true)}}
 
     ```{{/*rust_type(type="struct" crate="std" mod="collections" name="HashMap" no_mod=true)*/}}```
-* Plural Type: {{rust_type(type="struct" crate="std" mod="collections" name="HashMap" no_mod=true plural=true)}}
-
-    ```{{/*rust_type(type="struct" crate="std" mod="collections" name="HashMap" no_mod=true, plural=true)*/}}```
 * Function: {{rust_type(type="struct" crate="std" mod="collections" name="HashMap" no_mod=true method="insert")}}
 
     ```{{/*rust_type(type="struct" crate="std" mod="collections" name="HashMap" no_mod=true method="insert")*/}}```

--- a/content/learn/book/getting-started/apps/_index.md
+++ b/content/learn/book/getting-started/apps/_index.md
@@ -7,7 +7,7 @@ page_template = "docs-section.html"
 insert_anchor_links = "right"
 +++
 
-Bevy programs are referred to as {{rust_type(type="struct", crate="bevy_app", name="App", no_mod=true, plural=true)}}. The simplest Bevy app looks like this:
+Bevy programs are referred to as {{rust_type(type="struct", crate="bevy_app", name="App", no_mod=true)}}s. The simplest Bevy app looks like this:
 
 ```rs
 use bevy::prelude::*;

--- a/content/learn/migration-guides/0.5-0.6/_index.md
+++ b/content/learn/migration-guides/0.5-0.6/_index.md
@@ -233,7 +233,7 @@ struct SystemParamDerive<'w, 's> {
 
 <!-- Adapt for ParamSet instead, if https://github.com/bevyengine/bevy/pull/2765 is merged -->
 
-Due to the [System Param Lifetime Split](#system-param-lifetime-split), {{rust_type(type="struct" crate="bevy_ecs" mod="system" name="QuerySet" version="0.6.0" no_mod=true plural=true)}} now need to specify their Queries with {{rust_type(type="struct" crate="bevy_ecs" mod="query" version="0.6.0" name="QueryState" no_mod=true)}} instead of {{rust_type(type="struct" crate="bevy_ecs" mod="system" version="0.6.0" name="Query" no_mod=true)}}.
+Due to the [System Param Lifetime Split](#system-param-lifetime-split), {{rust_type(type="struct" crate="bevy_ecs" mod="system" name="QuerySet" version="0.6.0" no_mod=true)}}s now need to specify their Queries with {{rust_type(type="struct" crate="bevy_ecs" mod="query" version="0.6.0" name="QueryState" no_mod=true)}} instead of {{rust_type(type="struct" crate="bevy_ecs" mod="system" version="0.6.0" name="Query" no_mod=true)}}.
 
 ```rust
 // 0.5
@@ -255,7 +255,7 @@ The {{rust_type(type="struct" crate="bevy_input" mod="" version="0.5.0" name="In
 
 The {{rust_type(type="struct" crate="bevy_ecs" mod="system" version="0.5.0" name="SystemState" no_mod=true)}} struct, which stores the metadata of a System, was renamed to {{rust_type(type="struct" crate="bevy_ecs" mod="system" version="0.6.0" name="SystemMeta" no_mod=true)}}.
 
-This was done to accommodate the new {{rust_type(type="struct" crate="bevy_ecs" mod="system" version="0.6.0" name="SystemState" no_mod=true)}} which allows easier cached access to {{rust_type(type="trait" crate="bevy_ecs" mod="system" version="0.6.0" name="SystemParam" no_mod=true plural=true)}} outside of a regular System.
+This was done to accommodate the new {{rust_type(type="struct" crate="bevy_ecs" mod="system" version="0.6.0" name="SystemState" no_mod=true)}} which allows easier cached access to {{rust_type(type="trait" crate="bevy_ecs" mod="system" version="0.6.0" name="SystemParam" no_mod=true)}}s outside of a regular System.
 
 <!-- TODO: Link to entry for SystemState in the release blog post. -->
 

--- a/content/news/2020-08-10-introducing-bevy/index.md
+++ b/content/news/2020-08-10-introducing-bevy/index.md
@@ -80,7 +80,7 @@ fn main() {
 
 {{rust_type(type="trait", crate="bevy" version="0.1.0" name="AddDefaultPlugins" method="add_default_plugins" no_mod=true no_struct=true)}} adds all of the features you probably expect from a game engine: a 2D / 3D renderer, asset loading, a UI system, windows, input, etc
 
-You can also register the default {{rust_type(type="trait" name="Plugin" crate="bevy_app" version="0.1.0" plural=true)}} manually like this:
+You can also register the default {{rust_type(type="trait" name="Plugin" crate="bevy_app" version="0.1.0")}}s manually like this:
 
 ```rs
 fn main() {
@@ -829,13 +829,13 @@ fn event_consumer(mut state: Local<State>, my_events: Res<Events<MyEvent>>) {
 }
 ```
 
-`app.add_event::<MyEvent>()` adds a new {{rust_type(type="struct", crate="bevy_app" version="0.1.0" name="Events")}} resource for MyEvent and a system that swaps the ```Events<MyEvent>``` buffers every update.  {{rust_type(type="struct" crate="bevy_app" version="0.1.0" name="EventReader" plural=true)}} are very cheap to create. They are essentially just an array index that tracks the last event that has been read.
+`app.add_event::<MyEvent>()` adds a new {{rust_type(type="struct", crate="bevy_app" version="0.1.0" name="Events")}} resource for MyEvent and a system that swaps the ```Events<MyEvent>``` buffers every update.  {{rust_type(type="struct" crate="bevy_app" version="0.1.0" name="EventReader")}}s are very cheap to create. They are essentially just an array index that tracks the last event that has been read.
 
 Events are used in Bevy for features like window resizing, assets, and input. The tradeoff for being both allocation and cpu efficient is that each system only has one chance to receive an event, otherwise it will be lost on the next update. I believe this is the correct tradeoff for apps that run in a loop (ex: games).
 
 ## Assets
 
-Bevy {{rust_type(type="struct" crate="bevy_asset" version="0.1.0" name="Assets")}} are just typed data that can be referenced using asset {{rust_type(type="struct" crate="bevy_asset" version="0.1.0" name="Handle" plural=true)}} . For example, 3d meshes, textures, fonts, materials, scenes, and sounds are assets. `Assets<T>` is a generic collection of assets of type `T`. In general asset usage looks like this:
+Bevy {{rust_type(type="struct" crate="bevy_asset" version="0.1.0" name="Assets")}} are just typed data that can be referenced using asset {{rust_type(type="struct" crate="bevy_asset" version="0.1.0" name="Handle")}}s. For example, 3d meshes, textures, fonts, materials, scenes, and sounds are assets. `Assets<T>` is a generic collection of assets of type `T`. In general asset usage looks like this:
 
 ### Asset Creation
 

--- a/content/news/2020-12-19-bevy-0.4/index.md
+++ b/content/news/2020-12-19-bevy-0.4/index.md
@@ -295,7 +295,7 @@ Check out the excellent ["Fix Your Timestep!"](https://gafferongames.com/post/fi
 
 #### Typed Stage Builders
 
-Now that stages can be any type, we need a way for {{rust_type(type="trait" crate="bevy_app" version="0.4.0" name="Plugin" no_mod=true plural=true)}} to interact with arbitrary stage types:
+Now that stages can be any type, we need a way for {{rust_type(type="trait" crate="bevy_app" version="0.4.0" name="Plugin" no_mod=true)}}s to interact with arbitrary stage types:
 
 ```rust
 app

--- a/content/news/2021-04-06-bevy-0.5/index.md
+++ b/content/news/2021-04-06-bevy-0.5/index.md
@@ -166,7 +166,7 @@ for (a, mut b) in query.iter_mut(&mut world) {
 }
 ```
 
-However for {{rust_type(type="trait" crate="bevy_ecs" mod="system" version="0.5.0" name="System" no_mod=true plural=true)}}  this is a non-breaking change. Query state management is done internally by the relevant SystemParam.
+However for {{rust_type(type="trait" crate="bevy_ecs" mod="system" version="0.5.0" name="System" no_mod=true)}}s this is a non-breaking change. Query state management is done internally by the relevant SystemParam.
 
 We have achieved some pretty significant performance wins as a result of the new Query system.
 
@@ -223,7 +223,7 @@ Fortunately @Ratysz has been [doing](https://ratysz.github.io/article/scheduling
 
 <div class="release-feature-authors">authors: @Ratysz, @TheRawMeatball</div>
 
-Systems can now be assigned one or more {{rust_type(type="trait" crate="bevy_ecs" mod="schedule" version="0.5.0" name="SystemLabel" no_mod=true plural=true)}}. These labels can then be referenced by other systems (within a stage) to run before or after systems with that label:
+Systems can now be assigned one or more {{rust_type(type="trait" crate="bevy_ecs" mod="schedule" version="0.5.0" name="SystemLabel" no_mod=true)}}s. These labels can then be referenced by other systems (within a stage) to run before or after systems with that label:
 
 ```rust
 app
@@ -289,7 +289,7 @@ Bevy plugin authors should export labels like this in their public APIs to enabl
 
 ### System Sets
 
-{{rust_type(type="struct" crate="bevy_ecs" mod="schedule" version="0.5.0" name="SystemSet" no_mod=true plural=true)}} are a new way to apply the same configuration to a group of systems, which significantly cuts down on boilerplate. The "physics" example above could be rephrased like this:
+{{rust_type(type="struct" crate="bevy_ecs" mod="schedule" version="0.5.0" name="SystemSet" no_mod=true)}}s are a new way to apply the same configuration to a group of systems, which significantly cuts down on boilerplate. The "physics" example above could be rephrased like this:
 
 ```rust
 app
@@ -767,7 +767,7 @@ This example serves as a quick introduction to building 3D games in Bevy. It sho
 
 <div class="release-feature-authors">authors: @kokounet</div>
 
-The {{rust_type(type="struct" crate="bevy_core" version="0.5.0" name="Timer" no_mod=true)}} struct now internally uses {{rust_type(type="struct" crate="std" mod="time" name="Duration" no_mod=true plural=true)}} instead of using `f32` representations of seconds. This both increases precision and makes the api a bit nicer to look at.
+The {{rust_type(type="struct" crate="bevy_core" version="0.5.0" name="Timer" no_mod=true)}} struct now internally uses {{rust_type(type="struct" crate="std" mod="time" name="Duration" no_mod=true)}}s instead of using `f32` representations of seconds. This both increases precision and makes the api a bit nicer to look at.
 
 ```rust
 fn system(mut timer: ResMut<Timer>, time: Res<Time>) {

--- a/content/news/2021-08-10-bevys-first-birthday/index.md
+++ b/content/news/2021-08-10-bevys-first-birthday/index.md
@@ -90,7 +90,7 @@ I know the lack of stability has been tough for some people, but I think this is
 
 ### The Bevy App Model
 
-This year we invested heavily in what I call The Bevy App Model. Bevy {{rust_type(type="struct", crate="bevy_app", name="App", no_mod=true, plural=true)}} are easy to understand, ergonomic to write, and modular via {{rust_type(type="trait", crate="bevy_app", name="Plugin", no_mod=true, plural=true)}}. My goal was to blur the lines between engine developers and app developers. I think we absolutely nailed it:
+This year we invested heavily in what I call The Bevy App Model. Bevy {{rust_type(type="struct", crate="bevy_app", name="App", no_mod=true)}}s are easy to understand, ergonomic to write, and modular via {{rust_type(type="trait", crate="bevy_app", name="Plugin", no_mod=true)}}s. My goal was to blur the lines between engine developers and app developers. I think we absolutely nailed it:
 
 1. There is no "scripting interface" separating "engine logic" from "app logic". We use a single language (Rust) for the whole stack. Rust feels modern with "high level" niceties while retaining low level performance and control. In my opinion, Bevy Apps are often simpler and more expressive than high level equivalents like Unity or Godot, thanks to the state-of-the-art [Bevy ECS](https://github.com/bevyengine/bevy/tree/main/crates/bevy_ecs). And under the hood Bevy Apps _are_ simpler because there are no internal translation layers between languages like C++ and scripting languages like C#:
 

--- a/content/news/2022-01-08-bevy-0.6/index.md
+++ b/content/news/2022-01-08-bevy-0.6/index.md
@@ -168,7 +168,7 @@ Bevy's built-in render features build on top of the Core Pipeline (ex: `bevy_spr
 
 <div class="release-feature-authors">authors: @cart</div>
 
-The new renderer structure gives developers fine-grained control over how entities are drawn. Developers can manually define Extract, Prepare, and Queue systems to draw entities using arbitrary render commands in custom or built-in {{rust_type(type="trait" crate="bevy_core_pipeline" version="0.6.0" name="RenderPhase" plural=true)}}. However this level of control necessitates understanding the render pipeline internals and involve more boilerplate than most users are willing to tolerate. Sometimes all you want to do is slot your custom material shader into the existing pipelines!
+The new renderer structure gives developers fine-grained control over how entities are drawn. Developers can manually define Extract, Prepare, and Queue systems to draw entities using arbitrary render commands in custom or built-in {{rust_type(type="trait" crate="bevy_core_pipeline" version="0.6.0" name="RenderPhase")}}s. However this level of control necessitates understanding the render pipeline internals and involve more boilerplate than most users are willing to tolerate. Sometimes all you want to do is slot your custom material shader into the existing pipelines!
 
 The new {{rust_type(type="trait" crate="bevy_pbr" version="0.6.0" name="Material")}} trait enables users to ignore nitty gritty details in favor of a simpler interface: just implement the {{rust_type(type="trait" crate="bevy_pbr" version="0.6.0" name="Material")}} trait and add a {{rust_type(type="struct" crate="bevy_pbr" version="0.6.0" name="MaterialPlugin")}} for your type. The new [shader_material.rs](https://github.com/bevyengine/bevy/blob/v0.6.0/examples/shader/shader_material.rs) example illustrates this.
 
@@ -195,7 +195,7 @@ impl Material for CustomMaterial {
 
 There is also a {{rust_type(type="trait" crate="bevy_pbr" version="0.6.0" name="SpecializedMaterial")}} variant, which enables "specializing" shaders and pipelines using custom per-entity keys. This extra flexibility isn't always needed, but when you need it, you will be glad to have it! For example, the built-in StandardMaterial uses specialization to toggle whether or not the Entity should receive lighting in the shader.
 
-We also have big plans to make {{rust_type(type="trait" crate="bevy_pbr" version="0.6.0" name="Material" plural=true)}} even better:
+We also have big plans to make {{rust_type(type="trait" crate="bevy_pbr" version="0.6.0" name="Material")}}s even better:
 
 * **Bind Group derives**: this should cut down on the boilerplate of passing materials to the GPU.
 * **Material Instancing**: materials enable us to implement high-level mesh instancing as a simple configuration item for both built in and custom materials.

--- a/templates/shortcodes/rust_type.html
+++ b/templates/shortcodes/rust_type.html
@@ -25,5 +25,4 @@
 {{ throw(message="the plural option is no longer used. just put an 's' after the shortcode.") }}
 {% endif %}
 
-<a href="{{url}}/{{path}}{{mod_path}}/{{type}}.{{name}}.html{% if method %}#method.{{method}}{% endif %}"><code>{% if not no_crate and crate and not no_mod and mod %}{{crate}}::{% if not no_mod and mod%}{{mod}}::{% endif %}{% elif not no_mod and mod%}{{mod}}::{% endif %}{% if not no_struct %}{{name}}{% endif %}{% if method %}{% if not no_struct %}::{% endif %}{{method}}(){% endif %}</code>
-</a>
+<a href="{{url}}/{{path}}{{mod_path}}/{{type}}.{{name}}.html{% if method %}#method.{{method}}{% endif %}"><code>{% if not no_crate and crate and not no_mod and mod %}{{crate}}::{% if not no_mod and mod%}{{mod}}::{% endif %}{% elif not no_mod and mod%}{{mod}}::{% endif %}{% if not no_struct %}{{name}}{% endif %}{% if method %}{% if not no_struct %}::{% endif %}{{method}}(){% endif %}</code></a>

--- a/templates/shortcodes/rust_type.html
+++ b/templates/shortcodes/rust_type.html
@@ -21,5 +21,9 @@
 {% set path = crate ~ "/" ~ version ~ "/" ~ crate %}
 {% endif %}
 
-<a href="{{url}}/{{path}}{{mod_path}}/{{type}}.{{name}}.html{% if method %}#method.{{method}}{% endif %}"><code>{% if not no_crate and crate and not no_mod and mod %}{{crate}}::{% if not no_mod and mod%}{{mod}}::{% endif %}{% elif not no_mod and mod%}{{mod}}::{% endif %}{% if not no_struct %}{{name}}{% if plural %}s{% endif %}{% endif %}{% if method %}{% if not no_struct %}::{% endif %}{{method}}(){% endif %}</code>
+{% if plural %}
+{{ throw(message="the plural option is no longer used. just put an 's' after the shortcode.") }}
+{% endif %}
+
+<a href="{{url}}/{{path}}{{mod_path}}/{{type}}.{{name}}.html{% if method %}#method.{{method}}{% endif %}"><code>{% if not no_crate and crate and not no_mod and mod %}{{crate}}::{% if not no_mod and mod%}{{mod}}::{% endif %}{% elif not no_mod and mod%}{{mod}}::{% endif %}{% if not no_struct %}{{name}}{% endif %}{% if method %}{% if not no_struct %}::{% endif %}{{method}}(){% endif %}</code>
 </a>


### PR DESCRIPTION
For a type called `App` that is plural, it should look like this:

> `App`s

and not

> `Apps`

because the latter makes it sound like a singular type named "Apps".