### PR TITLE
Add learn/errors link card to the learn page

### DIFF
--- a/content/learn/links.toml
+++ b/content/learn/links.toml
@@ -41,6 +41,13 @@ image_alt = "Bevy logo"
 description = "Browse bevy examples compiled to wasm and running directly in your browser!"
 
 [[links]]
+title = "Bevy Errors"
+url = "/learn/errors"
+image = "/assets/bevy_icon_dark.svg"
+image_alt = "Bevy Logo"
+description = "List of Bevy's error codes for the current release."
+
+[[links]]
 title = "Frequently Asked Questions"
 url = "/faq"
 image = "/assets/bevy_icon_dark.svg"

--- a/content/learn/links.toml
+++ b/content/learn/links.toml
@@ -44,7 +44,7 @@ description = "Browse bevy examples compiled to wasm and running directly in you
 title = "Bevy Errors"
 url = "/learn/errors"
 image = "/assets/bevy_icon_dark.svg"
-image_alt = "Bevy Logo"
+image_alt = "Bevy logo"
 description = "List of Bevy's error codes for the current release."
 
 [[links]]


### PR DESCRIPTION
This PR makes the page that lists Bevy's errors for current release viewable from the learn page.

Closes #766 