### PR TITLE
Remove outdated notice in WebGPU examples

### DIFF
--- a/templates/example-webgpu.html
+++ b/templates/example-webgpu.html
@@ -19,9 +19,6 @@
         </h2>
         
         WebGPU is currently only supported on Chrome starting with version 113, and only on desktop. If they don't work on your configuration, you can check the WebGL2 examples <a href="/examples">here</a>.
-        <br />
-
-        Support for WebGPU in Bevy hasn't been released yet, this example has been compiled using the main branch.
     </div>    
 
     <br />  

--- a/templates/examples-webgpu.html
+++ b/templates/examples-webgpu.html
@@ -23,9 +23,6 @@
         </h2>
         
         WebGPU is currently only supported on Chrome starting with version 113, and only on desktop. If they don't work on your configuration, you can check the WebGL2 examples <a href="/examples">here</a>.
-        <br />
-
-        Support for WebGPU in Bevy hasn't been released yet, examples on this page are compiled using the main branch.
         
     </div>
     {% for subsection in section.subsections %}


### PR DESCRIPTION
WebGPU support has been launched with 0.11, so there is no longer a need to inform people that WebGPU examples are compiled with main branch (even though that's still the case for now).