### PR TITLE
Add Troubleshooting: Unable to debug dynamically linked Bevy application in VSCode

### DIFF
--- a/content/learn/book/troubleshooting/_index.md
+++ b/content/learn/book/troubleshooting/_index.md
@@ -43,7 +43,7 @@ For `cppvsdbg`:
 Or for `codelldb`:
 ```json
 "env": {
-    "PATH": "${env:RUSTUP_HOME}/toolchains/nightly-x86_64-pc-windows-msvc/bin;${workspaceFolder}/target/debug/deps;${env:PATH}",
+    "PATH": "${env:USERPROFILE}/.rustup/toolchains/nightly-x86_64-pc-windows-msvc/bin;${workspaceFolder}/target/debug/deps;${env:PATH}",
     // Switch `nightly` to `stable` if you're using Rust stable
-}
+},
 ```

--- a/content/learn/book/troubleshooting/_index.md
+++ b/content/learn/book/troubleshooting/_index.md
@@ -20,3 +20,30 @@ Causes include:
 
 1. Vulkan-compatible drivers not installed. To fix this, install/update the drivers. On Linux this may be `vulkan-intel` or `vulkan-radeon`.
 2. Trying to run an example on a headless machine. To fix this, install a GPU!
+
+## Unable to debug dynamically linked Bevy application in VSCode
+
+```txt
+The program '[10184] my-game.exe' has exited with code -1073741515 (0xc0000135).
+```
+
+Whilst `cargo run` may load the application successfully, running via the debugging UI in VSCode may yield the above error. This error means
+that the required libraries were not loaded correctly (likely due to a pathing quirk with VSCode debug extensions).
+
+Edit your launch configurations in `.vscode/launch.json` so that the rust libraries are found correctly.
+
+For `cppvsdbg`:
+```json
+"environment": [
+    {"name":"PATH", "value":"%USERPROFILE%/.rustup/toolchains/nightly-x86_64-pc-windows-msvc/bin;${workspaceFolder}/target/debug/deps;%PATH%"}
+    // Switch `nightly` to `stable` if you're using Rust stable
+],
+```
+
+Or for `codelldb`:
+```json
+"env": {
+    "PATH": "${env:RUSTUP_HOME}/toolchains/nightly-x86_64-pc-windows-msvc/bin;${workspaceFolder}/target/debug/deps;${env:PATH}",
+    // Switch `nightly` to `stable` if you're using Rust stable
+}
+```

--- a/content/learn/book/troubleshooting/_index.md
+++ b/content/learn/book/troubleshooting/_index.md
@@ -33,6 +33,7 @@ that the required libraries were not loaded correctly (likely due to a pathing q
 Edit your launch configurations in `.vscode/launch.json` so that the rust libraries are found correctly.
 
 For `cppvsdbg`:
+
 ```json
 "environment": [
     {"name":"PATH", "value":"%USERPROFILE%/.rustup/toolchains/nightly-x86_64-pc-windows-msvc/bin;${workspaceFolder}/target/debug/deps;%PATH%"}
@@ -41,6 +42,7 @@ For `cppvsdbg`:
 ```
 
 Or for `codelldb`:
+
 ```json
 "env": {
     "PATH": "${env:USERPROFILE}/.rustup/toolchains/nightly-x86_64-pc-windows-msvc/bin;${workspaceFolder}/target/debug/deps;${env:PATH}",

--- a/content/learn/book/troubleshooting/_index.md
+++ b/content/learn/book/troubleshooting/_index.md
@@ -21,14 +21,14 @@ Causes include:
 1. Vulkan-compatible drivers not installed. To fix this, install/update the drivers. On Linux this may be `vulkan-intel` or `vulkan-radeon`.
 2. Trying to run an example on a headless machine. To fix this, install a GPU!
 
-## Unable to debug dynamically linked Bevy application in VSCode
+## Unable to debug dynamically linked Bevy application in VSCode on Windows
 
 ```txt
 The program '[10184] my-game.exe' has exited with code -1073741515 (0xc0000135).
 ```
 
 Whilst `cargo run` may load the application successfully, running via the debugging UI in VSCode may yield the above error. This error means
-that the required libraries were not loaded correctly (likely due to a pathing quirk with VSCode debug extensions).
+that the required libraries were not loaded correctly (likely due to a pathing quirk with VSCode debug extensions on Windows).
 
 Edit your launch configurations in `.vscode/launch.json` so that the rust libraries are found correctly.
 


### PR DESCRIPTION
This change adds a troubleshooting section including a workaround for https://github.com/bevyengine/bevy/issues/2589

There may be a better solution to this issue and we might have to get in touch with the relevant VSCode extension maintainers but for now, this is a functional workaround.

It seems to be an issue with both cppvsdbg and codelldb.