### PR TITLE
Update zola

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,7 +215,7 @@ jobs:
           path: content/community/people
 
       - name: "Build website"
-        uses: shalzz/zola-deploy-action@v0.16.1-1
+        uses: shalzz/zola-deploy-action@v0.17.2
         env:
           PAGES_BRANCH: gh-pages
           BUILD_DIR: .

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: "Build and deploy website"
         if: github.repository_owner == 'bevyengine'
-        uses: shalzz/zola-deploy-action@v0.16.1-1
+        uses: shalzz/zola-deploy-action@v0.17.2
         env:
           PAGES_BRANCH: gh-pages
           BUILD_DIR: .


### PR DESCRIPTION
The 0.16.1 version of zola has a bug when using colocated_path, this prevents usage of image resolution in #710

Solution: upgrade the zola action we use.

The diff of the github action is available at:

https://github.com/shalzz/zola-deploy-action/compare/v0.16.1-1...v0.17.2

Unblocks #710