### PR TITLE
Fix 404 page logo

### DIFF
--- a/templates/404.html
+++ b/templates/404.html
@@ -3,6 +3,6 @@
 <div class="fourohfour">
     <h1>404</h1>
     <p>Sorry, we couldn't find that page.</p>
-    <img src="assets/bevy_icon_dark.svg" alt="Bevy logo">
+    <img src="/assets/bevy_icon_dark.svg" alt="Bevy logo">
 </div>
 {% endblock content %}


### PR DESCRIPTION
`https://bevyengine.org/learn1/` not works.