### PR TITLE
Fix typo in index.html

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -91,7 +91,7 @@
           <p>A capable animation system</p>
           <ul class=feature-sublist>
             <li>Skeletal rig animation driven by an ECS-based joint API</li>
-            <li>Play multiple animation at the same time by smoothly blending between them</li>
+            <li>Play multiple animations at the same time by smoothly blending between them</li>
             <li>Use blend shapes / morph targets to animate vertices directly</li>
             <li>Import animations from GLTF files</li>
         </div>


### PR DESCRIPTION
I found a small typo in the index page.