### PR TITLE
Explicit add deprecated shapes on migration guide

### DIFF
--- a/content/learn/migration-guides/0.12-to-0.13.md
+++ b/content/learn/migration-guides/0.12-to-0.13.md
@@ -1153,6 +1153,18 @@ If you were using the pipelined rendering channels, `MainToRenderAppSender` and 
 
 Bevy has previously used rendering-specific types like `UVSphere` and `Quad` for primitive mesh shapes. These have now been deprecated to use the geometric primitives newly introduced in version 0.13.
 
+- `bevy_render::mesh::Capsule` is deprecated use `bevy_math::primitives::dim3::Capsule3d` instead;
+- `bevy_render::mesh::Cylinder` is deprecated use `bevy_math::primitives::dim3::Cylinder` instead;
+- `bevy_render::mesh::Icosphere` is deprecated use `bevy_math::primitives::dim3::Sphere` instead;
+- `bevy_render::mesh::Cube` is deprecated use `bevy_math::primitives::dim3::Cuboid` instead;
+- `bevy_render::mesh::Box` is deprecated use `bevy_math::primitives::dim3::Cuboid` instead;
+- `bevy_render::mesh::Quad` is deprecated use `bevy_math::primitives::dim2::Rectangle` instead;
+- `bevy_render::mesh::Plane` is deprecated use `bevy_math::primitives::dim2::Plane2d` or `bevy_math::primitives::dim3::Plane3d` instead;
+- `bevy_render::mesh::RegularPolygon` is deprecated use `bevy_math::primitives::dim2::RegularPolygon` instead;
+- `bevy_render::mesh::Circle` is deprecated use `bevy_math::primitives::dim2::Circle` instead;
+- `bevy_render::mesh::Torus` is deprecated use `bevy_math::primitives::dim3::Torus` instead;
+- `bevy_render::mesh::UVSphere` is deprecated use `bevy_math::primitives::dim3::Sphere` instead;
+
 Some examples:
 
 ```rust


### PR DESCRIPTION
Closes #989 

The idea is to help users when they are just searching for their deprecated primitives, which will help to find the PR that introduced the change.