### PR TITLE
Use Environmental Files instead of `set-output` command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Get cache key
         id: cache-key
-        run: echo "::set-output name=key::$(date +'%Y-%m-%d')"
+        run: echo "key=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
       - name: Get crates.io datadump from cache
         uses: actions/cache@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Get current date
         id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
       - name: Cache multiple crates.io datadump
         uses: actions/cache@v4


### PR DESCRIPTION
Closes #920. This should fix the final warning emitted by the CI. :)