### PR TITLE
Rename `DefaultGizmoGroup` to `DefaultGizmoConfigGroup` in `0.12 -> 0.13 Migration Guide`

### DIFF
--- a/content/learn/migration-guides/0.12-to-0.13.md
+++ b/content/learn/migration-guides/0.12-to-0.13.md
@@ -617,7 +617,7 @@ Usage of `RunFixedUpdateLoop` should be renamed to `RunFixedMainLoop`.
     <div class="migration-guide-area-tag">Gizmos</div>
 </div>
 
-`GizmoConfig` is no longer a resource and has to be accessed through `GizmoConfigStore` resource. The default config group is `DefaultGizmoGroup`, but consider using your own custom config group if applicable.
+`GizmoConfig` is no longer a resource and has to be accessed through `GizmoConfigStore` resource. The default config group is `DefaultGizmoConfigGroup`, but consider using your own custom config group if applicable.
 
 ### [Use Direction3d for gizmos.circle normal](https://github.com/bevyengine/bevy/pull/11422)
 


### PR DESCRIPTION
The struct was renamed in https://github.com/bevyengine/bevy/pull/10342/commits/694b7c5a63139412e5fbc1f7b6d8b8923f26e9b4 and the migration guide section wasn't updated to accommodate. Reported on Discord here: https://discord.com/channels/691052431525675048/691052431974465548/1208862407477436426