### PR TITLE
Expand upon the 0.11 tonemapping migration guide

### DIFF
--- a/content/learn/migration-guides/0.10-0.11/_index.md
+++ b/content/learn/migration-guides/0.10-0.11/_index.md
@@ -1157,6 +1157,10 @@ fn view_logical_camera_rect(camera_query: Query<&Camera>) {
 
 The default tonemapper has been changed from ReinhardLuminance to TonyMcMapface. Explicitly set ReinhardLuminance on your cameras to get back the previous look.
 
+TonyMcMapface requires the `ktx2`, `tonemapping_luts`, and `zstd` features, which are enabled by default. If you disable the default features and notice that your scene is pink, you can either add the `ktx2`, `tonemapping_luts`, and `zstd` features, or use a different tonemapper.
+
+Of the tonemappers that don't require a lookup table (LUT), SomewhatBoringDisplayTransform is the closest to TonyMcMapface. LUT based tonemappers are preferable as they tend to be faster.
+
 ### [Apply codebase changes in preparation for `StandardMaterial` transmission](https://github.com/bevyengine/bevy/pull/8704)
 
 <div class="migration-guide-area-tags">


### PR DESCRIPTION
Mentions that the new tonemapper requires the `ktx2`, `tonemapping_luts`, and `zstd` features, and recommends `SomewhatBoringDisplayTransform` if for whatever reason you don't want to use those features.

edit: Also explicitly mentions scene turning pink so if people search for that, they will hopefully find it.