### PR TITLE
Adapt release notes generator to use merge state instead of bors

### DIFF
--- a/generate-release/src/github_client.rs
+++ b/generate-release/src/github_client.rs
@@ -78,6 +78,11 @@ pub struct GithubUserSearchResponse {
 }
 
 #[derive(Deserialize, Clone, Debug)]
+pub struct GithubIssuesResponsePullRequest {
+    pub merged_at: Option<String>,
+}
+
+#[derive(Deserialize, Clone, Debug)]
 pub struct GithubIssuesResponse {
     pub title: String,
     pub number: i32,
@@ -85,6 +90,7 @@ pub struct GithubIssuesResponse {
     pub labels: Vec<GithubLabel>,
     pub user: GithubUser,
     pub closed_at: DateTime<Utc>,
+    pub pull_request: Option<GithubIssuesResponsePullRequest>,
 }
 
 pub struct GithubClient {
@@ -219,7 +225,12 @@ impl GithubClient {
         Ok(response
             .iter()
             // Make sure to only get the PRs that were merged by bors
-            .filter(|pr| pr.title.starts_with("[Merged by Bors] - "))
+            .filter(|pr| {
+                pr.pull_request
+                    .as_ref()
+                    .map(|pr| pr.merged_at.is_some())
+                    .unwrap_or(false)
+            })
             .cloned()
             .collect())
     }


### PR DESCRIPTION
This release cycle we used merge queues instead of Bors. This adapts our release note generator to read that state instead of the bors merge state from the title. 