### PR TITLE
Simplify shallow clones in shell scripts

### DIFF
--- a/generate-community/generate_community.sh
+++ b/generate-community/generate_community.sh
@@ -4,11 +4,6 @@
 cd $(dirname $0)
 
 # Download a copy of the Bevy community repository.
-# FIXME: Can this be shortened to git clone --depth=1?
-git init bevy-community
-cd bevy-community
-git remote add origin https://github.com/bevyengine/bevy-community
-git pull --depth=1 origin main
-cd ..
+git clone --depth=1 https://github.com/bevyengine/bevy-community bevy-community
 
 cargo run --bin generate -- bevy-community ../content/ community

--- a/generate-wasm-examples/clone_bevy.sh
+++ b/generate-wasm-examples/clone_bevy.sh
@@ -3,8 +3,4 @@
 # Switch to script's directory, letting it be called from any folder.
 cd $(dirname $0)
 
-# FIXME: Can this be shortened to git clone --depth=1?
-git init bevy
-cd bevy
-git remote add origin https://github.com/bevyengine/bevy
-git pull --depth=1 origin latest
+git clone --depth=1 --branch=latest https://github.com/bevyengine/bevy bevy

--- a/generate-wasm-examples/generate_wasm_examples.sh
+++ b/generate-wasm-examples/generate_wasm_examples.sh
@@ -6,11 +6,8 @@ cd $(dirname $0)
 ./clone_bevy.sh
 
 # temporary: fetch tools from main branch
-git init bevy-tools
-cd bevy-tools
-git remote add origin https://github.com/bevyengine/bevy
-git pull --depth=1 origin main
-cd ..
+git clone --depth=1 https://github.com/bevyengine/bevy bevy-tools
+
 rm -rf bevy/tools
 cp -r bevy-tools/tools bevy
 rm -rf bevy-tools


### PR DESCRIPTION
Many of the shell scripts clone Git repositories such as `bevyengine/bevy` or `bevyengine/bevy-community`. Unlike normal developers, the scripts do not need the full commit history. Because of this, they usually pass `--depth=1` to Git, which only fetches the latest commit on the specified branch.

A few of these scripts have been accomplishing this by doing the following:

```shell
# Create a new, empty repository
$ git init bevy
$ cd bevy
# Set the repository to track Bevy
$ git remote add origin https://github.com/bevyengine/bevy
# Pull the latest commit
$ git pull --depth=1 origin latest
```

This can be simplified to:

```shell
$ git clone --depth=1 https://github.com/bevyengine/bevy bevy
```

This PR does exactly that. It reduces the shallow clones to a single command. From my testing, there is no behavioral difference and similar performance.

This is a follow up of #966.