### PR TITLE
Bevy 0.12 Blog Post - Feature "Added HSL methods to `Color` struct"

### DIFF
--- a/content/news/2023-10-21-bevy-0.12/index.md
+++ b/content/news/2023-10-21-bevy-0.12/index.md
@@ -29,13 +29,16 @@ You can now use `h()`, `s()`, `l()` together with their `set_h()`, `set_s()`, `s
 // Returns HSL component values
 let color = Color::ORANGE;
 let hue = color.h();
+// ...
 
 // Changes the HSL component values
 let mut color = Color::PINK;
 color.set_s(0.5);
+// ...
 
 // Modifies existing colors and returns them
 let color = Color::VIOLET.with_l(0.7);
+// ...
 ```
 
 ## <a name="what-s-next"></a>What's Next?

--- a/content/news/2023-10-21-bevy-0.12/index.md
+++ b/content/news/2023-10-21-bevy-0.12/index.md
@@ -23,7 +23,7 @@ Since our last release a few months ago we've added a _ton_ of new features, bug
 
 <div class="release-feature-authors">authors: @idedary</div>
 
-You can now use `h()`, `s()`, `l()` together with their `set_h()`, `set_s()`, `set_l()` and `with_h()`, `with_s()`, `with_l()` variants to manipulate *Hue*, *Saturation* and *Lightness* values of a `Color` struct without cloning. Previously you could do that only with RGBA values.
+You can now use `h()`, `s()`, `l()` together with their `set_h()`, `set_s()`, `set_l()` and `with_h()`, `with_s()`, `with_l()` variants to manipulate *Hue*, *Saturation* and *Lightness* values of a `Color` struct without cloning. Previously you could do that with only RGBA values.
 
 ```rust
 // Returns HSL component values

--- a/content/news/2023-10-21-bevy-0.12/index.md
+++ b/content/news/2023-10-21-bevy-0.12/index.md
@@ -19,6 +19,25 @@ Since our last release a few months ago we've added a _ton_ of new features, bug
 
 <div class="release-feature-authors">authors: @author</div>
 
+## Added HSL methods to `Color` struct
+
+<div class="release-feature-authors">authors: @idedary</div>
+
+You can now use `h()`, `s()`, `l()` together with their `set_h()`, `set_s()`, `set_l()` and `with_h()`, `with_s()`, `with_l()` variants to manipulate *Hue*, *Saturation* and *Lightness* values of a `Color` struct without cloning. Previously you could do that only with RGBA values.
+
+```rust
+// Returns HSL component values
+let color = Color::ORANGE;
+let hue = color.h();
+
+// Changes the HSL component values
+let mut color = Color::PINK;
+color.set_s(0.5);
+
+// Modifies existing colors and returns them
+let color = Color::VIOLET.with_l(0.7);
+```
+
 ## <a name="what-s-next"></a>What's Next?
 
 We have plenty of work that is pretty much finished and is therefore very likely to land in **Bevy 0.13**:

--- a/content/news/2023-10-21-bevy-0.12/index.md
+++ b/content/news/2023-10-21-bevy-0.12/index.md
@@ -23,7 +23,7 @@ Since our last release a few months ago we've added a _ton_ of new features, bug
 
 <div class="release-feature-authors">authors: @idedary</div>
 
-You can now use `h()`, `s()`, `l()` together with their `set_h()`, `set_s()`, `set_l()` and `with_h()`, `with_s()`, `with_l()` variants to manipulate *Hue*, *Saturation* and *Lightness* values of a `Color` struct without cloning. Previously you could do that with only RGBA values.
+You can now use `h()`, `s()`, `l()` together with their `set_h()`, `set_s()`, `set_l()` and `with_h()`, `with_s()`, `with_l()` variants to manipulate _Hue_, _Saturation_ and _Lightness_ values of a `Color` struct without cloning. Previously you could do that with only RGBA values.
 
 ```rust
 // Returns HSL component values


### PR DESCRIPTION
I added docs to the blog post for the PR `Added HSL methods to Color struct` that I did. It's nothing extraordinary, just QoL feature. I also just wanted to try out working with Git on a bigger project so I hope I did PR properly and as Cart said in the directions 😃 

# What I Added:

## Added HSL methods to `Color` struct

<div class="release-feature-authors">authors: @idedary</div>

You can now use `h()`, `s()`, `l()` together with their `set_h()`, `set_s()`, `set_l()` and `with_h()`, `with_s()`, `with_l()` variants to manipulate *Hue*, *Saturation* and *Lightness* values of a `Color` struct without cloning. Previously you could do that with only RGBA values.

```rust
// Returns HSL component values
let color = Color::ORANGE;
let hue = color.h();
// ...

// Changes the HSL component values
let mut color = Color::PINK;
color.set_s(0.5);
// ...

// Modifies existing colors and returns them
let color = Color::VIOLET.with_l(0.7);
// ...
```