### PR TITLE
Actually run code validation in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,11 +163,14 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
-      - uses: actions/upload-artifact@master
-        with:
-          name: generated-errors
-          path: content/learn/errors
-          retention-days: 1
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install alsa and udev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+
+      - name: Build & run doc tests
+        run: cd code-validation && cargo test
 
   build-website:
     runs-on: ubuntu-latest


### PR DESCRIPTION
97fef72 was committed to the `new-book` branch, adding a job to CI that would test all code blocks and validate them. Unfortunately something in #893 messed it up when merging / rebasing. This PR fixes that by configuring the code validation job to actually validate the code.

Additionally, it also removes the warning from uploading an empty artifact:

<img width="1071" alt="image" src="https://github.com/bevyengine/bevy-website/assets/59022059/99de3f72-b8eb-42c6-83dc-611e028815a7">

[As seen in this run](https://github.com/bevyengine/bevy-website/actions/runs/7787748624)