### PR TITLE
Add back in necessary prelude boilerplate to getting started

### DIFF
--- a/content/learn/quick-start/getting-started/apps.md
+++ b/content/learn/quick-start/getting-started/apps.md
@@ -16,7 +16,7 @@ fn main() {
 }
 ```
 
-The statement `use bevy::prelude::*` brings in the essential things from Bevy. However, since it is boilerplate it will be ommitted from all examples where it is irrelevant from here on out.
+The `use bevy::prelude::*` statement brings in the essential things from Bevy. For brevity, this guide may omit it in later steps.
 
 Nice and simple right? Copy the code above into your `main.rs` file, then run:
 

--- a/content/learn/quick-start/getting-started/apps.md
+++ b/content/learn/quick-start/getting-started/apps.md
@@ -9,11 +9,14 @@ weight = 2
 Bevy programs are referred to as [`App`]s. The simplest Bevy app looks like this:
 
 ```rs,hide_lines=1
-# use bevy::prelude::*;
+use bevy::prelude::*;
+
 fn main() {
     App::new().run();
 }
 ```
+
+The statement `use bevy::prelude::*` brings in the essential things from Bevy. However, since it is boilerplate it will be ommitted from all examples where it is irrelevant from here on out.
 
 Nice and simple right? Copy the code above into your `main.rs` file, then run:
 

--- a/content/learn/quick-start/getting-started/apps.md
+++ b/content/learn/quick-start/getting-started/apps.md
@@ -8,7 +8,7 @@ weight = 2
 
 Bevy programs are referred to as [`App`]s. The simplest Bevy app looks like this:
 
-```rs,hide_lines=1
+```rs
 use bevy::prelude::*;
 
 fn main() {

--- a/content/learn/quick-start/getting-started/ecs.md
+++ b/content/learn/quick-start/getting-started/ecs.md
@@ -60,7 +60,8 @@ fn hello_world() {
 This will be our first system. The only remaining step is to add it to our [`App`]!
 
 ```rs,hide_lines=1
-# use bevy::prelude::*;
+use bevy::prelude::*;
+
 fn main() {
     App::new()
         .add_systems(Update, hello_world)

--- a/content/learn/quick-start/getting-started/ecs.md
+++ b/content/learn/quick-start/getting-started/ecs.md
@@ -59,7 +59,7 @@ fn hello_world() {
 
 This will be our first system. The only remaining step is to add it to our [`App`]!
 
-```rs,hide_lines=1
+```rs
 use bevy::prelude::*;
 
 fn main() {


### PR DESCRIPTION
Makes a couple prelude boilerplate statements visible again and notifies readers that further use of it will be hidden. Caught after a user experienced issues with the tutorial on Discord: https://discord.com/channels/691052431525675048/691052431974465548/1208911025223761920