### PR TITLE
Fix lines not being hidden in indented code blocks

### DIFF
--- a/write-rustdoc-hide-lines/Cargo.lock
+++ b/write-rustdoc-hide-lines/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15,9 +24,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da2d6f23ffea9d7e76c53eee25dfb67bcd8fde7f1198b0855350698c9f07c780"
 
 [[package]]
+name = "memchr"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+
+[[package]]
+name = "regex"
+version = "1.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
 name = "write-rustdoc-hide-lines"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "indoc",
+ "regex",
 ]

--- a/write-rustdoc-hide-lines/Cargo.toml
+++ b/write-rustdoc-hide-lines/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
+regex = "1.5"
 
 [dev-dependencies]
 indoc = "1.0"

--- a/write-rustdoc-hide-lines/src/code_block_definition.rs
+++ b/write-rustdoc-hide-lines/src/code_block_definition.rs
@@ -79,10 +79,10 @@ pub struct CodeBlockDefinition {
 impl CodeBlockDefinition {
     pub fn new(line: &str) -> Option<CodeBlockDefinition> {
         let lang_re = Regex::new(r"(\s*)```(.+)").ok()?;
-        let captures = lang_re.captures(&line)?;
+        let captures = lang_re.captures(line)?;
 
-        let whitespace = captures.get(1).and_then(|mat| Some(mat.as_str()))?;
-        let lang = captures.get(2).and_then(|mat| Some(mat.as_str()))?;
+        let whitespace = captures.get(1).map(|mat| mat.as_str())?;
+        let lang = captures.get(2).map(|mat| mat.as_str())?;
 
         let mut hide_lines_idx = None;
 
@@ -142,12 +142,9 @@ impl CodeBlockDefinition {
     pub fn set_hidden_ranges(&mut self, hidden_ranges: HiddenRanges) {
         if hidden_ranges.is_empty() {
             // Remove
-            match self.hide_lines_idx {
-                Some(idx) => {
-                    self.annotations.remove(idx);
-                    self.hide_lines_idx = None;
-                }
-                None => (),
+            if let Some(idx) = self.hide_lines_idx {
+                self.annotations.remove(idx);
+                self.hide_lines_idx = None;
             }
         } else {
             // Add

--- a/write-rustdoc-hide-lines/src/code_block_definition.rs
+++ b/write-rustdoc-hide-lines/src/code_block_definition.rs
@@ -1,5 +1,7 @@
 use std::ops::Range;
 
+use regex::Regex;
+
 use crate::hidden_ranges::HiddenRanges;
 
 #[derive(Debug, PartialEq)]
@@ -74,27 +76,24 @@ pub struct CodeBlockDefinition {
     hide_lines_idx: Option<usize>,
 }
 
-const RUST_CODE_BLOCK_LONG: &str = "```rust";
-const RUST_CODE_BLOCK_SHORT: &str = "```rs";
-
 impl CodeBlockDefinition {
     pub fn new(line: &str) -> Option<CodeBlockDefinition> {
-        let tag: String;
+        let lang_re = Regex::new(r"(\s*)```(.+)").ok()?;
+        let captures = lang_re.captures(&line)?;
 
-        if line.starts_with(RUST_CODE_BLOCK_LONG) {
-            tag = RUST_CODE_BLOCK_LONG.into();
-        } else if line.starts_with(RUST_CODE_BLOCK_SHORT) {
-            tag = RUST_CODE_BLOCK_SHORT.into();
-        } else {
+        let whitespace = captures.get(1).and_then(|mat| Some(mat.as_str()))?;
+        let lang = captures.get(2).and_then(|mat| Some(mat.as_str()))?;
+
+        let mut hide_lines_idx = None;
+
+        let mut parts = lang.split(',');
+        let tag = parts.next()?;
+
+        if tag != "rs" && tag != "rust" {
             return None;
         }
 
-        let mut hide_lines_idx = None;
-        let annotations = line
-            .get(tag.len()..)
-            .unwrap_or("")
-            .split(',')
-            .filter(|a| a.trim() != "")
+        let annotations = parts
             .enumerate()
             .map(|(idx, a)| {
                 let annotation = Annotation::from(a);
@@ -108,7 +107,7 @@ impl CodeBlockDefinition {
             .collect();
 
         Some(CodeBlockDefinition {
-            tag,
+            tag: format!("{}```{}", whitespace, tag),
             annotations,
             hide_lines_idx,
         })
@@ -175,7 +174,7 @@ mod tests {
 
         for case in cases {
             let definition = CodeBlockDefinition::new(case);
-            assert_eq!(definition.is_none(), true);
+            assert_eq!(definition, None);
         }
     }
 

--- a/write-rustdoc-hide-lines/src/formatter.rs
+++ b/write-rustdoc-hide-lines/src/formatter.rs
@@ -69,7 +69,8 @@ fn format_file(reader: impl Iterator<Item = Result<String>>, file_size: usize) -
         let is_code_block_delim = code_block_delim_match.is_some();
 
         if !inside_code_block && is_code_block_delim {
-            if code_block_delim_match.unwrap().as_str() == "rust" {
+            let lang = code_block_delim_match.unwrap().as_str();
+            if lang == "rust" || lang == "rs" {
                 is_rust = true;
             }
 

--- a/write-rustdoc-hide-lines/src/formatter.rs
+++ b/write-rustdoc-hide-lines/src/formatter.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use regex::Regex;
 use std::{
     ffi::OsStr,
     fmt::Write,
@@ -7,9 +8,7 @@ use std::{
     path::Path,
 };
 
-use crate::{
-    code_block_definition::CodeBlockDefinition, hidden_ranges::get_hidden_ranges
-};
+use crate::{code_block_definition::CodeBlockDefinition, hidden_ranges::get_hidden_ranges};
 
 pub fn run(dir: &Path) -> Result<()> {
     visit_dir_md_files(dir, &|entry| {
@@ -19,8 +18,10 @@ pub fn run(dir: &Path) -> Result<()> {
         let file = File::open(entry.path())?;
         let file_size = file.metadata().unwrap().len().try_into().unwrap();
         let contents = format_file(
-            io::BufReader::new(file).lines().map(|line| line.map_err(anyhow::Error::from)),
-            file_size
+            io::BufReader::new(file)
+                .lines()
+                .map(|line| line.map_err(anyhow::Error::from)),
+            file_size,
         )?;
 
         // Rewrite file
@@ -53,57 +54,70 @@ fn visit_dir_md_files(dir: &Path, cb: &dyn Fn(&DirEntry) -> Result<()>) -> Resul
 
 fn format_file(reader: impl Iterator<Item = Result<String>>, file_size: usize) -> Result<String> {
     let mut contents = String::with_capacity(file_size);
-    let mut is_inside_rust_code_block = false;
     let mut rust_block: Vec<String> = vec![];
+    let mut is_rust = false;
+
+    let mut inside_code_block = false;
+
+    // Find a code block delimiter and optionally the first specified language
+    let code_block_delim = Regex::new(r"\s*```(\w*)")?;
 
     for line in reader {
         let line = line?;
-        let is_code_block_open = line.starts_with("```rust");
-        let is_code_block_close = line == "```";
 
-        if is_inside_rust_code_block && is_code_block_open {
-            panic!("Nested '```rust' code block not allowed");
-        } else if is_code_block_open {
-            is_inside_rust_code_block = true;
+        let code_block_delim_match = code_block_delim.captures(&line).and_then(|cap| cap.get(1));
+        let is_code_block_delim = code_block_delim_match.is_some();
+
+        if !inside_code_block && is_code_block_delim {
+            if code_block_delim_match.unwrap().as_str() == "rust" {
+                is_rust = true;
+            }
+
+            inside_code_block = true;
+        } else if inside_code_block && is_code_block_delim {
+            inside_code_block = false;
         }
 
-        // Skip the line, save it as is
-        if !is_inside_rust_code_block {
+        // Pass through non-rust code block contents and contents outside of code blocks.
+        if !is_rust {
             writeln!(&mut contents, "{}", &line)?;
             continue;
         }
 
         rust_block.push(line);
 
-        // Process the `rust` code block
-        if is_code_block_close {
-            let code = &rust_block[1..rust_block.len() - 1];
-            let real_hidden_ranges = get_hidden_ranges(code);
-            let mut definition = CodeBlockDefinition::new(&rust_block[0]).unwrap();
+        if inside_code_block {
+            continue;
+        }
 
-            match definition.get_hidden_ranges() {
-                Some(annotation_hidden_ranges) => {
-                    if *annotation_hidden_ranges != real_hidden_ranges {
-                        definition.set_hidden_ranges(real_hidden_ranges);
-                    }
-                }
-                None => {
-                    if !real_hidden_ranges.is_empty() {
-                        definition.set_hidden_ranges(real_hidden_ranges);
-                    }
+        // Process the `rust `code block
+        let code = &rust_block[1..rust_block.len() - 1];
+        let real_hidden_ranges = get_hidden_ranges(code);
+        let mut definition = CodeBlockDefinition::new(&rust_block[0]).unwrap();
+
+        match definition.get_hidden_ranges() {
+            Some(annotation_hidden_ranges) => {
+                if *annotation_hidden_ranges != real_hidden_ranges {
+                    definition.set_hidden_ranges(real_hidden_ranges);
                 }
             }
-
-            // Rewrite code block Zola annotations
-            rust_block[0] = definition.into_string();
-
-            // Write code block
-            writeln!(&mut contents, "{}", &rust_block.join("\n"))?;
-
-            // Reset state
-            is_inside_rust_code_block = false;
-            rust_block = vec![];
+            None => {
+                if !real_hidden_ranges.is_empty() {
+                    definition.set_hidden_ranges(real_hidden_ranges);
+                }
+            }
         }
+
+        // Rewrite code block Zola annotations
+        rust_block[0] = definition.into_string();
+
+        // Write code block
+        writeln!(&mut contents, "{}", &rust_block.join("\n"))?;
+
+        // Reset state
+        inside_code_block = false;
+        rust_block = vec![];
+        is_rust = false;
     }
 
     Ok(contents)
@@ -111,8 +125,8 @@ fn format_file(reader: impl Iterator<Item = Result<String>>, file_size: usize) -
 
 #[cfg(test)]
 mod tests {
-    use indoc::indoc;
     use super::*;
+    use indoc::indoc;
 
     fn lines_iter(code: &str) -> impl Iterator<Item = Result<String>> + '_ {
         code.split("\n").map(|line| Ok(String::from(line)))
@@ -202,6 +216,37 @@ mod tests {
                 ```
 
             "#}
+        );
+    }
+
+    #[test]
+    fn indented() {
+        let markdown = r#"
+    ```rust
+    # test
+    # test 2
+    fn not_hidden() {
+
+    }
+    # test 3
+    ```
+"#;
+
+        let contents = format_file(lines_iter(markdown), markdown.len());
+
+        assert_eq!(
+            contents.unwrap(),
+            r#"
+    ```rust,hide_lines=1-2 6
+    # test
+    # test 2
+    fn not_hidden() {
+
+    }
+    # test 3
+    ```
+
+"#
         );
     }
 }

--- a/write-rustdoc-hide-lines/src/formatter.rs
+++ b/write-rustdoc-hide-lines/src/formatter.rs
@@ -129,7 +129,7 @@ mod tests {
     use indoc::indoc;
 
     fn lines_iter(code: &str) -> impl Iterator<Item = Result<String>> + '_ {
-        code.split("\n").map(|line| Ok(String::from(line)))
+        code.split('\n').map(|line| Ok(String::from(line)))
     }
 
     #[test]

--- a/write-rustdoc-hide-lines/src/formatter.rs
+++ b/write-rustdoc-hide-lines/src/formatter.rs
@@ -142,6 +142,10 @@ mod tests {
 
             }
             # test 3
+            #[derive(Component)]
+            struct A;
+            # #[derive(Component)]
+            struct B;
             ```
         "#};
 
@@ -150,13 +154,17 @@ mod tests {
         assert_eq!(
             contents.unwrap(),
             indoc! {r#"
-                ```rust,hide_lines=1-2 6
+                ```rust,hide_lines=1-2 6 9
                 # test
                 # test 2
                 fn not_hidden() {
 
                 }
                 # test 3
+                #[derive(Component)]
+                struct A;
+                # #[derive(Component)]
+                struct B;
                 ```
 
             "#}
@@ -229,6 +237,10 @@ mod tests {
 
     }
     # test 3
+    #[derive(Component)]
+    struct A;
+    # #[derive(Component)]
+    struct B;
     ```
 "#;
 
@@ -237,13 +249,17 @@ mod tests {
         assert_eq!(
             contents.unwrap(),
             r#"
-    ```rust,hide_lines=1-2 6
+    ```rust,hide_lines=1-2 6 9
     # test
     # test 2
     fn not_hidden() {
 
     }
     # test 3
+    #[derive(Component)]
+    struct A;
+    # #[derive(Component)]
+    struct B;
     ```
 
 "#

--- a/write-rustdoc-hide-lines/src/hidden_ranges.rs
+++ b/write-rustdoc-hide-lines/src/hidden_ranges.rs
@@ -10,7 +10,8 @@ pub fn get_hidden_ranges<T: AsRef<str>>(code: &[T]) -> HiddenRanges {
     let mut ranges = vec![];
     let mut curr_range: Option<Range<usize>> = None;
 
-    let Ok(is_hidden_re) = Regex::new(r"\s*#") else {
+    // Match lines starting with a potentially indented `#` followed by a space or EOL.
+    let Ok(is_hidden_re) = Regex::new(r"^\s*#(?: |$)") else {
         return ranges;
     };
 

--- a/write-rustdoc-hide-lines/src/hidden_ranges.rs
+++ b/write-rustdoc-hide-lines/src/hidden_ranges.rs
@@ -17,7 +17,7 @@ pub fn get_hidden_ranges<T: AsRef<str>>(code: &[T]) -> HiddenRanges {
     for (idx, line) in code.iter().enumerate() {
         let n = idx + 1;
         let line = line.as_ref();
-        let is_hidden = is_hidden_re.is_match(&line);
+        let is_hidden = is_hidden_re.is_match(line);
 
         if is_hidden {
             if let Some(range) = curr_range.as_mut() {
@@ -47,7 +47,7 @@ mod tests {
     use indoc::indoc;
 
     fn split_lines(code: &str) -> Vec<&str> {
-        code.split("\n").collect::<Vec<_>>()
+        code.split('\n').collect::<Vec<_>>()
     }
 
     #[test]


### PR DESCRIPTION
# Objective

From Discord:

> doup — Today at 2:33 AM
> there is a CLI tool in the repo that adds the required zola annotations to the code blocks, go to write-rustdoc-hide-lines folder and run ./write_rustdoc_hide_lines.sh… it doesn't support indented code blocks (e.g. ones inside ul/ol lists)

I don't believe there are actually any code blocks like this currently in the repo. I added a test though, and tried it out on one of the book pages.

## Solution

Use a regex that accounts for whitespace rather than `starts_with` throughout the code.

## Discussion

Rust tests pass, but it would be nice to ensure this is producing identical output.