### PR TITLE
Align the type of the first System's Query to that of the first Component

### DIFF
--- a/content/learn/book/getting-started/ecs/_index.md
+++ b/content/learn/book/getting-started/ecs/_index.md
@@ -27,9 +27,9 @@ Bevy ECS is Bevy's implementation of the ECS pattern. Unlike other Rust ECS impl
 * **Systems**: normal Rust functions
 
     ```rs
-    fn print_position_system(query: Query<&Transform>) {
-        for transform in &query {
-            println!("position: {:?}", transform.translation);
+    fn print_position_system(query: Query<&Position>) {
+        for position in &query {
+            println!("position: {} {}", position.x, position.y);
         }
     }
     ```


### PR DESCRIPTION

# What
Change the type of the query parameter from `Query<&Transform>` to `Query<&Position>`. 

# Why
The first Component that's introduced in the lines above is `Position`, not `Transform`. Seeing the difference in type got me a bit confused. Aligning the types in hopes that 

# Ref 
- Initially used `Position` in #2aa8193
- Changed to `Transform` in #73