### PR TITLE
Fix table borders

### DIFF
--- a/sass/elements/_table.scss
+++ b/sass/elements/_table.scss
@@ -13,6 +13,6 @@ tr td {
     border-top: 2px solid $subtitle-color;
 }
 
-tr td:last-child {
+tr td:not(:first-child) {
     border-left: 2px solid $subtitle-color;
 }


### PR DESCRIPTION
I added table styling in #904, but I suddenly realized that I only added the inside borders for the last column 🙈

Tables larger than the two-column one I was using look like this:

![Broken](https://github.com/bevyengine/bevy-website/assets/57632562/2276ebe4-c618-4ce7-9d09-28d62a001b0b)

This is now fixed:

![Fixed](https://github.com/bevyengine/bevy-website/assets/57632562/919a1d20-b4ed-4c19-bfc5-1772ea4e6edf)
