### PR TITLE
Added a comment for linux users trying the examples

### DIFF
--- a/content/learn/quick-start/getting-started/_index.md
+++ b/content/learn/quick-start/getting-started/_index.md
@@ -45,6 +45,8 @@ Note: the "fast compiles" setup is on the next page, so you might want to read t
     cargo run --example breakout
     ```
 
+    If you are using a Linux distro, [install the dependencies](https://github.com/bevyengine/bevy/blob/main/docs/linux_dependencies.md) needed for bevy before trying the examples
+
 ### Add Bevy as a Dependency
 
 Bevy is [available as a library on crates.io](https://crates.io/crates/bevy).

--- a/content/learn/quick-start/getting-started/_index.md
+++ b/content/learn/quick-start/getting-started/_index.md
@@ -45,7 +45,7 @@ Note: the "fast compiles" setup is on the next page, so you might want to read t
     cargo run --example breakout
     ```
 
-    If you are using a Linux distro, [install the dependencies](https://github.com/bevyengine/bevy/blob/main/docs/linux_dependencies.md) needed for bevy before trying the examples
+    If you are using Linux, be sure to [install the dependencies](https://github.com/bevyengine/bevy/blob/main/docs/linux_dependencies.md) needed for Bevy before trying the examples.
 
 ### Add Bevy as a Dependency
 


### PR DESCRIPTION
Fixes #894 

When trying Bevy for the first time through the [Quick Start - Getting started](https://bevyengine.org/learn/quick-start/getting-started/) guide in a linux distro, you will get some errors when trying to `cargo run` the examples. That's because the dependencies listed [here](https://github.com/bevyengine/bevy/blob/main/docs/linux_dependencies.md) are needed for Bevy, and maybe not be installed in the user's system, which was in my case.