### PR TITLE
Fix grammar in 0.11 news release  (name -> names)

### DIFF
--- a/content/news/2023-07-09-bevy-0.11/index.md
+++ b/content/news/2023-07-09-bevy-0.11/index.md
@@ -111,7 +111,7 @@ Bevy, since the 0.7 release, supports 3D animations.
 
 But it only supported _skeletal_ animations. Leaving on the sidewalk a common
 animation type called _morph targets_ (aka blendshapes, aka keyshapes, and a slew
-of other name). This is the grandparent of all 3D character animation!
+of other names). This is the grandparent of all 3D character animation!
 [Crash Bandicoot]'s run cycle used morph targets.
 
 <video controls><source src="morph_targets_video.mp4" type="video/mp4"/></video>


### PR DESCRIPTION
A sentence from the news release was corrected from "(aka blendshapes, aka keyshapes, and a slew of other name)." to "(aka blendshapes, aka keyshapes, and a slew of other names)."