### PR TITLE
Remove `bevy_reflect: Type parameter bounds` migration guide

### DIFF
--- a/content/learn/migration-guides/0.12-to-0.13.md
+++ b/content/learn/migration-guides/0.12-to-0.13.md
@@ -762,17 +762,6 @@ Existing scene files containing the former (incorrect) serialization of the `Nam
 
 Convert any uses of `#[derive(TypeUuid)]` with `#[derive(TypePath]` for more complex uses see the relevant [documentation](https://docs.rs/bevy/latest/bevy/prelude/trait.TypePath.html) for more information.
 
-```rust
-// 0.12:
-#[derive(Reflect)]
-struct Foo<T>(#[reflect(ignore)] T);
-
-// 0.13:
-#[derive(Reflect)]
-#[reflect(where)]
-struct Foo<T>(#[reflect(ignore)] T);
-```
-
 ### [Explicit color conversion methods](https://github.com/bevyengine/bevy/pull/10321)
 
 <div class="migration-guide-area-tags">

--- a/content/learn/migration-guides/0.12-to-0.13.md
+++ b/content/learn/migration-guides/0.12-to-0.13.md
@@ -762,16 +762,6 @@ Existing scene files containing the former (incorrect) serialization of the `Nam
 
 Convert any uses of `#[derive(TypeUuid)]` with `#[derive(TypePath]` for more complex uses see the relevant [documentation](https://docs.rs/bevy/latest/bevy/prelude/trait.TypePath.html) for more information.
 
-### [bevy_reflect: Type parameter bounds](https://github.com/bevyengine/bevy/pull/9046)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">Reflection</div>
-</div>
-
-When deriving `Reflect`, generic type params that do not need the automatic reflection bounds (such as `Reflect`) applied to them will need to opt-out using a custom where clause like: `#[reflect(where T: Trait, U::Assoc: Trait, ...)]`.
-
-The attribute can define custom bounds only used by the reflection impls. To simply opt-out all the type params, we can pass in an empty where clause: `#[reflect(where)]`.
-
 ```rust
 // 0.12:
 #[derive(Reflect)]


### PR DESCRIPTION
The breaking changes were removed in a follow-up PR: https://github.com/bevyengine/bevy/pull/11597 . As such these changes, and their migration guide, were old and irrelevant to the released version of 0.13.

Reported on Discord: https://discord.com/channels/691052431525675048/695741366520512563/1208644034864750683
Notice of removal of breaking changes noted in https://github.com/bevyengine/bevy/pull/11597 's migration guide section.