### PR TITLE
Change current book to quick start guide

### DIFF
--- a/content/learn/links.toml
+++ b/content/learn/links.toml
@@ -6,6 +6,13 @@ image_alt = "Bevy book"
 description = "Learn how to use Bevy using this step-by-step guide. If you are new to Bevy, you should probably start here."
 
 [[links]]
+title = "The Quick Start Guide"
+url = "/learn/book/quick-start"
+image = "/assets/book.svg"
+image_alt = "Bevy book"
+description = "Learn the basics of how to use Bevy by following a quick tutorial. If you like learning by examples, you should probably start here."
+
+[[links]]
 title = "Migration Guides"
 url = "/learn/migration-guides/introduction"
 image = "/assets/migration-guides.svg"

--- a/content/learn/quick-start/_index.md
+++ b/content/learn/quick-start/_index.md
@@ -2,4 +2,6 @@
 title = "Quick Start"
 template = "docs-section.html"
 weight = 1
+redirect_to = "/learn/quick-start/introduction"
+aliases = ["/learn/book/quick-start"]
 +++

--- a/content/learn/quick-start/contributing/_index.md
+++ b/content/learn/quick-start/contributing/_index.md
@@ -11,7 +11,7 @@ subtitle = "join the bevy"
 
 Bevy is built by volunteers. If you want to help us build the next great game engine, [please reach out](/community)! We need all the help we can get:
 
-* If you are a software developer and you want to help out, check out the [Contributing Code](/learn/book/contributing/code) section.
-* If you are good at teaching or writing, consider [contributing to our docs](/learn/book/contributing/docs).
+* If you are a software developer and you want to help out, check out the [Contributing Code](code) section.
+* If you are good at teaching or writing, consider [contributing to our docs](docs).
 
 We want Bevy to be a vibrant developer community ... that's actually why we chose the name! A Bevy is a group of birds, just like we are a group of game developers. Join the Bevy!

--- a/content/learn/quick-start/getting-started/plugins/_index.md
+++ b/content/learn/quick-start/getting-started/plugins/_index.md
@@ -9,7 +9,7 @@ insert_anchor_links = "right"
 
 One of Bevy's core principles is modularity. All Bevy engine features are implemented as plugins. This includes internal features like the renderer, but games themselves are also implemented as plugins! This empowers developers to pick and choose which features they want. Don't need a UI? Don't register the [`UiPlugin`]. Want to build a headless server? Don't register the [`RenderPlugin`].
 
-This also means you are free to replace any components you don't like. If you feel the need, you are welcome to build your own [`UiPlugin`], but consider [contributing it back to Bevy](/learn/book/contributing) if you think it would be useful!
+This also means you are free to replace any components you don't like. If you feel the need, you are welcome to build your own [`UiPlugin`], but consider [contributing it back to Bevy](/learn/quick-start/contributing) if you think it would be useful!
 
 However, most developers don't need a custom experience and just want the "full engine" experience with no hassle. For this, Bevy provides a set of "default plugins".  
 

