### PR TITLE
Use `--depth 1` in getting started clone command

### DIFF
--- a/content/learn/book/getting-started/_index.md
+++ b/content/learn/book/getting-started/_index.md
@@ -20,7 +20,7 @@ Note: the "fast compiles" setup is on the next page, so you might want to read t
 1. Clone the [Bevy repo](https://github.com/bevyengine/bevy):
 
     ```sh
-    git clone https://github.com/bevyengine/bevy
+    git clone https://github.com/bevyengine/bevy --depth 1
     ```
 
 2. Navigate to the new "bevy" folder


### PR DESCRIPTION
Cloning the full repo with all its history can take up a long time/space to get started.

By cloning just one commit we reduce the "time to wow"