### PR TITLE
Changed bevy_core to bevy_time

### DIFF
--- a/content/learn/book/getting-started/resources/_index.md
+++ b/content/learn/book/getting-started/resources/_index.md
@@ -17,7 +17,7 @@ Here are some examples of data that could be encoded as **Resources**:
 
 ## Tracking Time with Resources
 
-Let's solve our App's "hello spam" problem by only printing "hello" once every two seconds. We'll do this by using the {{rust_type(type="struct" crate="bevy_core" name="Time")}} resource, which is automatically added to our App via `add_plugins(DefaultPlugins)`.
+Let's solve our App's "hello spam" problem by only printing "hello" once every two seconds. We'll do this by using the {{rust_type(type="struct" crate="bevy_time" name="Time")}} resource, which is automatically added to our App via `add_plugins(DefaultPlugins)`.
 
 For simplicity, remove the `hello_world` system from your App. This way we only need to adapt the `greet_people` system.
 


### PR DESCRIPTION
Fixes #753. [Comment](https://github.com/bevyengine/bevy/issues/10095#issuecomment-1759481728)

Following the above comment, changed crate from `bevy_core` to `bevy_time` as it has been replaced in the docs