### PR TITLE
Fix link to CONTRIBUTING in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The source files for <https://bevyengine.org>. This includes official Bevy news, docs, and interactive examples.
 
-If you would like to contribute, check out [CONTRIBUTING.md] and then submit a pull request!
+If you would like to contribute, check out [CONTRIBUTING.md](/CONTRIBUTING.md) and then submit a pull request!
 
 ## Zola
 


### PR DESCRIPTION
Trivial PR to fix the link to `CONTRIBUTING.md` from `README.md`.

Fixes #943 