--- a/content/learn/quick-start/getting-started/setup/_index.md
+++ b/content/learn/quick-start/getting-started/setup/_index.md
@@ -47,7 +47,7 @@ You can use any code editor you want, but we highly recommend one that has a [ru
 
 ### Rust Learning Resources
 
-The goal of this book is to learn Bevy, so it won't serve as a full Rust education. If you would like to learn more about the Rust language, check out the following resources:
+The goal of this guide is to get started learning Bevy quickly, so it won't serve as a full Rust education. If you would like to learn more about the Rust language, check out the following resources:
 
 * [**The Rust Book**](https://doc.rust-lang.org/book/): the best place to learn Rust from scratch
 * [**Rust by Example**](https://doc.rust-lang.org/rust-by-example/): learn Rust by working through live coding examples
@@ -202,7 +202,7 @@ Bevy can be built just fine using default configuration on stable Rust. However 
 
 To enable fast compiles, install the nightly rust compiler and LLD. Then copy the contents of [this file](https://github.com/bevyengine/bevy/blob/main/.cargo/config_fast_builds) to `YOUR_WORKSPACE/.cargo/config.toml`. For the project in this guide, that would be `my_bevy_game/.cargo/config.toml`.
 
-If something went wrong, check out our [troubleshooting section](/learn/book/troubleshooting/) or [ask for help on our Discord](https://discord.com/invite/gMUk5Ph).
+If something went wrong, check out our [troubleshooting section](/learn/quick-start/troubleshooting/) or [ask for help on our Discord](https://discord.com/invite/gMUk5Ph).
 
 ### Build Bevy
 

--- a/content/learn/quick-start/introduction/_index.md
+++ b/content/learn/quick-start/introduction/_index.md
@@ -38,6 +38,6 @@ Bevy is still in the early stages of development. Important features are missing
 
 If you are currently trying to pick an engine for your Next Big Project™, we recommend that you check out [Godot Engine](https://godotengine.org). It is currently much more feature-complete and stable. And it is also free, open-source, and [scriptable with Rust](https://github.com/godot-rust/gdext)!
 
-This official book is still very incomplete. It will help you get started with the setup and learning the basics, but it does not yet cover most of Bevy's features. See the [Next Steps](/learn/book/next-steps/) page for links to other, more exhaustive, learning resources you can use.
+The Quick Start Guide is not a comprehensive guide to Bevy and the next section [Getting Started](/learn/quick-start/getting-started/) will help you with the setup of Bevy and learning the basics, but it does not cover most of Bevy's features. In the future you can use the Bevy Book to gain a better understanding, until then see the last page [Next Steps](/learn/quick-start/next-steps) for more exhaustive and complex resources on Bevy.
 
 Phew! If you haven't been scared away yet, let's move on to learning some Bevy!

--- a/content/learn/quick-start/introduction/_index.md
+++ b/content/learn/quick-start/introduction/_index.md
@@ -26,7 +26,7 @@ Bevy has the following design goals:
 * **Fast**: App logic should run quickly, and when possible, in parallel
 * **Productive**: Changes should compile quickly ... waiting isn't fun
 
-Bevy is [built in the open by volunteers](/learn/book/contributing) using the [Rust programming language](https://www.rust-lang.org/). The code is free and open-source because we believe developers should fully own their tools. Games are a huge part of our culture and humanity is investing _millions_ of hours into the development of games. Why are we continuing to build up the ecosystems of closed-source monopolies that take cuts of our sales and deny us visibility into the tech we use daily? We believe that the developer community can do so much better.
+Bevy is [built in the open by volunteers](/learn/quick-start/contributing) using the [Rust programming language](https://www.rust-lang.org/). The code is free and open-source because we believe developers should fully own their tools. Games are a huge part of our culture and humanity is investing _millions_ of hours into the development of games. Why are we continuing to build up the ecosystems of closed-source monopolies that take cuts of our sales and deny us visibility into the tech we use daily? We believe that the developer community can do so much better.
 
 For a more in-depth introduction, check out the [Introducing Bevy](/news/introducing-bevy/) blog post.
 

--- a/content/learn/quick-start/next-steps/_index.md
+++ b/content/learn/quick-start/next-steps/_index.md
@@ -1,5 +1,5 @@
 +++
-title = "Next steps"
+title = "Next Steps"
 weight = 12
 sort_by = "weight"
 template = "docs-section.html"
@@ -7,7 +7,7 @@ page_template = "docs-section.html"
 insert_anchor_links = "right"
 +++
 
-You have reached the end of The Bevy Book! If you're hungry for more learning materials, we recommend checking out:
+You have reached the end of The Quick Start Guide! If you're hungry for more learning materials, we recommend checking out:
 
 * **[The Bevy Examples](https://github.com/bevyengine/bevy/tree/latest/examples#examples)**: We create an example for every major Bevy feature. This is currently the best way to learn Bevy's features and how to use them.
   * **[The Bevy Web Examples](https://bevyengine.org/examples)**: We also try to make most of these examples available directly in your browser.

--- a/content/learn/quick-start/plugin-development/_index.md
+++ b/content/learn/quick-start/plugin-development/_index.md
@@ -100,16 +100,16 @@ You can specify the dependency [both as a version and with git](https://doc.rust
 
 You can use one of these badges to communicate to your users how closely you intend to track Bevy's main branch.
 
-[![Following released Bevy versions](https://img.shields.io/badge/Bevy%20tracking-released%20version-lightblue)](https://bevyengine.org/learn/book/plugin-development/#main-branch-tracking)
+[![Following released Bevy versions](https://img.shields.io/badge/Bevy%20tracking-released%20version-lightblue)](https://bevyengine.org/learn/quick-start/plugin-development/#main-branch-tracking)
 
 ```markdown
-[![Following released Bevy versions](https://img.shields.io/badge/Bevy%20tracking-released%20version-lightblue)](https://bevyengine.org/learn/book/plugin-development/#main-branch-tracking)
+[![Following released Bevy versions](https://img.shields.io/badge/Bevy%20tracking-released%20version-lightblue)](https://bevyengine.org/learn/quick-start/plugin-development/#main-branch-tracking)
 ```
 
-[![Following Bevy's main branch](https://img.shields.io/badge/Bevy%20tracking-main-lightblue)](https://bevyengine.org/learn/book/plugin-development/#main-branch-tracking)
+[![Following Bevy's main branch](https://img.shields.io/badge/Bevy%20tracking-main-lightblue)](https://bevyengine.org/learn/quick-start/plugin-development/#main-branch-tracking)
 
 ```markdown
-[![Following Bevy's main branch](https://img.shields.io/badge/Bevy%20tracking-main-lightblue)](https://bevyengine.org/learn/book/plugin-development/#main-branch-tracking)
+[![Following Bevy's main branch](https://img.shields.io/badge/Bevy%20tracking-main-lightblue)](https://bevyengine.org/learn/quick-start/plugin-development/#main-branch-tracking)
 ```
 
 ## Documentation and Examples

--- a/content/news/2020-08-10-introducing-bevy/index.md
+++ b/content/news/2020-08-10-introducing-bevy/index.md
@@ -50,7 +50,7 @@ It also has many features most people expect from a modern, general purpose engi
 
 That being said, Bevy is still in the very early stages. I consider it to be in the "prototyping" phase: features are missing, APIs will change, and documentation is sparse. <span class="warning">I don't yet recommend using Bevy in serious projects unless you are willing to deal with gaps and instability</span>.
 
-Hopefully at this point you are either (1) jazzed about Bevy or (2) not reading anymore. If you want to dive in right now, [The Bevy Book](https://bevyengine.org/learn/book/introduction/) is the best place to get started. You can also keep reading to find out what the current state of Bevy is and where we'd like to take it.
+Hopefully at this point you are either (1) jazzed about Bevy or (2) not reading anymore. If you want to dive in right now, [The Quick Start Guide](/learn/book/quick-start/) is the best place to get started. You can also keep reading to find out what the current state of Bevy is and where we'd like to take it.
 
 **Quick note to the reader**: in this article you will find text formatted like this: [`Texture`]
 
@@ -1191,10 +1191,10 @@ Bevy's APIs are still quite unstable, so documentation is spotty. [The Bevy Book
 
 ## Join the Bevy!
 
-If any of this sounds interesting to you, I encourage you to check out [Bevy on GitHub](https://github.com/bevyengine/bevy), read [The Bevy Book](https://bevyengine.org/learn/book/introduction/), and [join the Bevy community](https://bevyengine.org/community/). Currently Bevy is 100% built by volunteers, so if you want to help us build the next great game engine, [please reach out](https://discord.com/invite/gMUk5Ph)! We need all the help we can get, especially if you are a:
+If any of this sounds interesting to you, I encourage you to check out [Bevy on GitHub](https://github.com/bevyengine/bevy), read [The Quick Start Guide](/learn/book/quick-start), and [join the Bevy community](https://bevyengine.org/community/). Currently Bevy is 100% built by volunteers, so if you want to help us build the next great game engine, [please reach out](https://discord.com/invite/gMUk5Ph)! We need all the help we can get, especially if you are a:
 
-* <b class="fun-list">Software Developer</b>: check out the [Contributing Code](/learn/book/contributing/code) section of The Bevy Book.
-* <b class="fun-list">Technical Writer</b>: check out the [Contributing Docs](/learn/book/contributing/docs) section of The Bevy Book.
+* <b class="fun-list">Software Developer</b>: check out the [Contributing Code](/learn/quick-start/contributing/code) section of The Bevy Book.
+* <b class="fun-list">Technical Writer</b>: check out the [Contributing Docs](/learn/quick-start/contributing/docs) section of The Bevy Book.
 
 I want Bevy to become a vibrant developer community ... thats actually why I chose the name! A Bevy is a group of birds, just like we are a group of game developers. Join the Bevy!
 

--- a/content/news/2020-09-19-bevy-0.2/index.md
+++ b/content/news/2020-09-19-bevy-0.2/index.md
@@ -14,7 +14,7 @@ image_subtitle_link = "https://github.com/TheNeikos/bevy_squares"
 
 A month after the initial Bevy release, and thanks to **87** contributors, **174** pull requests, and our [**generous sponsors**](https://github.com/sponsors/cart), I'm happy to announce the **Bevy 0.2** release on [crates.io](https://crates.io/crates/bevy)!
 
-For those who don't know, Bevy is a refreshingly simple data-driven game engine built in Rust. You can check out [Quick Start Guide](/learn/book/getting-started/) to get started. Bevy is also free and open source forever! You can grab the full [source code](https://github.com/bevyengine/bevy) on GitHub.
+For those who don't know, Bevy is a refreshingly simple data-driven game engine built in Rust. You can check out [The Quick Start Guide](/learn/book/quick-start/) to get started. Bevy is also free and open source forever! You can grab the full [source code](https://github.com/bevyengine/bevy) on GitHub.
 
 Here are some of the highlights from this release:
 

--- a/content/news/2020-11-03-bevy-0.3/index.md
+++ b/content/news/2020-11-03-bevy-0.3/index.md
@@ -14,7 +14,7 @@ image_subtitle_link = "https://twitter.com/schneckerstein/status/130949112155541
 
 A little over a month after releasing Bevy 0.2, and thanks to **59** contributors, **122** pull requests, and our [**generous sponsors**](https://github.com/sponsors/cart), I'm happy to announce the **Bevy 0.3** release on [crates.io](https://crates.io/crates/bevy)!
 
-For those who don't know, Bevy is a refreshingly simple data-driven game engine built in Rust. You can check out [Quick Start Guide](/learn/book/getting-started/) to get started. Bevy is also free and open source forever! You can grab the full [source code](https://github.com/bevyengine/bevy) on GitHub.
+For those who don't know, Bevy is a refreshingly simple data-driven game engine built in Rust. You can check out [The Quick Start Guide](/learn/book/quick-start) to get started. Bevy is also free and open source forever! You can grab the full [source code](https://github.com/bevyengine/bevy) on GitHub.
 
 Here are some of the highlights from this release:
 

--- a/content/news/2020-12-19-bevy-0.4/index.md
+++ b/content/news/2020-12-19-bevy-0.4/index.md
@@ -14,7 +14,7 @@ image_subtitle_link = "https://github.com/indiv0/colonize/"
 
 A little over a month after releasing Bevy 0.3, and thanks to **66** contributors, **178** pull requests, and our [**generous sponsors**](https://github.com/sponsors/cart), I'm happy to announce the **Bevy 0.4** release on [crates.io](https://crates.io/crates/bevy)!
 
-For those who don't know, Bevy is a refreshingly simple data-driven game engine built in Rust. You can check out [Quick Start Guide](/learn/book/getting-started/) to get started. Bevy is also free and open source forever! You can grab the full [source code](https://github.com/bevyengine/bevy) on GitHub.
+For those who don't know, Bevy is a refreshingly simple data-driven game engine built in Rust. You can check out [The Quick Start Guide](/learn/book/quick-start) to get started. Bevy is also free and open source forever! You can grab the full [source code](https://github.com/bevyengine/bevy) on GitHub.
 
 Here are some of the highlights from this release:
 
@@ -457,7 +457,7 @@ By spawning beneath a parent, this enables you to do things like translate/rotat
 
 @bjorn3 discovered that you can force Bevy to dynamically link.
 
-This _significantly_ reduces iterative compile times. Check out how long it takes to compile a change made to the `3d_scene.rs` example with the [Fast Compiles Config](https://bevyengine.org/learn/book/getting-started/setup/) _and_ dynamic linking:
+This _significantly_ reduces iterative compile times. Check out how long it takes to compile a change made to the `3d_scene.rs` example with the [Fast Compiles Config](https://bevyengine.org/learn/quick-start/getting-started/setup/) _and_ dynamic linking:
 
 ![fast dynamic](dynamic_fast.png)
 

--- a/content/news/2021-04-06-bevy-0.5/index.md
+++ b/content/news/2021-04-06-bevy-0.5/index.md
@@ -14,7 +14,7 @@ image_subtitle_link = ""
 
 Thanks to **88** contributors, **283** pull requests, and our [**generous sponsors**](https://github.com/sponsors/cart), I'm happy to announce the **Bevy 0.5** release on [crates.io](https://crates.io/crates/bevy)!
 
-For those who don't know, Bevy is a refreshingly simple data-driven game engine built in Rust. You can check out [Quick Start Guide](/learn/book/getting-started/) to get started. Bevy is also free and open source forever! You can grab the full [source code](https://github.com/bevyengine/bevy) on GitHub. Check out [Awesome Bevy](https://github.com/bevyengine/awesome-bevy) for a list of community-developed plugins, games, and learning resources.
+For those who don't know, Bevy is a refreshingly simple data-driven game engine built in Rust. You can check out [The Quick Start Guide](/learn/book/quick-start) to get started. Bevy is also free and open source forever! You can grab the full [source code](https://github.com/bevyengine/bevy) on GitHub. Check out [Awesome Bevy](https://github.com/bevyengine/awesome-bevy) for a list of community-developed plugins, games, and learning resources.
 
 **Bevy 0.5** is quite a bit bigger than our past few releases (and took a bit longer) as we have made a number of foundational changes. If you plan on updating your App or Plugin to **Bevy 0.5**, check out our [0.4 to 0.5 Migration Guide](/learn/migration-guides/0.4-0.5/).
 

--- a/content/news/2021-08-10-bevys-first-birthday/index.md
+++ b/content/news/2021-08-10-bevys-first-birthday/index.md
@@ -14,7 +14,7 @@ show_image = true
 
 Today is Bevy's first birthday! And what a year it has been! Now seems like as good a time as any to look back on how far we've come, reflect a bit, and start thinking about what the next year of Bevy development will look like.
 
-For those who don't know, Bevy is a refreshingly simple data-driven game engine built in Rust. Bevy is also free and open source forever! You can grab the full [source code](https://github.com/bevyengine/bevy) on GitHub. We have a [Quick Start Guide](/learn/book/getting-started/) and a [Bevy Book](https://bevyengine.org/learn/book/introduction/). You can also check out [Bevy Assets](https://bevyengine.org/assets/) for a library of community-developed plugins, crates, games, and learning resources.
+For those who don't know, Bevy is a refreshingly simple data-driven game engine built in Rust. Bevy is also free and open source forever! You can grab the full [source code](https://github.com/bevyengine/bevy) on GitHub. We have a [Quick Start Guide](/learn/book/quick-start). You can also check out [Bevy Assets](https://bevyengine.org/assets/) for a library of community-developed plugins, crates, games, and learning resources.
 
 <!-- more -->
 

--- a/content/news/2022-01-08-bevy-0.6/index.md
+++ b/content/news/2022-01-08-bevy-0.6/index.md
@@ -14,7 +14,7 @@ image_subtitle_link = ""
 
 Thanks to **170** contributors, **623** pull requests, and our [**generous sponsors**](https://github.com/sponsors/cart), I'm happy to announce the **Bevy 0.6** release on [crates.io](https://crates.io/crates/bevy)!
 
-For those who don't know, Bevy is a refreshingly simple data-driven game engine built in Rust. You can check out [Quick Start Guide](/learn/book/getting-started/) to get started. Bevy is also free and open source forever! You can grab the full [source code](https://github.com/bevyengine/bevy) on GitHub. Check out [Bevy Assets](https://bevyengine.org/assets) for a collection of community-developed plugins, games, and learning resources.
+For those who don't know, Bevy is a refreshingly simple data-driven game engine built in Rust. You can check out [The Quick Start Guide](/learn/book/quick-start) to get started. Bevy is also free and open source forever! You can grab the full [source code](https://github.com/bevyengine/bevy) on GitHub. Check out [Bevy Assets](https://bevyengine.org/assets) for a collection of community-developed plugins, games, and learning resources.
 
 To update an existing Bevy App or Plugin to **Bevy 0.6**, check out our [0.5 to 0.6 Migration Guide](/learn/migration-guides/0.5-0.6/).
 
@@ -1057,7 +1057,7 @@ Nested scenes, property overrides, inline assets, and nicer syntax are all on th
 
 ### The New Bevy Book
 
-The [current Bevy Book](/learn/book/) is a great way to learn how to set up Bevy and dip your toes into writing Bevy Apps. But it barely scratches the surface of what Bevy can do.
+The current Bevy Book is a great way to learn how to set up Bevy and dip your toes into writing Bevy Apps. But it barely scratches the surface of what Bevy can do.
 
 To solve this problem @alice-i-cecile has [started working](https://github.com/bevyengine/bevy-website/pull/182) on a new Bevy Book, with the goal of being a complete learning resource for Bevy. If you are interested in helping out, please reach out to them!
 

--- a/content/news/2022-04-15-bevy-0.7/index.md
+++ b/content/news/2022-04-15-bevy-0.7/index.md
@@ -14,7 +14,7 @@ image_subtitle_link = "https://sketchfab.com/3d-models/stylized-mushrooms-9d22e0
 
 Thanks to **123** contributors, **349** pull requests, and our [**generous sponsors**](https://github.com/sponsors/cart), I'm happy to announce the **Bevy 0.7** release on [crates.io](https://crates.io/crates/bevy)!
 
-For those who don't know, Bevy is a refreshingly simple data-driven game engine built in Rust. You can check out [Quick Start Guide](/learn/book/getting-started/) to get started. Bevy is also free and open source forever! You can grab the full [source code](https://github.com/bevyengine/bevy) on GitHub. Check out [Bevy Assets](https://bevyengine.org/assets) for a collection of community-developed plugins, games, and learning resources.
+For those who don't know, Bevy is a refreshingly simple data-driven game engine built in Rust. You can check out [The Quick Start Guide](/learn/book/quick-start) to get started. Bevy is also free and open source forever! You can grab the full [source code](https://github.com/bevyengine/bevy) on GitHub. Check out [Bevy Assets](https://bevyengine.org/assets) for a collection of community-developed plugins, games, and learning resources.
 
 To update an existing Bevy App or Plugin to **Bevy 0.7**, check out our [0.6 to 0.7 Migration Guide](/learn/migration-guides/0.6-0.7/).
 
@@ -721,7 +721,7 @@ We now automatically deploy Bevy's `main` development branch to [https://dev-doc
 
 <div class="release-feature-authors">authors: @doup</div>
 
-The [Bevy Book](/learn/book) now has a much nicer pager widget that displays previous / next section names:
+The Bevy Book now has a much nicer pager widget that displays previous / next section names:
 
 ![pager](pager.png)
 

--- a/content/news/2022-07-30-bevy-0.8/index.md
+++ b/content/news/2022-07-30-bevy-0.8/index.md
@@ -14,7 +14,7 @@ image_subtitle_link = "https://codeberg.org/rmemr/w3.terrain-texturing"
 
 Thanks to **130** contributors, **461** pull requests, community reviewers, and our [**generous sponsors**](https://github.com/sponsors/cart), I'm happy to announce the **Bevy 0.8** release on [crates.io](https://crates.io/crates/bevy)!
 
-For those who don't know, Bevy is a refreshingly simple data-driven game engine built in Rust. You can check out our [Quick Start Guide](/learn/book/getting-started/) to try it today. It's free and open source forever! You can grab the full [source code](https://github.com/bevyengine/bevy) on GitHub. Check out [Bevy Assets](https://bevyengine.org/assets) for a collection of community-developed plugins, games, and learning resources.
+For those who don't know, Bevy is a refreshingly simple data-driven game engine built in Rust. You can check out our [Quick Start Guide](/learn/book/quick-start) to try it today. It's free and open source forever! You can grab the full [source code](https://github.com/bevyengine/bevy) on GitHub. Check out [Bevy Assets](https://bevyengine.org/assets) for a collection of community-developed plugins, games, and learning resources.
 
 To update an existing Bevy App or Plugin to **Bevy 0.8**, check out our [0.7 to 0.8 Migration Guide](/learn/migration-guides/0.7-0.8/).
 

--- a/content/news/2022-08-10-bevys-second-birthday/index.md
+++ b/content/news/2022-08-10-bevys-second-birthday/index.md
@@ -14,7 +14,7 @@ show_image = true
 
 It has now been two years since the initial Bevy release! As is (now) tradition, I will take this as a chance to reflect on the past year and outline our plans for the future. If you're curious, check out [last year's birthday post](/news/bevys-first-birthday).
 
-For those who don't know, Bevy is a refreshingly simple data-driven game engine built in Rust. Bevy is also free and open source forever! You can grab the full [source code](https://github.com/bevyengine/bevy) on GitHub. We have a [Quick Start Guide](/learn/book/getting-started/) and a [Bevy Book](/learn/book/introduction/). You can also check out [Bevy Assets](/assets/) for a library of community-developed plugins, crates, games, and learning resources.
+For those who don't know, Bevy is a refreshingly simple data-driven game engine built in Rust. Bevy is also free and open source forever! You can grab the full [source code](https://github.com/bevyengine/bevy) on GitHub. We have a [Quick Start Guide](/learn/book/quick-start). You can also check out [Bevy Assets](/assets/) for a library of community-developed plugins, crates, games, and learning resources.
 
 <!-- more -->
 

--- a/content/news/2022-11-12-bevy-0.9/index.md
+++ b/content/news/2022-11-12-bevy-0.9/index.md
@@ -12,7 +12,7 @@ show_image = true
 
 Thanks to **159** contributors, **430** pull requests, community reviewers, and our [**generous sponsors**](https://github.com/sponsors/cart), I'm happy to announce the **Bevy 0.9** release on [crates.io](https://crates.io/crates/bevy)!
 
-For those who don't know, Bevy is a refreshingly simple data-driven game engine built in Rust. You can check out our [Quick Start Guide](/learn/book/getting-started/) to try it today. It's free and open source forever! You can grab the full [source code](https://github.com/bevyengine/bevy) on GitHub. Check out [Bevy Assets](https://bevyengine.org/assets) for a collection of community-developed plugins, games, and learning resources.
+For those who don't know, Bevy is a refreshingly simple data-driven game engine built in Rust. You can check out our [Quick Start Guide](/learn/book/quick-start) to try it today. It's free and open source forever! You can grab the full [source code](https://github.com/bevyengine/bevy) on GitHub. Check out [Bevy Assets](https://bevyengine.org/assets) for a collection of community-developed plugins, games, and learning resources.
 
 To update an existing Bevy App or Plugin to **Bevy 0.9**, check out our [0.8 to 0.9 Migration Guide](/learn/migration-guides/0.8-0.9/).
 

--- a/content/news/2023-03-06-bevy-0.10/index.md
+++ b/content/news/2023-03-06-bevy-0.10/index.md
@@ -11,7 +11,7 @@ image_subtitle_link = "https://github.com/coreh/bevy-demo-ruins"
 
 Thanks to **173** contributors, **689** pull requests, community reviewers, and our [**generous sponsors**](/community/donate), we're happy to announce the **Bevy 0.10** release on [crates.io](https://crates.io/crates/bevy)!
 
-For those who don't know, Bevy is a refreshingly simple data-driven game engine built in Rust. You can check out our [Quick Start Guide](/learn/book/getting-started/) to try it today. It's free and open source forever! You can grab the full [source code](https://github.com/bevyengine/bevy) on GitHub. Check out [Bevy Assets](https://bevyengine.org/assets) for a collection of community-developed plugins, games, and learning resources.
+For those who don't know, Bevy is a refreshingly simple data-driven game engine built in Rust. You can check out our [Quick Start Guide](/learn/book/quick-start) to try it today. It's free and open source forever! You can grab the full [source code](https://github.com/bevyengine/bevy) on GitHub. Check out [Bevy Assets](https://bevyengine.org/assets) for a collection of community-developed plugins, games, and learning resources.
 
 To update an existing Bevy App or Plugin to **Bevy 0.10**, check out our [0.9 to 0.10 Migration Guide](/learn/migration-guides/0.9-0.10/).
 

--- a/content/news/2023-05-17-bevy-webgpu/index.md
+++ b/content/news/2023-05-17-bevy-webgpu/index.md
@@ -24,7 +24,7 @@ WebGPU has started making waves because [Chrome just shipped WebGPU support in C
 
 For those who don't know, Bevy is a refreshingly simple cross-platform data-driven game engine built in Rust. It has a modern and extensible 2D and 3D renderer, a best-in-class ECS (entity component system) that is delightful to use, [plenty of features](/), and a vibrant and open [developer community](/community). It currently supports Windows, MacOS, Linux, iOS, and Web. We also have work in progress Android support ... and ambitions for even more platforms in the future!
 
-You can check out our [Quick Start Guide](/learn/book/getting-started/) to try it today. It is free and open source forever! You can grab the full [source code](https://github.com/bevyengine/bevy) on GitHub. Check out [Bevy Assets](https://bevyengine.org/assets) for a collection of community-developed plugins, games, and learning resources.
+You can check out our [Quick Start Guide](/learn/book/quick-start) to try it today. It is free and open source forever! You can grab the full [source code](https://github.com/bevyengine/bevy) on GitHub. Check out [Bevy Assets](https://bevyengine.org/assets) for a collection of community-developed plugins, games, and learning resources.
 
 <!-- more -->
 

--- a/content/news/2023-07-09-bevy-0.11/index.md
+++ b/content/news/2023-07-09-bevy-0.11/index.md
@@ -9,7 +9,7 @@ show_image = true
 
 Thanks to **166** contributors, **522** pull requests, community reviewers, and our [**generous sponsors**](/community/donate), we're happy to announce the **Bevy 0.11** release on [crates.io](https://crates.io/crates/bevy)!
 
-For those who don't know, Bevy is a refreshingly simple data-driven game engine built in Rust. You can check out our [Quick Start Guide](/learn/book/getting-started/) to try it today. It's free and open source forever! You can grab the full [source code](https://github.com/bevyengine/bevy) on GitHub. Check out [Bevy Assets](https://bevyengine.org/assets) for a collection of community-developed plugins, games, and learning resources.
+For those who don't know, Bevy is a refreshingly simple data-driven game engine built in Rust. You can check out our [Quick Start Guide](/learn/book/quick-start/) to try it today. It's free and open source forever! You can grab the full [source code](https://github.com/bevyengine/bevy) on GitHub. Check out [Bevy Assets](https://bevyengine.org/assets) for a collection of community-developed plugins, games, and learning resources.
 
 To update an existing Bevy App or Plugin to **Bevy 0.11**, check out our [0.10 to 0.11 Migration Guide](/learn/migration-guides/0.10-0.11/).
 

--- a/content/news/2023-08-10-bevys-third-birthday/index.md
+++ b/content/news/2023-08-10-bevys-third-birthday/index.md
@@ -16,7 +16,7 @@ As is tradition, I will take this as a chance to reflect on the past year and ou
 
 This year, I am also highly encouraging everyone to write their own "Bevy Birthday" reflection posts. Just publish your post somewhere (and to social media if you want) and [link to it here](https://github.com/bevyengine/bevy-website/issues/728). One month from now, we will do a followup "Reflecting on Bevy's Third Year" rollup post that aggregates these in one place. This is our chance as a community to celebrate our wins, identify improvement areas, and calibrate our path for the next year.
 
-For those who don't know, Bevy is a refreshingly simple data-driven game engine built in Rust. Bevy is also free and open source forever! You can grab the full [source code](https://github.com/bevyengine/bevy) on GitHub. We have a [Quick Start Guide](/learn/book/getting-started/) and a [Bevy Book](/learn/book/introduction/). You can also check out [Bevy Assets](/assets/) for a library of community-developed plugins, crates, games, and learning resources.
+For those who don't know, Bevy is a refreshingly simple data-driven game engine built in Rust. Bevy is also free and open source forever! You can grab the full [source code](https://github.com/bevyengine/bevy) on GitHub. We have a [Quick Start Guide](/learn/book/quick-start). You can also check out [Bevy Assets](/assets/) for a library of community-developed plugins, crates, games, and learning resources.
 
 <!-- more -->
 

--- a/content/news/2023-09-21-community-reflection-on-bevys-third-year/index.md
+++ b/content/news/2023-09-21-community-reflection-on-bevys-third-year/index.md
@@ -16,7 +16,7 @@ This year for the first time I also encouraged the Bevy community to write their
 
 ## What is Bevy?
 
-For those who don't know, Bevy is a refreshingly simple data-driven game engine built in Rust. Bevy is also free and open source forever! You can grab the full [source code](https://github.com/bevyengine/bevy) on GitHub. We have a [Quick Start Guide](/learn/book/getting-started/) and a [Bevy Book](/learn/book/introduction/). You can also check out [Bevy Assets](/assets/) for a library of community-developed plugins, crates, games, and learning resources.
+For those who don't know, Bevy is a refreshingly simple data-driven game engine built in Rust. Bevy is also free and open source forever! You can grab the full [source code](https://github.com/bevyengine/bevy) on GitHub. We have a [Quick Start Guide](/learn/book/quick-start). You can also check out [Bevy Assets](/assets/) for a library of community-developed plugins, crates, games, and learning resources.
 
 ## Reflections
 

--- a/content/news/2023-11-04-bevy-0.12/index.md
+++ b/content/news/2023-11-04-bevy-0.12/index.md
@@ -12,7 +12,7 @@ image_subtitle_link = "https://twitter.com/i_am_feenster"
 
 Thanks to **185** contributors, **567** pull requests, community reviewers, and our [**generous sponsors**](/community/donate), we're happy to announce the **Bevy 0.12** release on [crates.io](https://crates.io/crates/bevy)!
 
-For those who don't know, Bevy is a refreshingly simple data-driven game engine built in Rust. You can check out our [Quick Start Guide](/learn/book/getting-started/) to try it today. It's free and open source forever! You can grab the full [source code](https://github.com/bevyengine/bevy) on GitHub. Check out [Bevy Assets](https://bevyengine.org/assets) for a collection of community-developed plugins, games, and learning resources.
+For those who don't know, Bevy is a refreshingly simple data-driven game engine built in Rust. You can check out our [Quick Start Guide](/learn/book/quick-start) to try it today. It's free and open source forever! You can grab the full [source code](https://github.com/bevyengine/bevy) on GitHub. Check out [Bevy Assets](https://bevyengine.org/assets) for a collection of community-developed plugins, games, and learning resources.
 
 To update an existing Bevy App or Plugin to **Bevy 0.12**, check out our [0.11 to 0.12 Migration Guide](/learn/migration-guides/0.11-0.12/).
 

--- a/templates/layouts/base.html
+++ b/templates/layouts/base.html
@@ -74,6 +74,8 @@
             {{page.extra.header_message}}
             {% elif section and section.path is starting_with("/learn/book/") %}
             The Book
+            {% elif section and section.path is starting_with("/learn/quick-start/") %}
+            Quick Start
             {% elif section and section.path is starting_with("/learn/migration-guides/") %}
             Migration Guides
             {% elif section and section.path is starting_with("/news/") %}


### PR DESCRIPTION
Changes references inside the quick start guide from book to quick start guide, fixes links inside of the quick start guide that used to go to the book. It also clarifies and fixes the last section in next steps.

Closes #875 
Fixes #261 