### PR TITLE
Fix typo in getting-started/ecs

### DIFF
--- a/content/learn/book/getting-started/ecs/_index.md
+++ b/content/learn/book/getting-started/ecs/_index.md
@@ -127,7 +127,7 @@ Now we just register the system in our App. Note that you can pass more than one
 fn main() {
     App::new()
         .add_systems(Startup, add_people)
-        .add_systems(Update, (hello_world, greet people))
+        .add_systems(Update, (hello_world, greet_people))
         .run();
 }
 ```


### PR DESCRIPTION
Hello!

I was following the getting started part of the book and noticed this tiny error. The greet_people system was missing its underscore leading to an error, and I thought I'd pop in and offer a fix.

Thanks for a great guide so far!