### PR TITLE
Add a note about platform-specific dependencies in quick start

### DIFF
--- a/content/learn/quick-start/getting-started/_index.md
+++ b/content/learn/quick-start/getting-started/_index.md
@@ -65,4 +65,3 @@ bevy = "0.12" # make sure this is the latest version
 ```
 
 Make sure to use the latest `bevy` crate version ([![Crates.io](https://img.shields.io/crates/v/bevy.svg)](https://crates.io/crates/bevy)).
-

--- a/content/learn/quick-start/getting-started/_index.md
+++ b/content/learn/quick-start/getting-started/_index.md
@@ -13,7 +13,10 @@ This section will help you get started on your Bevy journey as quickly as possib
 
 If you want to dive in immediately and you already have a working Rust setup, feel free to follow this "quick start" guide. Otherwise, move on to the next page.
 
-Note: the "fast compiles" setup is on the next page, so you might want to read that section first.
+Note: depending on your platform, you may have to [install additional dependencies]. You can also speed up compile times by following the ["fast compiles"] section.
+
+[install additional dependencies]: /learn/quick-start/getting-started/setup/#installing-os-dependencies
+["fast compiles"]: /learn/quick-start/getting-started/setup/#enable-fast-compiles-optional
 
 ### Try the Examples
 
@@ -62,3 +65,4 @@ bevy = "0.12" # make sure this is the latest version
 ```
 
 Make sure to use the latest `bevy` crate version ([![Crates.io](https://img.shields.io/crates/v/bevy.svg)](https://crates.io/crates/bevy)).
+


### PR DESCRIPTION
Closes #894, alternative to #932.

This adds a note to the [getting started] page that mentions platform specific dependencies. This should help guide Linux users into discovering the [Linux Dependencies] guide, as well as help Windows and Mac users.

[getting started]: https://bevyengine.org/learn/quick-start/getting-started/
[Linux Dependencies]: https://github.com/bevyengine/bevy/blob/main/docs/linux_dependencies.md