### PR TITLE
Reverse migration guide ordering

### DIFF
--- a/content/learn/migration-guides/0.10-0.11/_index.md
+++ b/content/learn/migration-guides/0.10-0.11/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "0.10 to 0.11"
-weight = 2
+weight = 6
 sort_by = "weight"
 template = "docs-section.html"
 page_template = "docs-section.html"
@@ -1269,12 +1269,12 @@ impl Plugin for MyPlugin {
     fn build(&self, app: &mut App) {
         app.insert_resource::<MyResource>
             .add_systems(Update, my_system);
-    
+
         let render_app = match app.get_sub_app_mut(RenderApp) {
             Ok(render_app) => render_app,
             Err(_) => return,
         };
-    
+
         render_app
             .init_resource::<OtherRenderResource>();
     }
@@ -1284,7 +1284,7 @@ impl Plugin for MyPlugin {
             Ok(render_app) => render_app,
             Err(_) => return,
         };
-    
+
         render_app
             .init_resource::<RenderResourceNeedingDevice>();
     }

--- a/content/learn/migration-guides/0.4-0.5/_index.md
+++ b/content/learn/migration-guides/0.4-0.5/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "0.4 to 0.5"
-weight = 8
+weight = 0
 template = "docs-section.html"
 insert_anchor_links = "right"
 aliases = ["learn/book/migration-guides/0.4-0.5"]

--- a/content/learn/migration-guides/0.5-0.6/_index.md
+++ b/content/learn/migration-guides/0.5-0.6/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "0.5 to 0.6"
-weight = 7
+weight = 1
 template = "docs-section.html"
 insert_anchor_links = "right"
 aliases = ["learn/book/migration-guides/0.5-0.6"]

--- a/content/learn/migration-guides/0.6-0.7/_index.md
+++ b/content/learn/migration-guides/0.6-0.7/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "0.6 to 0.7"
-weight = 6
+weight = 2
 template = "docs-section.html"
 insert_anchor_links = "right"
 aliases = ["learn/book/migration-guides/0.6-0.7"]

--- a/content/learn/migration-guides/0.7-0.8/_index.md
+++ b/content/learn/migration-guides/0.7-0.8/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "0.7 to 0.8"
-weight = 5
+weight = 3
 template = "docs-section.html"
 insert_anchor_links = "right"
 aliases = ["learn/book/migration-guides/0.7-0.8"]

--- a/content/learn/migration-guides/0.9-0.10/_index.md
+++ b/content/learn/migration-guides/0.9-0.10/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "0.9 to 0.10"
-weight = 3
+weight = 5
 template = "docs-section.html"
 insert_anchor_links = "right"
 aliases = ["learn/book/migration-guides/0.9-0.10"]

--- a/content/learn/migration-guides/introduction/_index.md
+++ b/content/learn/migration-guides/introduction/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Introduction"
-weight = 1
+weight = 8
 template = "docs-section.html"
 insert_anchor_links = "right"
 aliases = ["learn/book/migration-guides/introduction"]

--- a/templates/macros/docs.html
+++ b/templates/macros/docs.html
@@ -43,8 +43,16 @@
 
 {% macro docs_menu(root, prefix) %}
     <ul class="tree-menu">
-        {% for s in root.subsections %}
-            {{ self::docs_menu_row(prefix=prefix, section_path=s) }}
-        {% endfor %}
+        {# Book #}
+        {% if section and section.path is starting_with("/learn/book/") %}
+            {% for s in root.subsections %}
+                {{ self::docs_menu_row(prefix=prefix, section_path=s) }}
+            {% endfor %}
+        {# Migration Guide #}
+        {% else %}
+            {% for s in root.subsections | reverse %}
+                {{ self::docs_menu_row(prefix=prefix, section_path=s) }}
+            {% endfor %}
+        {% endif %}
     </ul>
 {% endmacro %}

--- a/templates/macros/docs.html
+++ b/templates/macros/docs.html
@@ -43,14 +43,14 @@
 
 {% macro docs_menu(root, prefix) %}
     <ul class="tree-menu">
-        {# Book #}
-        {% if section and section.path is starting_with("/learn/book/") %}
-            {% for s in root.subsections %}
+        {# Migration Guides #}
+        {% if section and section.path is starting_with("/learn/migration-guides") %}
+            {% for s in root.subsections | reverse %}
                 {{ self::docs_menu_row(prefix=prefix, section_path=s) }}
             {% endfor %}
-        {# Migration Guide #}
+        {# Other #}
         {% else %}
-            {% for s in root.subsections | reverse %}
+            {% for s in root.subsections %}
                 {{ self::docs_menu_row(prefix=prefix, section_path=s) }}
             {% endfor %}
         {% endif %}


### PR DESCRIPTION
Use reverse ordering for the migration guide so that we don't need to update all the weights every release

This require a bit of a hack in the docs.html template to detect that we are on the migration guide page