### PR TITLE
Check all PRs for migration guides

### DIFF
--- a/generate-release/src/migration_guide.rs
+++ b/generate-release/src/migration_guide.rs
@@ -51,6 +51,8 @@ As a result, the Minimum Supported Rust Version (MSRV) is "the latest stable rel
             .iter()
             .any(|l| l.name.contains("C-Breaking-Change"));
 
+        // We want to check for PRs with the breaking label but without the guide section
+        // to make it easier to track down missing guides
         if has_migration_guide_section || has_breaking_label {
             let area = get_pr_area(pr);
             areas

--- a/generate-release/src/migration_guide.rs
+++ b/generate-release/src/migration_guide.rs
@@ -102,7 +102,8 @@ As a result, the Minimum Supported Rust Version (MSRV) is "the latest stable rel
     }
     writeln!(&mut output, "</div>")?;
 
-    println!("\nFound {} breaking PRs merged by bors", count);
+    println!("\nFound {} breaking PRs merged", count);
+
 
     std::fs::write(path, output)?;
 


### PR DESCRIPTION
Instead of looking for PRs with the `C-Breaking-Change` label, look for all PRs that have a Migration Guide section. Still check for PRs with the label to detect if there's any missing migration guide.