### PR TITLE
display Bevy logo if an image is missing

### DIFF
--- a/templates/macros/images.html
+++ b/templates/macros/images.html
@@ -2,7 +2,12 @@
     {%- if path is ending_with(".svg") or path is ending_with(".gif") or path is ending_with(".webp") -%}
         {{- get_url(path=path) -}}
     {%- else -%}
-        {%- set image = resize_image(path=path, width=width, height=height, op="fit") -%}
-        {{- image.url -}}
+        {% set metadata = get_image_metadata(path=path, allow_missing=true) %}
+        {% if metadata %}
+            {%- set image = resize_image(path=path, width=width, height=height, op="fit") -%}
+            {{- image.url -}}
+        {% else %}
+            assets/bevy_icon_dark.svg
+        {% endif %}
     {%- endif -%}
 {%- endmacro card %}


### PR DESCRIPTION
avoid failing on missing example screenshot: display Bevy logo as a placeholder