### PR TITLE
0.13 migration: Simplify entry for 7650

### DIFF
--- a/content/learn/migration-guides/0.12-to-0.13.md
+++ b/content/learn/migration-guides/0.12-to-0.13.md
@@ -1457,20 +1457,7 @@ Consider changing usage:
     <div class="migration-guide-area-tag">Windowing</div>
 </div>
 
-Set the `bevy_window::Window`’s `name` field when needed:
-
-```rust
-App::new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                title: "I am a window!".into(),
-                name: Some("SpaceGameCompany.SpaceShooter".into()),
-                ..default()
-            }),
-            ..default()
-        }))
-        .run();
-```
+`Window` has a new [`name`](https://docs.rs/bevy/latest/bevy/prelude/struct.Window.html#structfield.name) field for specifying the "window class name." If you don't need this, set it to `None`.
 
 ### [delete methods deprecated in 0.12](https://github.com/bevyengine/bevy/pull/10693)
 


### PR DESCRIPTION
The current text/code feels like a lot for this change, and I think the current phrasing could be interpreted as "you need to use this."

The vast majority of users won't be using `Window` without `..default()`, and I would imagine that most folks don't need / want to figure out what value to put in there.
