### PR TITLE
Migration guide 0.10 -> 0.11 Audio API FIX

### DIFF
--- a/content/learn/migration-guides/0.10-0.11/_index.md
+++ b/content/learn/migration-guides/0.10-0.11/_index.md
@@ -159,8 +159,10 @@ fn play_music(
     asset_server: Res<AssetServer>,
 ) {
     commands.spawn((
-        AudioBundle::from_audio_source(asset_server.load("music.ogg"))
-            .with_settings(PlaybackSettings::LOOP.with_volume(0.5)),
+        AudioBundle {
+            source: asset_server.load("music.ogg"),
+            settings: PlaybackSettings::LOOP.with_volume(Volume::new_relative(0.5)),
+        },
         MyMusic,
     ));
 }
@@ -169,7 +171,7 @@ fn toggle_pause_music(
     // `AudioSink` will be inserted by Bevy when the audio starts playing
     query_music: Query<&AudioSink, With<MyMusic>>,
 ) {
-    if let Ok(sink) = query.get_single() {
+    if let Ok(sink) = query_music.get_single() {
         sink.toggle();
     }
 }


### PR DESCRIPTION
The auto-generated guide for Audio from the original PR is outdated. Seems like Cart changed the code last minute, so the code that is in migration guide is invalid. I guess I am the first one to notice that...

So I changed this:
![image](https://github.com/bevyengine/bevy-website/assets/49441831/89974132-f30b-4901-b6a4-e4a43d49036b)

To this: 
![image](https://github.com/bevyengine/bevy-website/assets/49441831/11e92457-9ae7-4c19-8aa4-e377b79d6ea3)

Source (Cart himself): [Link to PR](https://github.com/bevyengine/bevy/pull/8424)

![image](https://github.com/bevyengine/bevy-website/assets/49441831/931f15fe-1661-4619-896d-852b012fe022)