### PR TITLE
Add Search on Examples page

### DIFF
--- a/templates/examples-webgpu.html
+++ b/templates/examples-webgpu.html
@@ -25,6 +25,9 @@
         WebGPU is currently only supported on Chrome starting with version 113, and only on desktop. If they don't work on your configuration, you can check the WebGL2 examples <a href="/examples">here</a>.
         
     </div>
+    <div class="assets-search">
+        <input class="assets-search__input" type="text" id="assets-search" placeholder="Search Example">
+    </div>
     {% for subsection in section.subsections %}
         {% set section = get_section(path=subsection) %}
 
@@ -48,4 +51,7 @@
 
     {% endfor %}
 </div>
+<script type="module">
+    import '/assets.js'
+</script>
 {% endblock content %}

--- a/templates/examples.html
+++ b/templates/examples.html
@@ -21,6 +21,9 @@
             If you would like to try WASM + WebGPU, you can explore our <a href="/examples-webgpu">live WebGPU examples</a> page. 
         </p>
     </div>
+    <div class="assets-search">
+        <input class="assets-search__input" type="text" id="assets-search" placeholder="Search Example">
+    </div>
     {% for subsection in section.subsections %}
         {% set section = get_section(path=subsection) %}
 
@@ -44,4 +47,7 @@
 
     {% endfor %}
 </div>
+<script type="module">
+    import '/assets.js'
+</script>
 {% endblock content %}


### PR DESCRIPTION
## Objective

Since #734 we have a search bar on the assets page, I think it will be good to add it to the example page as well.