### PR TITLE
0.12 Migration: multi-threaded feature is not just for bevy_ecs and bevy_tasks users

### DIFF
--- a/content/learn/migration-guides/0.11-0.12/_index.md
+++ b/content/learn/migration-guides/0.11-0.12/_index.md
@@ -382,7 +382,9 @@ unsafe impl WorldQuery for MyQuery {
     <div class="migration-guide-area-tag">ECS</div>
 </div>
 
-The `multi-threaded` feature in `bevy_ecs` and `bevy_tasks` is no longer enabled by default. However, this remains a default feature for the umbrella `bevy` crate. If you depend on `bevy_ecs` or `bevy_tasks` directly, you should consider enabling this to allow systems to run in parallel.
+The `multi-threaded` feature in `bevy_ecs` and `bevy_tasks` is no longer enabled by default. However, this remains a default feature for the umbrella `bevy` crate.
+
+if you are using `bevy` without `default-features`, or if you depend on `bevy_ecs` or `bevy_tasks` directly, you most likely want to enable this to allow systems to run in parallel.
 
 ### [Refactor build_schedule and related errors](https://github.com/bevyengine/bevy/pull/9579)
 


### PR DESCRIPTION
It is not uncommon for apps to depend on bevy without `default-features`.

e.g.
- A 2d game that does not want to compile `bevy_pbr`, animation code, etc.
- Anyone who doesn't want the default font.
- Anyone who is doing a webgpu build and needs to disable `webgl2`.

If these apps don't add `multi-threaded`, they are going to have a bad time.

I added some text for that scenario and strengthened the suggestion a bit.

(There also seems to be a bug with `bevy_tasks` not actually working single-threaded? https://discord.com/channels/691052431525675048/1019697973933899910/threads/1172911162808074281) but I'm assuming that'll get fixed up.)