### PR TITLE
Add migration guide for the default clearcolor change

### DIFF
--- a/content/learn/migration-guides/0.11-0.12/_index.md
+++ b/content/learn/migration-guides/0.11-0.12/_index.md
@@ -1512,4 +1512,18 @@ fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
 
 `&mut EventReader` does not implement `IntoIterator` anymore. replace `for foo in &mut events` by `for foo in events.iter()`
 
+### [Update default `ClearColor`` to better match Bevy's branding](https://github.com/bevyengine/bevy/pull/10339)
+
+<div class="migration-guide-area-tags">
+    <div class="migration-guide-area-tag">Rendering</div>
+</div>
+
+The default app background color has changed. To use the old default, add a `ClearColor` resource.
+
+```rust
+App::new()
+    .insert_resource(ClearColor(Color::rgb(0.4, 0.4, 0.4)))
+    .add_plugins(DefaultPlugins)
+```
+
 </div>


### PR DESCRIPTION
This was missed by #798 because [bevy#10339](https://github.com/bevyengine/bevy/pull/10339#) did not have a migration guide section / breaking change label.