### PR TITLE
Let shell scripts be called from any directory

### DIFF
--- a/generate-assets/generate_assets.sh
+++ b/generate-assets/generate_assets.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Switch to script's directory, letting it be called from any folder.
+cd $(dirname $0)
+
 git clone --depth=1 https://github.com/bevyengine/bevy-assets assets
 
 cargo run --release --bin generate -- assets ../content

--- a/generate-community/generate_community.sh
+++ b/generate-community/generate_community.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Switch to script's directory, letting it be called from any folder.
+cd $(dirname $0)
+
 git init bevy-community
 cd bevy-community
 git remote add origin https://github.com/bevyengine/bevy-community

--- a/generate-community/generate_community.sh
+++ b/generate-community/generate_community.sh
@@ -3,6 +3,8 @@
 # Switch to script's directory, letting it be called from any folder.
 cd $(dirname $0)
 
+# Download a copy of the Bevy community repository.
+# FIXME: Can this be shortened to git clone --depth=1?
 git init bevy-community
 cd bevy-community
 git remote add origin https://github.com/bevyengine/bevy-community

--- a/generate-errors/generate_errors.sh
+++ b/generate-errors/generate_errors.sh
@@ -3,6 +3,7 @@
 # Switch to script's directory, letting it be called from any folder.
 cd $(dirname $0)
 
+# Only download the `errors` folder from the main Bevy repository.
 git init bevy
 cd bevy
 git remote add origin https://github.com/bevyengine/bevy

--- a/generate-errors/generate_errors.sh
+++ b/generate-errors/generate_errors.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Switch to script's directory, letting it be called from any folder.
+cd $(dirname $0)
+
 git init bevy
 cd bevy
 git remote add origin https://github.com/bevyengine/bevy

--- a/generate-wasm-examples/clone_bevy.sh
+++ b/generate-wasm-examples/clone_bevy.sh
@@ -3,6 +3,7 @@
 # Switch to script's directory, letting it be called from any folder.
 cd $(dirname $0)
 
+# FIXME: Can this be shortened to git clone --depth=1?
 git init bevy
 cd bevy
 git remote add origin https://github.com/bevyengine/bevy

--- a/generate-wasm-examples/clone_bevy.sh
+++ b/generate-wasm-examples/clone_bevy.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Switch to script's directory, letting it be called from any folder.
+cd $(dirname $0)
+
 git init bevy
 cd bevy
 git remote add origin https://github.com/bevyengine/bevy

--- a/generate-wasm-examples/generate_wasm_examples.sh
+++ b/generate-wasm-examples/generate_wasm_examples.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Switch to script's directory, letting it be called from any folder.
+cd $(dirname $0)
+
 ./clone_bevy.sh
 
 # temporary: fetch tools from main branch

--- a/write-rustdoc-hide-lines/write_rustdoc_hide_lines.sh
+++ b/write-rustdoc-hide-lines/write_rustdoc_hide_lines.sh
@@ -1,3 +1,7 @@
 #!/bin/sh
+
+# Switch to script's directory, letting it be called from any folder.
+cd $(dirname $0)
+
 cargo run --release -- ../content/learn/book
 cargo run --release -- ../content/learn/quick-start


### PR DESCRIPTION
This calls:

```shell
$ cd $(dirname $0)
```

at the beginning of all shell scripts in this repository. This guarantees the assumption that a script will be operating in the same directory it lives in. Namely, the following commands will do the same thing:

```shell
(bevy-website) $ ./generate-assets/generate_assets.sh
(bevy-website/generate-assets) $ ./generate_assets.sh
```

Technically a portion of this was implemented for specifically `write-rustdoc-hide-lines` in #923, but that is not yet merged and this widens the change to all scripts. There will be merge conflicts, but I'll fix them. :)

<details>
  <summary>But what is the command actually doing?</summary>

```shell
$ cd $(dirname $0)
```

Let's break it down.

- `cd` stands for "change directory." It changes the current directory to whatever path is given to it.
- `$(...)` is an evaluation block. It will execute any command within it, then return the output as a string.
- `dirname` accepts a file path and returns the full path to the directory of that file. For instance, `dirname path/to/foo.txt` would return `path/to`.
- `$0` is a special variable that represents the path to the current script being executed. If `./bin/dostuff.sh` was executed, `$0` would be `./bin/dostuff.sh`.

So in summary, the command is finding the folder of the script being run and `cd`-ing into it. Tada! :D

</details>