### PR TITLE
Remove redundant + conflicting table styling

### DIFF
--- a/sass/pages/_content.scss
+++ b/sass/pages/_content.scss
@@ -107,31 +107,6 @@ $content-font-size: 1.22rem;
         padding-left: 0px;
         padding-right: 0px;
     }
-
-    table {
-        border-collapse: separate;
-        border-radius: $border-radius;
-        border: 1px solid;
-        border-spacing: 0;
-    }
-
-    table  th:not(:last-child), table td:not(:last-child) {
-        border-right: 1px solid;
-    }
-
-    table>thead>tr:not(:last-child)>th,
-    table>thead>tr:not(:last-child)>td,
-    table>tbody>tr:not(:last-child)>th,
-    table>tbody>tr:not(:last-child)>td,
-    table>tfoot>tr:not(:last-child)>th,
-    table>tfoot>tr:not(:last-child)>td,
-    table>tr:not(:last-child)>td,
-    table>tr:not(:last-child)>th,
-    table>thead:not(:last-child),
-    table>tbody:not(:last-child),
-    table>tfoot:not(:last-child) {
-        border-bottom: 1px solid;
-    }
 }
 
 .fun-list {


### PR DESCRIPTION
I accidentally re-created slightly different (and conflicting) table styling in the 0.13 blog post. This removes that in favor of the original, which is slightly better.