### PR TITLE
Update landing page audio feature description

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -141,7 +141,7 @@
                     Load audio files and play them on demand
                     <ul class="feature-sublist">
                         <li>Load audio files as Assets</li>
-                        <li>Play audio Assets using Audio bundles</li>
+                        <li>Play audio Assets using Audio entities</li>
                     </ul>
                 </div>
             </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -141,7 +141,7 @@
                     Load audio files and play them on demand
                     <ul class="feature-sublist">
                         <li>Load audio files as Assets</li>
-                        <li>Play audio Assets using the Audio resource</li>
+                        <li>Play audio Assets using Audio bundles</li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
Updates the landing page's audio feature description to use Audio-as-Entities since the audio feature changed in `0.11`.

Closes #744 