### PR TITLE
add version filter to assets

### DIFF
--- a/sass/pages/_assets.scss
+++ b/sass/pages/_assets.scss
@@ -35,4 +35,17 @@
             }
         }
     }
+
+    .asset-version-select {
+        border-radius: $border-radius;
+        border: 2px solid #383838;
+        background-color: $syntax-theme-background;
+        font-size: 1.0rem;
+        padding: .4rem;
+        
+        &:hover {
+            background-color: $card-hover-background;
+            border: 2px solid #6b6b6b;
+        }
+    }
 }

--- a/sass/pages/_assets.scss
+++ b/sass/pages/_assets.scss
@@ -3,6 +3,10 @@
         margin-bottom: 20px;
     }
 
+    .assets-filters {
+        margin-bottom: 20px;
+    }
+
     .asset-section {
         font-size: 2.4rem;
         margin: 0 0 20px;

--- a/static/assets.js
+++ b/static/assets.js
@@ -69,7 +69,10 @@ document
 
         for (const asset of document.querySelectorAll('.asset-card')) {
             let tag = asset.querySelector('.asset-card__tags .asset-card__bevy-versions .asset-card__tag');
-            if (tag) {
+            if (item.target.value === 'all_versions') {
+                asset.parentElement.style.display = 'block'
+            }
+            else if (tag) {
                 const searchMatch = item.target.value === normalize_version(tag.innerText);
                 asset.parentElement.style.display = searchMatch ? 'block' : 'none'
             } else {

--- a/static/assets.js
+++ b/static/assets.js
@@ -71,14 +71,16 @@ if (versionsSelect) {
 document
     .querySelector('#assets-filter')
     .addEventListener("change", (item) => {
-
+        let selected_value = item.target.value;
         for (const asset of document.querySelectorAll('.asset-card')) {
             let tag = asset.querySelector('.asset-card__tags .asset-card__bevy-versions .asset-card__tag');
-            if (item.target.value === 'all_versions') {
+            if (selected_value === 'all_versions') {
                 asset.parentElement.style.display = 'block'
             }
             else if (tag) {
-                const searchMatch = item.target.value === normalize_version(tag.innerText);
+                let raw_item_value = tag.innerText;
+                let normalized_version = normalize_version(raw_item_value);
+                const searchMatch = ['*', 'master'].includes(raw_item_value) || selected_value == normalized_version;
                 asset.parentElement.style.display = searchMatch ? 'block' : 'none'
             } else {
                 asset.parentElement.style.display = 'none'

--- a/static/assets.js
+++ b/static/assets.js
@@ -37,3 +37,43 @@ function hideEmptySections() {
         section.style.display = 'none'
     })
 }
+
+//  ------------    Version Filtering
+function normalize_version(raw_version) {
+    let version = raw_version
+        .replace(/^[^\d]+/, '')
+        .replace(/[^\d]+$/, '');
+    return version ? Array.from({ ...version.split('.'), length: 3 }, (v, i) => v ?? 0).join('.') : null;
+}
+
+let versionsQuery = document.querySelectorAll('.asset-card .asset-card__tags .asset-card__bevy-versions .asset-card__tag');
+let versions = [...new Set([...versionsQuery]
+    .map(item => normalize_version(item.innerText))
+    .filter(i => i)
+)];
+
+
+let versionsSelect = document.querySelector('#assets-filter');
+if (versionsSelect) {
+    versions.map(i => {
+        var opt = document.createElement('option');
+        opt.value = i;
+        opt.innerHTML = i;
+        versionsSelect.appendChild(opt);
+    })
+}
+
+document
+    .querySelector('#assets-filter')
+    .addEventListener("change", (item) => {
+
+        for (const asset of document.querySelectorAll('.asset-card')) {
+            let tag = asset.querySelector('.asset-card__tags .asset-card__bevy-versions .asset-card__tag');
+            if (tag) {
+                const searchMatch = item.target.value === normalize_version(tag.innerText);
+                asset.parentElement.style.display = searchMatch ? 'block' : 'none'
+            } else {
+                asset.parentElement.style.display = 'none'
+            }
+        }
+    })

--- a/static/assets.js
+++ b/static/assets.js
@@ -50,6 +50,11 @@ let versionsQuery = document.querySelectorAll('.asset-card .asset-card__tags .as
 let versions = [...new Set([...versionsQuery]
     .map(item => normalize_version(item.innerText))
     .filter(i => i)
+    .sort((a, b) => {
+        let a1 = a.split('.').map(i => i.padStart(3, '0')).join('');
+        let b1 = b.split('.').map(i => i.padStart(3, '0')).join('');;
+        return b1 - a1;
+    })
 )];
 
 

--- a/templates/assets.html
+++ b/templates/assets.html
@@ -4,70 +4,78 @@
 {% block page_name %}Bevy Assets{% endblock %}
 
 {% block mobile_page_menu %}
-    {{assets_macros::assets_menu(prefix="mobile-menu", root=section)}}
+{{assets_macros::assets_menu(prefix="mobile-menu", root=section)}}
 {% endblock %}
 
 {% block page_menu %}
-    {{assets_macros::assets_menu(prefix="page-menu", root=section)}}
+{{assets_macros::assets_menu(prefix="page-menu", root=section)}}
 {% endblock %}
 
 {% block page_content %}
-    <div class="assets">
-        {{ assets_macros::init_svg() }}
+<div class="assets">
+    {{ assets_macros::init_svg() }}
 
-        <div class="assets-search">
-            <input class="assets-search__input" type="text" id="assets-search" placeholder="Search (ie: 0.11 MIT)">
-        </div>
+    <div class="assets-search">
+        <input class="assets-search__input" type="text" id="assets-search" placeholder="Search (ie: 0.11 MIT)">
+    </div>
 
-        <div class="assets-intro media-content">
-            A collection of third-party Bevy assets, plugins, learning resources, and apps made by the community. If you would like to
-            share what you're working on, <a href="https://github.com/bevyengine/bevy-assets">submit a pull request</a>!
-        </div>
+    <div class="assets-filters">
+        <label>Bevy last supported version</label>
+        <select id="assets-filter">
+            <option value="all_versions">All</option>
+        </select>
+    </div>
 
-        {% for subsection in section.subsections %}
-        {% set section = get_section(path=subsection) %}
+    <div class="assets-intro media-content">
+        A collection of third-party Bevy assets, plugins, learning resources, and apps made by the community. If you
+        would like to
+        share what you're working on, <a href="https://github.com/bevyengine/bevy-assets">submit a pull request</a>!
+    </div>
 
-        <h1 class="asset-section" id="{{ section.title | slugify }}">
-            {{ section.title }}<a class="anchor-link" href="#{{ section.title | slugify }}">#</a>
-        </h1>
+    {% for subsection in section.subsections %}
+    {% set section = get_section(path=subsection) %}
 
-        {% if section.pages %}
-        <div class="item-grid item-grid--multi-cols">
-            {% set pages = section.pages %}
-            {% if section.extra.sort_order_reversed %}
-            {% set pages = section.pages | reverse %}
-            {% endif %}
-            {% for post in pages %}
-            {{ assets_macros::card(post=post) }}
-            {% endfor %}
-        </div>
-        {% endif %}
+    <h1 class="asset-section" id="{{ section.title | slugify }}">
+        {{ section.title }}<a class="anchor-link" href="#{{ section.title | slugify }}">#</a>
+    </h1>
 
-        {% set subsections = section.subsections %}
+    {% if section.pages %}
+    <div class="item-grid item-grid--multi-cols">
+        {% set pages = section.pages %}
         {% if section.extra.sort_order_reversed %}
-        {% set subsections = section.subsections | reverse %}
+        {% set pages = section.pages | reverse %}
         {% endif %}
-        {% for subsection in subsections %}
-        {% set section = get_section(path=subsection) %}
-
-        <h3 class="asset-subsection" id="{{ section.title | slugify }}">
-            {{ section.title }}<a class="anchor-link" href="#{{ section.title | slugify }}">#</a>
-        </h3>
-        <div class="item-grid item-grid--multi-cols">
-            {% set pages = section.pages %}
-            {% if section.extra.sort_order_reversed %}
-            {% set pages = section.pages | reverse %}
-            {% endif %}
-            {% for post in pages %}
-            {{ assets_macros::card(post=post) }}
-            {% endfor %}
-        </div>
-
+        {% for post in pages %}
+        {{ assets_macros::card(post=post) }}
         {% endfor %}
+    </div>
+    {% endif %}
+
+    {% set subsections = section.subsections %}
+    {% if section.extra.sort_order_reversed %}
+    {% set subsections = section.subsections | reverse %}
+    {% endif %}
+    {% for subsection in subsections %}
+    {% set section = get_section(path=subsection) %}
+
+    <h3 class="asset-subsection" id="{{ section.title | slugify }}">
+        {{ section.title }}<a class="anchor-link" href="#{{ section.title | slugify }}">#</a>
+    </h3>
+    <div class="item-grid item-grid--multi-cols">
+        {% set pages = section.pages %}
+        {% if section.extra.sort_order_reversed %}
+        {% set pages = section.pages | reverse %}
+        {% endif %}
+        {% for post in pages %}
+        {{ assets_macros::card(post=post) }}
         {% endfor %}
     </div>
 
-    <script type="module">
-        import '/assets.js'
-    </script>
+    {% endfor %}
+    {% endfor %}
+</div>
+
+<script type="module">
+    import '/assets.js'
+</script>
 {% endblock %}

--- a/templates/assets.html
+++ b/templates/assets.html
@@ -21,7 +21,7 @@
 
     <div class="assets-filters">
         <label>Bevy last supported version</label>
-        <select id="assets-filter">
+        <select class="asset-version-select" id="assets-filter">
             <option value="all_versions">All</option>
         </select>
     </div>


### PR DESCRIPTION
This PR extends work that was done in [734](https://github.com/bevyengine/bevy-website/pull/734) and adds filter to select the latest supported version 

it does some version normalization:
- ignores any non digits
- pads version with 0

```
^0.9 -> 0.9.0
0.12 -> 0.12.0
0.12.* -> 0.12.0
~0.8 -> 0.8.0
>=0.9 -> 0.9.0
```


also, there are some cases of versions that I don't know how to treat: 'git', '*', 'main'. But all of them are shown when a filter is reset to `all`

P.S. seems like my IDE added some formatting to older code. Hope this will not be an issue )

![asd1asdasdzsdasd](https://github.com/bevyengine/bevy-website/assets/30506/e465a5d6-2c6e-4d9d-8b0a-c5b2f963a6a3)


https://github.com/bevyengine/bevy-website/assets/30506/b9ab467d-35d1-44af-9cbc-264e39a8c3db

for some reason vide does not capture select box, but it is there. Believe me!
