### PR TITLE
Showcase PlaybackMode in the Bevy 0.11 changelog

### DIFF
--- a/content/news/2023-07-09-bevy-0.11/index.md
+++ b/content/news/2023-07-09-bevy-0.11/index.md
@@ -664,7 +664,7 @@ fn play_music(mut commands: Commands, asset_server: Res<AssetServer>) {
 
 The `mode` field in the [`PlaybackSettings`] struct offers a straightforward way to manage the lifecycle of these audio entities.
 
-By passing a [`PlaybackMode`], you are able to choose whether it plays once or repeatedly, using `Once` and `Loop` respectively. If you anticipate that the audio might be played again, you can save resources by temporarily unloading audio using `Despawn` or free up its memory immediately if it is a one-time effect using `Remove`.
+By passing a [`PlaybackMode`], you are able to choose whether it plays once or repeatedly, using `Once` and `Loop` respectively. If you anticipate that the audio might be played again, you can save resources by temporarily unloading it using `Despawn`, or free up its memory immediately if it is a one-time effect using `Remove`.
 
 ```rust
 AudioBundle {

--- a/content/news/2023-07-09-bevy-0.11/index.md
+++ b/content/news/2023-07-09-bevy-0.11/index.md
@@ -675,8 +675,6 @@ AudioBundle {
     }
 }
 ```
-
-
 Much simpler! To adjust playback you can query for the [`AudioSink`] component:
 
 ```rust

--- a/content/news/2023-07-09-bevy-0.11/index.md
+++ b/content/news/2023-07-09-bevy-0.11/index.md
@@ -662,6 +662,21 @@ fn play_music(mut commands: Commands, asset_server: Res<AssetServer>) {
 }
 ```
 
+The `mode` field in the [`PlaybackSettings`] struct offers a straightforward way to manage the lifecycle of these audio entities.
+
+By passing a [`PlaybackMode`], you are able to choose whether it plays once or repeatedly, using `Once` and `Loop` respectively. If you anticipate that the audio might be played again, you can save resources by temporarily unloading audio using `Despawn` or free up its memory immediately if it is a one-time effect using `Remove`.
+
+```rust
+AudioBundle {
+    source: asset_server.load("hit_sound.ogg"),
+    settings: PlaybackSettings {
+        mode: PlaybackMode::Despawn,
+        ..default()
+    }
+}
+```
+
+
 Much simpler! To adjust playback you can query for the [`AudioSink`] component:
 
 ```rust
@@ -675,6 +690,8 @@ fn pause_music(query_music: Query<&AudioSink, With<MyMusic>>) {
 [`Entity`]: https://docs.rs/bevy/0.11.0/bevy/ecs/entity/struct.Entity.html
 [`AudioBundle`]: https://docs.rs/bevy/0.11.0/bevy/audio/type.AudioBundle.html
 [`AudioSink`]: https://docs.rs/bevy/0.11.0/bevy/audio/struct.AudioSink.html
+[`PlaybackSettings`]: https://docs.rs/bevy/0.11.0/bevy/audio/struct.PlaybackSettings.html 
+[`PlaybackMode`]: https://docs.rs/bevy/0.11.0/bevy/audio/enum.PlaybackMode.html 
 
 ## Global Audio Volume
 

--- a/content/news/2023-07-09-bevy-0.11/index.md
+++ b/content/news/2023-07-09-bevy-0.11/index.md
@@ -687,7 +687,7 @@ fn pause_music(query_music: Query<&AudioSink, With<MyMusic>>) {
 [`Entity`]: https://docs.rs/bevy/0.11.0/bevy/ecs/entity/struct.Entity.html
 [`AudioBundle`]: https://docs.rs/bevy/0.11.0/bevy/audio/type.AudioBundle.html
 [`AudioSink`]: https://docs.rs/bevy/0.11.0/bevy/audio/struct.AudioSink.html
-[`PlaybackSettings`]: https://docs.rs/bevy/0.11.0/bevy/audio/struct.PlaybackSettings.html 
+[`PlaybackSettings`]: https://docs.rs/bevy/0.11.0/bevy/audio/struct.PlaybackSettings.html
 [`PlaybackMode`]: https://docs.rs/bevy/0.11.0/bevy/audio/enum.PlaybackMode.html 
 
 ## Global Audio Volume

--- a/content/news/2023-07-09-bevy-0.11/index.md
+++ b/content/news/2023-07-09-bevy-0.11/index.md
@@ -675,6 +675,7 @@ AudioBundle {
     }
 }
 ```
+
 Much simpler! To adjust playback you can query for the [`AudioSink`] component:
 
 ```rust

--- a/content/news/2023-07-09-bevy-0.11/index.md
+++ b/content/news/2023-07-09-bevy-0.11/index.md
@@ -674,6 +674,7 @@ AudioBundle {
         ..default()
     }
 }
+```
 Much simpler! To adjust playback you can query for the [`AudioSink`] component:
 
 ```rust

--- a/content/news/2023-07-09-bevy-0.11/index.md
+++ b/content/news/2023-07-09-bevy-0.11/index.md
@@ -688,7 +688,7 @@ fn pause_music(query_music: Query<&AudioSink, With<MyMusic>>) {
 [`AudioBundle`]: https://docs.rs/bevy/0.11.0/bevy/audio/type.AudioBundle.html
 [`AudioSink`]: https://docs.rs/bevy/0.11.0/bevy/audio/struct.AudioSink.html
 [`PlaybackSettings`]: https://docs.rs/bevy/0.11.0/bevy/audio/struct.PlaybackSettings.html
-[`PlaybackMode`]: https://docs.rs/bevy/0.11.0/bevy/audio/enum.PlaybackMode.html 
+[`PlaybackMode`]: https://docs.rs/bevy/0.11.0/bevy/audio/enum.PlaybackMode.html
 
 ## Global Audio Volume
 

--- a/content/news/2023-07-09-bevy-0.11/index.md
+++ b/content/news/2023-07-09-bevy-0.11/index.md
@@ -674,7 +674,6 @@ AudioBundle {
         ..default()
     }
 }
-```
 Much simpler! To adjust playback you can query for the [`AudioSink`] component:
 
 ```rust


### PR DESCRIPTION
Added a snippet to the blog post which mentions the `PlaybackSettings` struct which allows users to manage an audio entity's lifetime.