### PR TITLE
Add link to examples-wgpu in the examples page

### DIFF
--- a/templates/examples.html
+++ b/templates/examples.html
@@ -17,6 +17,9 @@
         These examples demonstrate how to use Bevy's features in a minimal, easy to understand way. Click an example below to run it in
         your browser (using WASM + WebGL) and view the source code. You can also view these examples (and others) in the
         <a href="https://github.com/bevyengine/bevy/tree/latest/examples#examples">Bevy repo</a>.
+        <p>
+            If you would like to try WASM + WebGPU, you can explore our <a href="/examples-webgpu">live WebGPU examples</a> page. 
+        </p>
     </div>
     {% for subsection in section.subsections %}
         {% set section = get_section(path=subsection) %}


### PR DESCRIPTION

# Objective

Add a easy way to access the examples-wgpu page. I always struggle to find it.

 # Solution
Add a link to [examples-wgpu](https://bevyengine.org/examples-webgpu) in the [examples section](https://bevyengine.org/examples/)