### PR TITLE
Fix build of the news section

### DIFF
--- a/templates/news.html
+++ b/templates/news.html
@@ -21,7 +21,7 @@
                     Written {{ page.date | date(format="%B %d, %Y") }} by {{ page.extra.author }}
                 </div>
                 <p class="link-card__description link-card__description--ellipsis">
-                    {{ page.summary | striptags | truncate(length=350) | safe}}
+                    {{ page.content | striptags | truncate(length=350) | safe}}
                 </p>
             </div>
         </a>


### PR DESCRIPTION
When writing my section of the 0.13 news post, I found that zola refused to generate the news section. After digging, it seems that this change fixes it.

I notice build fails on #895  and #891, it might fix it.