### PR TITLE
Make incorrect code examples accessible

### DIFF
--- a/sass/components/_syntax-theme.scss
+++ b/sass/components/_syntax-theme.scss
@@ -6,13 +6,22 @@
 div.incorrect {
     position: relative;
     background-color: #542326;
-    border-left: 10px solid red;
+    border-left: 10px solid darkred;
     border-radius: 10px;
-    padding-right: 75px;
+    padding-right: 55px;
 
     .z-code,
     .z-code code {
         background-color: #542326;
+    }
+}
+
+div.incorrect:hover {
+    border-color: red;
+
+    img {
+      /* SVG filter color for red */
+      filter: invert(10%) sepia(85%) saturate(7491%) hue-rotate(5deg) brightness(116%) contrast(114%);
     }
 }
 
@@ -23,8 +32,10 @@ div.incorrect-image {
     top: 10px;
 
     img {
-        width: 50px;
-        height: 50px;
+        width: 35px;
+        height: 35px;
+        /* SVG filter color for firebrick red */
+        filter: invert(11%) sepia(57%) saturate(5143%) hue-rotate(350deg) brightness(118%) contrast(87%);
     }
 }
 

--- a/sass/components/_syntax-theme.scss
+++ b/sass/components/_syntax-theme.scss
@@ -4,13 +4,27 @@
 }
 
 div.incorrect {
+    position: relative;
     background-color: #542326;
     border-left: 10px solid red;
     border-radius: 10px;
+    padding-right: 75px;
 
     .z-code,
     .z-code code {
         background-color: #542326;
+    }
+}
+
+div.incorrect-image {
+    position: absolute;
+    z-index: 99;
+    right: 20px;
+    top: 10px;
+
+    img {
+        width: 50px;
+        height: 50px;
     }
 }
 

--- a/static/assets/error_icon.svg
+++ b/static/assets/error_icon.svg
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="23.283333mm"
+   height="23.283335mm"
+   viewBox="0 0 23.283333 23.283335"
+   version="1.1"
+   id="svg1"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm" />
+  <defs
+     id="defs1" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-74.820894,-82.101698)">
+    <rect
+       style="fill:#ffffff;fill-opacity:0;stroke:#fe0000;stroke-width:2.11667;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect3"
+       width="0.25757128"
+       height="18.821035"
+       x="127.39073"
+       y="-3.6036105"
+       transform="rotate(44.697598)" />
+    <rect
+       style="fill:#ffffff;fill-opacity:0;stroke:#fe0000;stroke-width:2.11667;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect4"
+       width="19.004786"
+       height="0.0013227463"
+       x="117.90938"
+       y="5.8055844"
+       transform="rotate(44.697598)" />
+    <circle
+       style="fill:#ffffff;fill-opacity:0;stroke:#fe0000;stroke-width:2.11667;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       id="path1"
+       cx="86.462563"
+       cy="93.743362"
+       r="10.583333" />
+  </g>
+</svg>

--- a/static/assets/error_icon.svg
+++ b/static/assets/error_icon.svg
@@ -7,6 +7,8 @@
    viewBox="0 0 23.283333 23.283335"
    version="1.1"
    id="svg1"
+   inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
+   sodipodi:docname="warning.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
@@ -20,7 +22,16 @@
      inkscape:pageopacity="0"
      inkscape:pagecheckerboard="0"
      inkscape:deskcolor="#d1d1d1"
-     inkscape:document-units="mm" />
+     inkscape:document-units="mm"
+     inkscape:zoom="4.0409091"
+     inkscape:cx="322.8234"
+     inkscape:cy="359.94376"
+     inkscape:window-width="1499"
+     inkscape:window-height="773"
+     inkscape:window-x="2306"
+     inkscape:window-y="163"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
   <defs
      id="defs1" />
   <g
@@ -29,7 +40,7 @@
      id="layer1"
      transform="translate(-74.820894,-82.101698)">
     <rect
-       style="fill:#ffffff;fill-opacity:0;stroke:#fe0000;stroke-width:2.11667;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       style="fill:#000000;fill-opacity:0;stroke:#000000;stroke-width:2.11667;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
        id="rect3"
        width="0.25757128"
        height="18.821035"
@@ -37,18 +48,24 @@
        y="-3.6036105"
        transform="rotate(44.697598)" />
     <rect
-       style="fill:#ffffff;fill-opacity:0;stroke:#fe0000;stroke-width:2.11667;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       style="fill:#000000;fill-opacity:0;stroke:#000000;stroke-width:2.11667;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
        id="rect4"
        width="19.004786"
        height="0.0013227463"
        x="117.90938"
        y="5.8055844"
-       transform="rotate(44.697598)" />
+       transform="rotate(44.697598)"
+       inkscape:export-filename="../Dev/bevy-website/static/assets/error_icon.svg"
+       inkscape:export-xdpi="96"
+       inkscape:export-ydpi="96" />
     <circle
-       style="fill:#ffffff;fill-opacity:0;stroke:#fe0000;stroke-width:2.11667;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       style="fill:#000000;fill-opacity:0;stroke:#000000;stroke-width:2.11667;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
        id="path1"
        cx="86.462563"
        cy="93.743362"
-       r="10.583333" />
+       r="10.583333"
+       inkscape:export-filename="wrong.svg"
+       inkscape:export-xdpi="96"
+       inkscape:export-ydpi="96" />
   </g>
 </svg>

--- a/templates/shortcodes/incorrect_code_block.html
+++ b/templates/shortcodes/incorrect_code_block.html
@@ -1,3 +1,6 @@
 <div class="incorrect">
-    {{ body | markdown | safe }}
+  <div class="incorrect-image">
+    <img src="/assets/error_icon.svg" alt="This code is incorrect" title="This code is incorrect" />
+  </div>
+  {{ body | markdown | safe }}
 </div>

--- a/templates/shortcodes/incorrect_code_block.html
+++ b/templates/shortcodes/incorrect_code_block.html
@@ -1,6 +1,6 @@
 <div class="incorrect">
   <div class="incorrect-image">
-    <img src="/assets/error_icon.svg" alt="This code is incorrect" title="This code is incorrect" />
+    <img src="/assets/error_icon.svg" alt="This code is invalid" title="This code is invalid" />
   </div>
   {{ body | markdown | safe }}
 </div>


### PR DESCRIPTION
Adds a warning icon with alternative and title text that is in the DOM before the example meaning it _should_ be read before the example by screen readers, probably.

Example of change:
![image](https://github.com/bevyengine/bevy-website/assets/31419708/582a3f35-8bda-4e0c-9e20-f176cb7bdd56)


Closes #418 