### PR TITLE
Fix extra whitespace in example code block

### DIFF
--- a/templates/example.html
+++ b/templates/example.html
@@ -33,7 +33,7 @@
   <div class="example__code media-content">
     {% set code = load_data(path=page.extra.code_path) %}
     {% set code_md = "```rust
-    " ~ code ~ "```" %}
+" ~ code ~ "```" %}
 
     {{code_md | markdown(inline=true) | safe}}
   </div>


### PR DESCRIPTION
I think this indentation was added mistakenly in #893. It's already correct in `example-webgpu.html`.

### Before / After
![image](https://github.com/bevyengine/bevy-website/assets/200550/c7c515dd-9c12-4b41-8184-128bacbd3c90)
