### PR TITLE
Link to dev-docs on contributing page

### DIFF
--- a/content/learn/quick-start/contributing/code/_index.md
+++ b/content/learn/quick-start/contributing/code/_index.md
@@ -16,6 +16,7 @@ Would you like to contribute code to Bevy?  Here's how!
 
 1. Fork the [`bevyengine/bevy` repository on GitHub][bevy], you'll need to create a GitHub account if you don't have one already.*
 2. Make your changes in a local clone of your fork
+   - You can view the unstable developer documentation [here](https://dev-docs.bevyengine.org), generated from the main branch on Github.
 3. For a higher chance of CI passing the first time, consider locally running `cargo run -p ci`. You can run the commands manually:
    1. `cargo fmt --all -- --check`  (remove `--check` to let the command fix found problems)
    2. `cargo clippy --workspace --all-targets --all-features -- -D warnings -A clippy::type_complexity -A clippy::manual-strip`

--- a/content/learn/quick-start/contributing/docs/_index.md
+++ b/content/learn/quick-start/contributing/docs/_index.md
@@ -47,7 +47,7 @@ We use Markdown reference-style links to nicely link to the Rust API docs:
 
 ## Rust API Docs
 
-Bevy's Rust API Docs are automatically generated from the latest Bevy source code. If you add [Rust documentation comments](https://doc.rust-lang.org/book/ch14-02-publishing-to-crates-io.html#making-useful-documentation-comments) to the Bevy codebase, the API docs will be automatically updated.
+Bevy's Rust API Docs are automatically generated from the latest Bevy source code. If you add [Rust documentation comments](https://doc.rust-lang.org/book/ch14-02-publishing-to-crates-io.html#making-useful-documentation-comments) to the Bevy codebase, the API docs will be automatically updated. You can view the unstable developer documentation [here](https://dev-docs.bevyengine.org), generated from the main branch.
 
 ## Bevy Markdown Docs
 


### PR DESCRIPTION
Closes #775.

This adds links on the contributing pages of the website, both for code and for docs. This is similar to #852, but I believe my approach avoids the confusion @mockersf warns about since it is targeted towards programmers developing the engine.

_I don't want to imply that #852 is bad, just that my approach is a compromise and easier to merge._