### PR TITLE
Fix 'chose' 'choose' typo in 0.13 blog

### DIFF
--- a/content/news/2024-02-17-bevy-0.13/index.md
+++ b/content/news/2024-02-17-bevy-0.13/index.md
@@ -679,7 +679,7 @@ fn list_entities(user_query: String, world: &mut World) {
 }
 ```
 
-It's impossible to chose a type based on the value of `user_query`!
+It's impossible to choose a type based on the value of `user_query`!
 [`QueryBuilder`] solves this problem.
 
 ```rust


### PR DESCRIPTION
Reported on discord https://discord.com/channels/691052431525675048/691052431974465548/1208509821330923552