### PR TITLE
Clarify `Texture Atlas rework` migration guide

### DIFF
--- a/content/learn/migration-guides/0.12-to-0.13.md
+++ b/content/learn/migration-guides/0.12-to-0.13.md
@@ -890,7 +890,7 @@ The `TextureAtlas` asset that previously contained both the atlas layout and ima
 
 `TextureAtlasBuilder::finish` now returns a `Result<(TextureAtlasLayout, Image), TextureAtlasBuilderError>`.
 
-`UiAtlasImage` was removed. The `AtlasImageBundle` is now identical to `ImageBundle` with an additional `TextureAtlas`.
+`UiTextureAtlasImage` was removed. The `AtlasImageBundle` is now identical to `ImageBundle` with an additional `TextureAtlas`.
 
 - Sprites
 

--- a/content/learn/migration-guides/0.12-to-0.13.md
+++ b/content/learn/migration-guides/0.12-to-0.13.md
@@ -944,6 +944,31 @@ fn my_system(
 }
 ```
 
+- Queries (taken from the [sprite sheet example](https://bevyengine.org/examples/2D%20Rendering/sprite-sheet/))
+```diff
+fn animate_sprite(
+    time: Res<Time>,
+    mut query: Query<(
+        &AnimationIndices,
+        &mut AnimationTimer,
+-       &mut TextureAtlasSprite)>,
++       &mut TextureAtlas)>,
+) {
+-   for (indices, mut timer, mut sprite) in &mut query {
++   for (indices, mut timer, mut atlas) in &mut query {
+        timer.tick(time.delta());
+        if timer.just_finished() {
+            atlas.index = if atlas.index == indices.last {
+                indices.first
+            } else {
+-               sprite.index + 1
++               atlas.index + 1
+            };
+        }
+    }
+}
+```
+
 ### [Exposure settings (adopted)](https://github.com/bevyengine/bevy/pull/11347)
 
 <div class="migration-guide-area-tags">

--- a/content/learn/migration-guides/0.12-to-0.13.md
+++ b/content/learn/migration-guides/0.12-to-0.13.md
@@ -884,7 +884,7 @@ The `TextureAtlas` asset that previously contained both the atlas layout and ima
 
 `SpriteSheetBundle` now uses a `Sprite` instead of a `TextureAtlasSprite` component and a `TextureAtlas` component instead of a `Handle<TextureAtlaslayout>`.
 
-`DynamicTextureAtlasBuilder::add_texture` takes an addition `&Handle<Image>` parameter.
+`DynamicTextureAtlasBuilder::add_texture` takes an additional `&Handle<Image>` parameter.
 
 `TextureAtlasLayout::from_grid` no longer takes a `Handle<Image>` parameter.
 

--- a/content/learn/migration-guides/0.12-to-0.13.md
+++ b/content/learn/migration-guides/0.12-to-0.13.md
@@ -884,6 +884,14 @@ The `TextureAtlas` asset that previously contained both the atlas layout and ima
 
 `SpriteSheetBundle` now uses a `Sprite` instead of a `TextureAtlasSprite` component and a `TextureAtlas` component instead of a `Handle<TextureAtlaslayout>`.
 
+`DynamicTextureAtlasBuilder::add_texture` takes an addition `&Handle<Image>` parameter.
+
+`TextureAtlasLayout::from_grid` no longer takes a `Handle<Image>` parameter.
+
+`TextureAtlasBuilder::finish` now returns a `Result<(TextureAtlasLayout, Handle<Image>), _>`.
+
+`UiAtlasImage` was removed. The atlas bundle is now identical to `ImageBundle` with an additional `TextureAtlas`.
+
 - Sprites
 
 ```diff

--- a/content/learn/migration-guides/0.12-to-0.13.md
+++ b/content/learn/migration-guides/0.12-to-0.13.md
@@ -878,6 +878,10 @@ Renamed `PbrInput::occlusion` to `diffuse_occlusion`, and added `specular_occlus
     <div class="migration-guide-area-tag">Rendering</div>
 </div>
 
+The `TextureAtlas` asset that previously contained both the atlas layout and image handle has been renamed to `TextureAtlasLayout` that only contains the layout now. A separate `Handle<Image>`gotten through either `SpriteSheetBundle::texture` or `AtlasImageBundle::image` replaces the prior image handle functionality of `TextureAtlasLayout`.
+
+`TextureAtlasSprite` was removed and replaced by a new component, `TextureAtlas`, which now holds the atlas index and is a direct component of `SpriteSheetBundle` replacing the `Handle<TextureAtlasLayout>` from before. The `Sprite` component can be used for `flip_x`, `flip_y`, `custom_size`, `anchor`, and `color` and replaces `TextureAtlasSprite` in `SpriteSheetBundle`.
+
 - Sprites
 
 ```diff
@@ -894,12 +898,14 @@ fn my_system(
     commands.spawn(SpriteSheetBundle {
 -      sprite: TextureAtlasSprite::new(0),
 -      texture_atlas: atlas_handle,
+       // the new sprite initialization is covered by the `..default()` expression; however, it is added to showcase migration
++      sprite: Sprite::default()
 +      atlas: TextureAtlas {
 +         layout: layout_handle,
 +         index: 0
 +      },
 +      texture: texture_handle,
-       ..Default::default()
+       ..default()
      });
 }
 ```
@@ -933,7 +939,7 @@ fn my_system(
 +           flip_x: false,
 +           flip_y: false,
 +       },
-       ..Default::default()
+       ..default()
      });
 }
 ```

--- a/content/learn/migration-guides/0.12-to-0.13.md
+++ b/content/learn/migration-guides/0.12-to-0.13.md
@@ -880,7 +880,7 @@ Renamed `PbrInput::occlusion` to `diffuse_occlusion`, and added `specular_occlus
 
 The `TextureAtlas` asset that previously contained both the atlas layout and image handle has been renamed to `TextureAtlasLayout` that only contains the layout now. A separate `Handle<Image>`gotten through either `SpriteSheetBundle::texture` or `AtlasImageBundle::image` replaces the prior image handle functionality of `TextureAtlasLayout`.
 
-`TextureAtlasSprite` was removed and replaced by a new component, `TextureAtlas`, which now holds the atlas index and is a direct component of `SpriteSheetBundle` replacing the `Handle<TextureAtlasLayout>` from before. The `Sprite` component can be used for `flip_x`, `flip_y`, `custom_size`, `anchor`, and `color` and replaces `TextureAtlasSprite` in `SpriteSheetBundle`.
+`TextureAtlasSprite` was removed and replaced by a new component, `TextureAtlas`, which now holds the atlas index and is a direct component of `SpriteSheetBundle` replacing the `Handle<TextureAtlas>` from before (the handle contained the asset now named `TextureAtlasLayout`, not the component). The `Sprite` component can be used for `flip_x`, `flip_y`, `custom_size`, `anchor`, and `color` and replaces `TextureAtlasSprite` in `SpriteSheetBundle`.
 
 - Sprites
 

--- a/content/learn/migration-guides/0.12-to-0.13.md
+++ b/content/learn/migration-guides/0.12-to-0.13.md
@@ -959,7 +959,8 @@ fn animate_sprite(
 +   for (indices, mut timer, mut atlas) in &mut query {
         timer.tick(time.delta());
         if timer.just_finished() {
-            atlas.index = if atlas.index == indices.last {
+-           sprite.index = if sprite.index == indices.last {
++           atlas.index = if atlas.index == indices.last {
                 indices.first
             } else {
 -               sprite.index + 1

--- a/content/learn/migration-guides/0.12-to-0.13.md
+++ b/content/learn/migration-guides/0.12-to-0.13.md
@@ -888,7 +888,7 @@ The `TextureAtlas` asset that previously contained both the atlas layout and ima
 
 `TextureAtlasLayout::from_grid` no longer takes a `Handle<Image>` parameter.
 
-`TextureAtlasBuilder::finish` now returns a `Result<(TextureAtlasLayout, Handle<Image>), _>`.
+`TextureAtlasBuilder::finish` now returns a `Result<(TextureAtlasLayout, Image), TextureAtlasBuilderError>`.
 
 `UiAtlasImage` was removed. The atlas bundle is now identical to `ImageBundle` with an additional `TextureAtlas`.
 

--- a/content/learn/migration-guides/0.12-to-0.13.md
+++ b/content/learn/migration-guides/0.12-to-0.13.md
@@ -945,6 +945,7 @@ fn my_system(
 ```
 
 - Queries (taken from the [sprite sheet example](https://bevyengine.org/examples/2D%20Rendering/sprite-sheet/))
+
 ```diff
 fn animate_sprite(
     time: Res<Time>,

--- a/content/learn/migration-guides/0.12-to-0.13.md
+++ b/content/learn/migration-guides/0.12-to-0.13.md
@@ -890,7 +890,7 @@ The `TextureAtlas` asset that previously contained both the atlas layout and ima
 
 `TextureAtlasBuilder::finish` now returns a `Result<(TextureAtlasLayout, Image), TextureAtlasBuilderError>`.
 
-`UiAtlasImage` was removed. The atlas bundle is now identical to `ImageBundle` with an additional `TextureAtlas`.
+`UiAtlasImage` was removed. The `AtlasImageBundle` is now identical to `ImageBundle` with an additional `TextureAtlas`.
 
 - Sprites
 

--- a/content/learn/migration-guides/0.12-to-0.13.md
+++ b/content/learn/migration-guides/0.12-to-0.13.md
@@ -878,9 +878,11 @@ Renamed `PbrInput::occlusion` to `diffuse_occlusion`, and added `specular_occlus
     <div class="migration-guide-area-tag">Rendering</div>
 </div>
 
-The `TextureAtlas` asset that previously contained both the atlas layout and image handle has been renamed to `TextureAtlasLayout` that only contains the layout now. A separate `Handle<Image>`gotten through either `SpriteSheetBundle::texture` or `AtlasImageBundle::image` replaces the prior image handle functionality of `TextureAtlasLayout`.
+The `TextureAtlas` asset that previously contained both the atlas layout and image handle was renamed to `TextureAtlasLayout` with the image handle portion moved to a separate `Handle<Image>` available from `SpriteSheetBundle::texture` or `AtlasImageBundle::image`.
 
-`TextureAtlasSprite` was removed and replaced by a new component, `TextureAtlas`, which now holds the atlas index and is a direct component of `SpriteSheetBundle` replacing the `Handle<TextureAtlas>` from before (the handle contained the asset now named `TextureAtlasLayout`, not the component). The `Sprite` component can be used for `flip_x`, `flip_y`, `custom_size`, `anchor`, and `color` and replaces `TextureAtlasSprite` in `SpriteSheetBundle`.
+`TextureAtlasSprite` was removed and replaced by a new component, `TextureAtlas`, which now holds the atlas index. The `Sprite` component can be used for `flip_x`, `flip_y`, `custom_size`, `anchor`, and `color`.
+
+`SpriteSheetBundle` now uses a `Sprite` instead of a `TextureAtlasSprite` component and a `TextureAtlas` component instead of a `Handle<TextureAtlaslayout>`.
 
 - Sprites
 


### PR DESCRIPTION
Clarifies the `Texture Atlas rework` migration guide. Uses @rparrett's [migration guide notes](https://gist.github.com/rparrett/508035fa19d3324db0adf8e509e7affd#httpsgithubcombevyenginebevypull10099) and https://github.com/bevyengine/bevy/pull/5103 's change log as a base. 

Resolves #1025 