### PR TITLE
Fix missed mobile page menu link to book

### DIFF
--- a/templates/layouts/base.html
+++ b/templates/layouts/base.html
@@ -104,7 +104,7 @@
               {% block mobile_page_menu %}{% endblock %}
             </div>
             <ul class="main-menu__menu">
-              {{header_macros::header_item(name="Getting Started", path="/learn/book/getting-started/",
+              {{header_macros::header_item(name="Getting Started", path="/learn/quick-start/getting-started",
               extra_class="main-menu__entry--getting-started", current_path=current_path)}}
               {{header_macros::header_item(name="Learn", current_path=current_path)}}
               {{header_macros::header_item(name="News", current_path=current_path)}}


### PR DESCRIPTION
Changes a link to the book into a link to the quick start guide in the mobile page menu.

Fixes #929