### PR TITLE
Add image-compare widget

### DIFF
--- a/sass/components/_image_compare.scss
+++ b/sass/components/_image_compare.scss
@@ -1,5 +1,6 @@
 div.image-compare {
-  display: block;
+  display: flex;
+  align-items: center;
   position: relative;
   border-radius: 10px;
   width: 100%;
@@ -7,16 +8,30 @@ div.image-compare {
   background-color: black;
   --slider-value: 50%;
 
-  & img {
+  &::before,
+  &::after {
+    position: absolute;
+    font-weight: bolder;
+    font-size: 175%;
+    writing-mode: vertical-rl;
+  }
+  &::before {
+    content: attr(data-title-a);
+    z-index: 1;
+  }
+  &::after {
+    content: attr(data-title-b);
     width: 100%;
   }
 
+  & img {
+    width: 100%;
+  }
   & .image-a {
     position: absolute;
     -webkit-clip-path: inset(0 calc(100% - var(--slider-value) + 1.5px) 0 0);
     clip-path: inset(0 calc(100% - var(--slider-value) + 1.5px) 0 0);
   }
-
   & .image-b {
     float: right;
     -webkit-clip-path: inset(0 0 0 calc(var(--slider-value) + 1.5px));
@@ -32,6 +47,7 @@ div.image-compare {
     background-color: transparent;
     -webkit-appearance: none;
     appearance: none;
+    z-index: 2;
 
     &::-moz-range-thumb {
       border: none;

--- a/sass/components/_image_compare.scss
+++ b/sass/components/_image_compare.scss
@@ -1,0 +1,46 @@
+div.image-compare {
+  display: block;
+  position: relative;
+  border-radius: 10px;
+  width: 100%;
+  aspect-ratio: 16 / 9; // fallback
+  background-color: black;
+  --slider-value: 50%;
+
+  & img {
+    width: 100%;
+  }
+
+  & .image-a {
+    position: absolute;
+    -webkit-clip-path: inset(0 calc(100% - var(--slider-value) + 1.5px) 0 0);
+    clip-path: inset(0 calc(100% - var(--slider-value) + 1.5px) 0 0);
+  }
+
+  & .image-b {
+    float: right;
+    -webkit-clip-path: inset(0 0 0 calc(var(--slider-value) + 1.5px));
+    clip-path: inset(0 0 0 calc(var(--slider-value) + 1.5px));
+  }
+
+  & input[type="range"] {
+    position: absolute;
+    padding: 0;
+    margin: 0;
+    width: inherit;
+    height: 100%;
+    background-color: transparent;
+    -webkit-appearance: none;
+    appearance: none;
+
+    &::-moz-range-thumb {
+      border: none;
+      background-color: transparent;
+    }
+    &::-webkit-slider-thumb {
+      width: 0; // no clue why this is required, but it is
+      -webkit-appearance: none;
+      appearance: none;
+    }
+  }
+}

--- a/sass/site.scss
+++ b/sass/site.scss
@@ -42,6 +42,7 @@
 @import "components/syntax-theme";
 @import "components/tree-menu";
 @import "components/asset-card";
+@import "components/image_compare";
 
 // Pages
 // - Page specific CSS

--- a/static/components.js
+++ b/static/components.js
@@ -9,9 +9,10 @@ function clamp(val, min, max) {
 // Usage in a document should look like:
 // ```html
 // <main>
-//   <div class="image-compare" style="aspect-ratio: 16 / 9">
-//     <img class="image-a" src="$url" />
-//     <img class="image-b" src="$url" />
+//   <div class="image-compare" style="aspect-ratio: 16 / 9"
+//   data-title-a="Apples" data-title-b="Oranges">
+//     <img class="image-a" alt="Apples" src="apples.png" />
+//     <img class="image-b" alt="Oranges" src="oranges.png" />
 //   </div>
 // </main>
 // ```

--- a/static/components.js
+++ b/static/components.js
@@ -1,0 +1,41 @@
+
+// clamp a number to the given range
+function clamp(val, min, max) {
+  return Math.min(Math.max(val, min), max)
+}
+
+// inserts the input element required to activate image_compare components
+//
+// Usage in a document should look like:
+// ```html
+// <main>
+//   <div class="image-compare" style="aspect-ratio: 16 / 9">
+//     <img class="image-a" src="$url" />
+//     <img class="image-b" src="$url" />
+//   </div>
+// </main>
+// ```
+//
+// The `image_compare` scss component should be used.
+//
+// Ideally the `aspect-ratio` should be set, but it will
+// fallback to 16/9.
+function enable_image_compare() {
+  const image_compares = document.querySelectorAll("div.image-compare");
+  for (const img_cmp of image_compares) {
+    // insert the input only when js is running
+    const slider = document.createElement('input');
+    slider.type = "range";
+    slider.min = "0";
+    slider.max = "100";
+    slider.value = "50";
+    img_cmp.appendChild(slider);
+    // setup callback
+    img_cmp.style.setProperty('--slider-value', clamp(slider.value, 7, 93) + "%");
+    slider.addEventListener("input", (event) => {
+      img_cmp.style.setProperty('--slider-value', clamp(slider.value, 7, 93) + "%");
+    });
+  }
+}
+
+export { enable_image_compare };

--- a/templates/news-page.html
+++ b/templates/news-page.html
@@ -56,4 +56,11 @@
   </div>
   {% endif %}
   <div class="media-content news-content">{{ page.content | safe }}</div>
+  <script type="module">
+    import { enable_image_compare } from '/components.js';
+
+    document.addEventListener("DOMContentLoaded", function() {
+      enable_image_compare();
+    });
+  </script>
 {% endblock content %}


### PR DESCRIPTION
Adds a side-by-side image-compare widget for usage in news posts.

Usage in a document should look as follows
```html
<main>
  <div class="image-compare" style="aspect-ratio: 16 / 9" data-title-a="Apples" data-title-b="Oranges">
    <img class="image-a" alt="Apples" src="apples.png" />
    <img class="image-b" alt="Oranges" src="oranges.png" />
  </div>
</main>
<script type="module">
  import { enable_image_compare } from '/components.js';
  document.addEventListener("DOMContentLoaded", function() {
    enable_image_compare();
  });
</script>
```

The `aspect-ratio` should be set to match the aspect ratio of the images, but it will default to 16/9.

---

I tested this on Windows with Firefox, Chrome, & Edge. Additional testing for Safari & others would be appreciated.