### PR TITLE
Bump Github Actions versions

### DIFF
--- a/.github/workflows/build-wasm-examples.yml
+++ b/.github/workflows/build-wasm-examples.yml
@@ -52,7 +52,7 @@ jobs:
           cargo run -p example-showcase -- --per-page ${{ env.PER_PAGE }} --page ${{ matrix.page }} build-wasm-examples --content-folder wasm-examples --api ${{ matrix.api }} --website-hacks --optimize-size
 
       - name: Upload Generated Files
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.api }}-examples-${{ matrix.page }}
           path: wasm-examples
@@ -67,7 +67,7 @@ jobs:
       steps:
         
         - name: Download all artifacts
-          uses: actions/download-artifact@v3
+          uses: actions/download-artifact@v4
 
         - name: Group examples in one folder
           run: |

--- a/.github/workflows/build-wasm-examples.yml
+++ b/.github/workflows/build-wasm-examples.yml
@@ -18,14 +18,14 @@ jobs:
     steps:
 
       - name: Checkout Bevy latest tag
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
         with:
           repository: 'bevyengine/bevy'
           ref: 'latest'
 
       # temporary: fetch tools from main branch
       - name: Checkout Bevy Tools
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
         with:
           repository: 'bevyengine/bevy'
           ref: 'main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} &&
           ./generate_assets.sh
 
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v4
         with:
           name: generated-assets
           path: content/assets
@@ -68,7 +68,7 @@ jobs:
           cd generate-errors &&
           ./generate_errors.sh
 
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v4
         with:
           name: generated-errors
           path: content/learn/errors
@@ -105,13 +105,13 @@ jobs:
           cd generate-wasm-examples &&
           ./generate_wasm_examples.sh
 
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v4
         with:
           name: generated-wasm-examples
           path: content/examples
           retention-days: 1
 
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v4
         with:
           name: generated-wasm-examples-webgpu
           path: content/examples-webgpu
@@ -138,7 +138,7 @@ jobs:
           cd generate-community &&
           ./generate_community.sh
 
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v4
         with:
           name: generated-community
           path: content/community/people
@@ -163,7 +163,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v4
         with:
           name: generated-errors
           path: content/learn/errors
@@ -175,27 +175,27 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v4
         with:
           name: generated-assets
           path: content/assets
 
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v4
         with:
           name: generated-errors
           path: content/learn/errors
 
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v4
         with:
           name: generated-wasm-examples
           path: content/examples
 
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v4
         with:
           name: generated-wasm-examples-webgpu
           path: content/examples-webgpu
 
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v4
         with:
           name: generated-community
           path: content/community/people

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     needs: [markdownlint, test-code]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
 
       - uses: actions/cache@v3
         with:
@@ -51,7 +51,7 @@ jobs:
     needs: [markdownlint, test-code]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
 
       - uses: actions/cache@v3
         with:
@@ -78,7 +78,7 @@ jobs:
     needs: [markdownlint, test-code]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
 
       - name: "Clone Bevy"
         run: >
@@ -121,7 +121,7 @@ jobs:
     needs: [markdownlint, test-code]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
 
       - uses: actions/cache@v3
         with:
@@ -147,7 +147,7 @@ jobs:
   markdownlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
@@ -161,7 +161,7 @@ jobs:
   test-code:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
 
       - uses: actions/upload-artifact@master
         with:
@@ -174,7 +174,7 @@ jobs:
     needs: [markdownlint, generate-assets, generate-errors, generate-wasm-examples, generate-community]
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - uses: actions/download-artifact@master
         with:
           name: generated-assets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -30,7 +30,7 @@ jobs:
         run: echo "::set-output name=key::$(date +'%Y-%m-%d')"
 
       - name: Get crates.io datadump from cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: generate-assets/data
           key: ${{ runner.os }}-${{ steps.cache-key.outputs.key }}
@@ -53,7 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -85,7 +85,7 @@ jobs:
           cd generate-wasm-examples &&
           ./clone_bevy.sh
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -123,7 +123,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
 
       - name: Cache multiple crates.io datadump
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: generate-assets/data
           key: ${{ runner.os }}-${{ steps.date.outputs.date }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
 
       - name: Get current date
         id: date

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -56,7 +56,7 @@ jobs:
           xvfb-run cargo run -p example-showcase -- --page ${{ matrix.page }} --per-page ${{ env.PER_PAGE }} run --screenshot --in-ci
 
       - name: Upload Generated Files
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: screenshots-${{ matrix.page }}
           path: screenshots
@@ -74,7 +74,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: Move examples to the correct folder
         run: |

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -17,14 +17,14 @@ jobs:
     steps:
 
       - name: Checkout Bevy latest tag
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
         with:
           repository: 'bevyengine/bevy'
           ref: 'latest'
 
       # temporary: fetch tools from main branch
       - name: Checkout Bevy Tools
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
         with:
           repository: 'bevyengine/bevy'
           ref: 'main'
@@ -71,7 +71,7 @@ jobs:
     steps:
       
       - name: Clone bevy-website repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
 
       - name: Download all artifacts
         uses: actions/download-artifact@v3

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -87,7 +87,7 @@ jobs:
           done
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6
         with:
           delete-branch: true
           branch-suffix: random


### PR DESCRIPTION
This PR increases the versions of actions used by CI. The specific actions being updated are split by commit. They are:

- `actions/checkout` to v4 (b9166c2a802a1dbfed418250daa7f2bf3d8d2f68)
- `actions/upload-artifact` and `actions/download-artifact` to v4 (c1cc6afd44ce0f9a17bd622556ae957fa79b2964)
- `actions/cache` to v4 (bc782e70af1a5931cb6ef3129cded2e54b936e4e)
- `peter-evans/create-pull-request` to v6 (459e9c9cb046e0d349f4b692b8916e1d4bf319a2)

A few versions were inconsistent across the project, so this fixes that too. I don't believe any of the breaking changes affect us, since most of the changes were bumping the NodeJS runtime to version 20. The other breaking changes are documented in the commit descriptions.

Many actions were targeting the `master` branch. Since `master` was renamed to `main` for all of those projects, runs were pulling what is equivalent of a random out-of-date commit from the repositories. I updated them to target actual releases, to avoid breaking changes.

The only action I left outdated (that I'm aware of) is [`shalzz/zola-deploy-action`](https://github.com/shalzz/zola-deploy-action/) since the [release notes](https://github.com/shalzz/zola-deploy-action/releases) are more confusing and I didn't want to break anything. That may come in another PR.