### PR TITLE
fix range input min/max handling on vivaldi

### DIFF
--- a/static/components.js
+++ b/static/components.js
@@ -1,3 +1,8 @@
+// clamp a number to the given range
+function clamp(val, min, max) {
+  return Math.min(Math.max(val, min), max)
+}
+
 // inserts the input element required to activate image_compare components
 //
 // Usage in a document should look like:
@@ -30,7 +35,7 @@ function enable_image_compare() {
     img_cmp.appendChild(slider);
     // setup callback
     slider.addEventListener("input", (event) => {
-      img_cmp.style.setProperty('--slider-value', slider.value + "%");
+      img_cmp.style.setProperty('--slider-value', clamp(slider.value, slider.min, slider.max) + "%");
     });
   }
 }


### PR DESCRIPTION
This addresses the issue raised in https://github.com/bevyengine/bevy-website/pull/703#pullrequestreview-1522440159 regarding the Vivaldi browser behaving incorrectly. 

The fix is simply to manually clamp the value, which is effectively a no-op on other (well-behaved) browsers