### PR TITLE
0.11 Migration: Add section for `CalculatedSize`

### DIFF
--- a/content/learn/migration-guides/0.10-0.11/_index.md
+++ b/content/learn/migration-guides/0.10-0.11/_index.md
@@ -1428,16 +1428,49 @@ pub const ABSOLUTE_STYLE: Style = Style {
 // Implement all the fields or don't use const
 ```
 
+### `CalculatedSize` split
+
+`CalculatedSize` doesn't exist anymore.
+
+The data from the `CalculatedSize` `size` field still exists. But it has been
+split between the two following components:
+
+* the new component `bevy::ui::widget::UiImageSize::size`'s method
+* the new component `bevy::text::TextLayoutInfo::size`'s field
+
+```rust
+// before: 0.10.1
+fn evaluate_size(query: Query<&CalculatedSize>) {
+    for calculated in &query {
+        let size = calculated.size;
+        // do things with size
+    }
+}
+// after: 0.11.0
+use bevy::{
+    ui::widget::UiImageSize,
+    text::TextLayoutInfo,
+};
+fn evaluate_size(query: Query<AnyOf<(&UiImageSize, &TextLayoutInfo)>>) {
+    for calculated in &query {
+        let size = match calculated {
+            (Some(image), None) => image.size(),
+            (None, Some(text)) => text.size,
+            _ => unreachable!(),
+        };
+        // do things with size
+    }
+}
+```
+
 ### [`MeasureFunc` improvements](https://github.com/bevyengine/bevy/pull/8402)
 
 <div class="migration-guide-area-tags">
     <div class="migration-guide-area-tag">UI</div>
 </div>
 
-- `CalculatedSize` has been renamed to `ContentSize`.
 - The `upsert_leaf` function has been removed from `UiSurface` and replaced with `update_measure` which updates the `MeasureFunc` without node insertion.
 - The `dyn_clone` method has been removed from the `Measure` trait.
-- The new function of `CalculatedSize` has been replaced with the method `set`.
 - `ImageBundle` and `TextBundle` don't implement `Clone` anymore. [You can either](https://github.com/bevyengine/bevy-website/issues/699):
 
     1. Wrap yourself the bundle type and implement `Clone` by skipping cloning the `ContentSize` field.

--- a/content/learn/migration-guides/0.10-0.11/_index.md
+++ b/content/learn/migration-guides/0.10-0.11/_index.md
@@ -1430,6 +1430,10 @@ pub const ABSOLUTE_STYLE: Style = Style {
 
 ### `CalculatedSize` split
 
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">UI</div>
+</div>
+
 `CalculatedSize` doesn't exist anymore.
 
 The data from the `CalculatedSize` `size` field still exists. But it has been

--- a/content/learn/migration-guides/0.10-0.11/_index.md
+++ b/content/learn/migration-guides/0.10-0.11/_index.md
@@ -1435,8 +1435,8 @@ pub const ABSOLUTE_STYLE: Style = Style {
 The data from the `CalculatedSize` `size` field still exists. But it has been
 split between the two following components:
 
-* the new component `bevy::ui::widget::UiImageSize::size`'s method
-* the new component `bevy::text::TextLayoutInfo::size`'s field
+- the new component `bevy::ui::widget::UiImageSize::size`'s method
+- the new component `bevy::text::TextLayoutInfo::size`'s field
 
 ```rust
 // before: 0.10.1

--- a/content/learn/migration-guides/0.10-0.11/_index.md
+++ b/content/learn/migration-guides/0.10-0.11/_index.md
@@ -1428,45 +1428,6 @@ pub const ABSOLUTE_STYLE: Style = Style {
 // Implement all the fields or don't use const
 ```
 
-### `CalculatedSize` split
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">UI</div>
-</div>
-
-`CalculatedSize` doesn't exist anymore.
-
-The data from the `CalculatedSize` `size` field still exists. But it has been
-split between the two following components:
-
-- the new component `bevy::ui::widget::UiImageSize::size`'s method
-- the new component `bevy::text::TextLayoutInfo::size`'s field
-
-```rust
-// before: 0.10.1
-fn evaluate_size(query: Query<&CalculatedSize>) {
-    for calculated in &query {
-        let size = calculated.size;
-        // do things with size
-    }
-}
-// after: 0.11.0
-use bevy::{
-    ui::widget::UiImageSize,
-    text::TextLayoutInfo,
-};
-fn evaluate_size(query: Query<AnyOf<(&UiImageSize, &TextLayoutInfo)>>) {
-    for calculated in &query {
-        let size = match calculated {
-            (Some(image), None) => image.size(),
-            (None, Some(text)) => text.size,
-            _ => unreachable!(),
-        };
-        // do things with size
-    }
-}
-```
-
 ### [`MeasureFunc` improvements](https://github.com/bevyengine/bevy/pull/8402)
 
 <div class="migration-guide-area-tags">
@@ -1550,7 +1511,39 @@ Use these helper functions to replace the variants of `Overflow`:
     <div class="migration-guide-area-tag">UI</div>
 </div>
 
-`ImageBundle` has a new field `image_size` of type `UiImageSize` which contains the size of the image bundle's texture and is updated automatically by `update_image_calculated_size_system`.
+`CalculatedSize` doesn't exist anymore.
+
+The data from the `CalculatedSize` `size` field still exists. But it has been
+split between the two following components:
+
+- the new component `bevy::ui::widget::UiImageSize::size`'s method. It is
+    updated in the `update_image_calculated_size_system` system.
+- the new component `bevy::text::TextLayoutInfo::size`'s field
+
+```rust
+// before: 0.10.1
+fn evaluate_size(query: Query<&CalculatedSize>) {
+    for calculated in &query {
+        let size = calculated.size;
+        // do things with size
+    }
+}
+// after: 0.11.0
+use bevy::{
+    ui::widget::UiImageSize,
+    text::TextLayoutInfo,
+};
+fn evaluate_size(query: Query<AnyOf<(&UiImageSize, &TextLayoutInfo)>>) {
+    for calculated in &query {
+        let size = match calculated {
+            (Some(image), None) => image.size(),
+            (None, Some(text)) => text.size,
+            _ => unreachable!(),
+        };
+        // do things with size
+    }
+}
+```
 
 ### [Update ahash and hashbrown](https://github.com/bevyengine/bevy/pull/8623)
 


### PR DESCRIPTION
Fixes #701

Note: The removed points from the `MeasureFunc` section are changes that are not relevant to migrating from 0.10 to 0.11, they are changes to code that was already changed in a previous 0.11 PR.