### PR TITLE
Asset page filtering

### DIFF
--- a/sass/pages/_assets.scss
+++ b/sass/pages/_assets.scss
@@ -16,4 +16,19 @@
     .item-grid {
         margin-bottom: 52px;
     }
+
+    .assets-search {
+        margin-bottom: 20px;
+
+        &__input {
+            @include card;
+            font-size: 1.2rem;
+            padding: $asset-card-padding;
+            width: 100%;
+
+            &:focus-visible {
+                outline: none;
+            }
+        }
+    }
 }

--- a/static/assets.js
+++ b/static/assets.js
@@ -1,10 +1,39 @@
-const search = document.querySelector('#assets-search')
+const searchElement = document.querySelector('#assets-search')
 
-search.addEventListener("input", (_) => {
-    const searchTerms = search.value.toLowerCase().split(' ')
+searchElement.addEventListener("input", (_) => {
+    filterSearchTerms()
+    hideEmptySubSections()
+    hideEmptySections()
+})
+
+function filterSearchTerms() {
+    const searchTerms = searchElement.value.toLowerCase().split(' ')
     for (const asset of document.querySelectorAll('.asset-card')) {
         const fullText = asset.text.toLowerCase()
         const searchMatch = searchTerms.every((term) => fullText.includes(term))
-        asset.style.display = searchMatch ? 'block' : 'none'
+        asset.parentElement.style.display = searchMatch ? 'block' : 'none'
     }
-})
+}
+
+function hideEmptySubSections() {
+    for (const itemGrid of document.querySelectorAll('.item-grid')) {
+        const cardInGrid = [...itemGrid.querySelectorAll('.asset-card')]
+        const areAllHidden = (cardInGrid.every((card) => card.parentElement.style.display === 'none'))
+        itemGrid.style.display = areAllHidden ? 'none' : 'grid'
+        itemGrid.previousElementSibling.style.display = areAllHidden ? 'none' : 'block'
+    }
+}
+
+function hideEmptySections() {
+    document.querySelectorAll('.asset-section').forEach(section => {
+        let nextElement = section.nextElementSibling
+        while (nextElement && !nextElement.classList.contains('asset-section')) {
+            if (nextElement.style.display !== 'none') {
+                section.style.display = 'block'
+                return
+            }
+            nextElement = nextElement.nextElementSibling
+        }
+        section.style.display = 'none'
+    })
+}

--- a/static/assets.js
+++ b/static/assets.js
@@ -1,0 +1,10 @@
+const search = document.querySelector('#assets-search')
+
+search.addEventListener("input", (_) => {
+    const searchTerms = search.value.toLowerCase().split(' ')
+    for (const asset of document.querySelectorAll('.asset-card')) {
+        const fullText = asset.text.toLowerCase()
+        const searchMatch = searchTerms.every((term) => fullText.includes(term))
+        asset.style.display = searchMatch ? 'block' : 'none'
+    }
+})

--- a/templates/assets.html
+++ b/templates/assets.html
@@ -15,6 +15,10 @@
     <div class="assets">
         {{ assets_macros::init_svg() }}
 
+        <div class="assets-search">
+            <input class="assets-search__input" type="text" id="assets-search" placeholder="Search (ie: 0.11 MIT)">
+        </div>
+
         <div class="assets-intro media-content">
             A collection of third-party Bevy assets, plugins, learning resources, and apps made by the community. If you would like to
             share what you're working on, <a href="https://github.com/bevyengine/bevy-assets">submit a pull request</a>!
@@ -62,4 +66,8 @@
         {% endfor %}
         {% endfor %}
     </div>
+
+    <script type="module">
+        import '/assets.js'
+    </script>
 {% endblock %}


### PR DESCRIPTION
WIP for Issue #450 

I created a search bar that can filter cards in JS. The problem is that the cards are in a `grid` and when setting `display:none` it will leave around empty spaces. The only way I see to do it properly would be to change the display of the cards to `flex-row` instead of `grid` (which I think makes more sense for this layout anyway), but that requires quite a bit of work making sure everything is responsive and that there are no regressions.

![image](https://github.com/bevyengine/bevy-website/assets/6576777/a5c91858-2b97-4e19-ba01-fb99e04072a1)

Result when searching for "MIT"

![image](https://github.com/bevyengine/bevy-website/assets/6576777/0538452a-ee52-4525-acce-22b1df481920)

Any thoughts on this?