### PR TITLE
Change println! to info! in getting started tut

### DIFF
--- a/content/learn/book/getting-started/ecs/_index.md
+++ b/content/learn/book/getting-started/ecs/_index.md
@@ -29,7 +29,7 @@ Bevy ECS is Bevy's implementation of the ECS pattern. Unlike other Rust ECS impl
     ```rs
     fn print_position_system(query: Query<&Position>) {
         for position in &query {
-            println!("position: {} {}", position.x, position.y);
+            info!("position: {} {}", position.x, position.y);
         }
     }
     ```
@@ -40,6 +40,8 @@ Bevy ECS is Bevy's implementation of the ECS pattern. Unlike other Rust ECS impl
     struct Entity(u64);
     ```
 
+**Note**: You may have noticed that in the above examples, and throughout this tutorial, we use `info!()` from Bevy rather than `println!()` to output text to the console. Why? `info!()` when used in a debug scenario reduces blocking behavior and runs faster compared to `println!()`.
+
 Now let's see how this works in practice!
 
 ## Your First System
@@ -48,7 +50,7 @@ Paste the following function into your `main.rs` file:
 
 ```rs
 fn hello_world() {
-    println!("hello world!");
+    info!("hello world!");
 }
 ```
 
@@ -112,7 +114,7 @@ We could run this now and the `add_people` system would run first, followed by `
 ```rs
 fn greet_people(query: Query<&Name, With<Person>>) {
     for name in &query {
-        println!("hello {}!", name.0);
+        info!("hello {}!", name.0);
     }
 }
 ```

--- a/content/learn/book/getting-started/ecs/_index.md
+++ b/content/learn/book/getting-started/ecs/_index.md
@@ -40,7 +40,7 @@ Bevy ECS is Bevy's implementation of the ECS pattern. Unlike other Rust ECS impl
     struct Entity(u64);
     ```
 
-**Note**: You may have noticed that in the above examples, and throughout this tutorial, we use `info!()` from Bevy rather than `println!()` to output text to the console. Why? `info!()` when used in a debug scenario reduces blocking behavior and runs faster compared to `println!()`.
+**Note**: You may have noticed that in the above examples, and throughout this tutorial, we use {{rust_type(type="macro", crate="bevy_log",name="info", no_mod=true)}} from Bevy rather than {{rust_type(type="macro", crate="std", name="println", no_mod=true)}} to output text to the console. Why? Well, `info` when used in a debug scenario reduces blocking behavior and runs faster compared to `println`.
 
 Now let's see how this works in practice!
 

--- a/content/learn/book/getting-started/resources/_index.md
+++ b/content/learn/book/getting-started/resources/_index.md
@@ -26,7 +26,7 @@ Resources are accessed in much the same way that we access components. You can a
 ```rs
 fn greet_people(time: Res<Time>, query: Query<&Name, With<Person>>) {
     for name in &query {
-        println!("hello {}!", name.0);
+        info!("hello {}!", name.0);
     }
 }
 ```
@@ -45,7 +45,7 @@ fn greet_people(
     // if that caused the timer to finish, we say hello to everyone
     if timer.0.tick(time.delta()).just_finished() {
         for name in &query {
-            println!("hello {}!", name.0);
+            info!("hello {}!", name.0);
         }
     }
 }


### PR DESCRIPTION
This PR changes the use of `println!` to `info!` in the getting started tutorial to reflect to beginners the best practices when debugging actual Bevy games.

Closes #108 