### PR TITLE
ignore http errors when loading assets

### DIFF
--- a/static/tools.js
+++ b/static/tools.js
@@ -24,6 +24,11 @@ async function progressiveFetch(resource, callbacks={}) {
     const lengthBytes = response.headers.get('content-length');
     let loadedBytes = 0;
 
+    // don't hang on error
+    if (response.status !== 200) {
+        cb.finish({ filename, lengthBytes: 0 });
+    }
+
     function update() {
         const loaded = Math.min(1.0, loadedBytes / lengthBytes);
         const loadedPercent = loaded * 100.0;


### PR DESCRIPTION
Fixes #841

Examples keep a "loading" bar with meta files as they are never loaded

<img width="1800" alt="Screenshot 2023-12-18 at 20 27 20" src="https://github.com/bevyengine/bevy-website/assets/8672791/6b92404a-6638-4a8a-83b2-7df9a5020bfb">

Consider every http request with a status different than 200 as finished loading