### PR TITLE
Add bevy dev docs link to learn page

### DIFF
--- a/content/learn/links.toml
+++ b/content/learn/links.toml
@@ -24,7 +24,7 @@ title = "Bevy Pre-Release (git) API Docs"
 url = "https://dev-docs.bevyengine.org/"
 image = "/assets/icon-docs-dev.svg"
 image_alt = "Bevy docs in development logo"
-description ="Documentation for developers of the Bevy engine and any other bleeding-edge users."
+description ="Documentation for developers of the Bevy engine and other bleeding-edge users."
 
 [[links]]
 title = "Official Examples"

--- a/content/learn/links.toml
+++ b/content/learn/links.toml
@@ -23,7 +23,7 @@ description = "Learn how to use Bevy's types, traits and methods using the in-de
 title = "Bevy Pre-Release (git) API Docs"
 url = "https://dev-docs.bevyengine.org/"
 image = "/assets/icon-docs-dev.svg"
-image_alt = "Rust logo"
+image_alt = "Bevy docs in development logo"
 description ="Documentation for developers of the Bevy engine and any other bleeding-edge users."
 
 [[links]]

--- a/content/learn/links.toml
+++ b/content/learn/links.toml
@@ -20,6 +20,13 @@ image_alt = "Rust logo"
 description = "Learn how to use Bevy's types, traits and methods using the in-depth reference documentation, complete with inline examples."
 
 [[links]]
+title = "Bevy Pre-Release (git) API Docs"
+url = "https://dev-docs.bevyengine.org/"
+image = "/assets/icon-docs-dev.svg"
+image_alt = "Rust logo"
+description ="Documentation for developers of the Bevy engine and any other bleeding-edge users."
+
+[[links]]
 title = "Official Examples"
 url = "https://github.com/bevyengine/bevy/tree/latest/examples#examples"
 image = "/assets/github.svg"


### PR DESCRIPTION
Adds a link to the bevy developer docs so that they're discoverable for anyone unaware.

Closes #775 