### PR TITLE
0.13 migration: Remove section for change of type not present in 0.12

### DIFF
--- a/content/learn/migration-guides/0.12-to-0.13.md
+++ b/content/learn/migration-guides/0.12-to-0.13.md
@@ -1047,17 +1047,6 @@ The trait `GetBatchData` no longer hold associated type `Data` and `Filter`
 
 It just means that the program didn’t properly cleanup their registry keys on an update/uninstall, and vulkan uses those keys to load validation layers. The fix is to [backup your registry](https://support.microsoft.com/en-us/topic/how-to-back-up-and-restore-the-registry-in-windows-855140ad-e318-2a13-2829-d428a2ab0692#ID0EBD=Windows_11), then remove the offending keys in `"Computer\HKEY_LOCAL_MACHINE\SOFTWARE\Khronos\Vulkan\ImplicitLayers"`.
 
-### [RenderAssetPersistencePolicy → RenderAssetUsages](https://github.com/bevyengine/bevy/pull/11399)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">Rendering</div>
-</div>
-
-- `RenderAssetPersistencePolicy::Keep` → `RenderAssetUsages::MAIN_WORLD | RenderAssetUsages::RENDER_WORLD` (or `RenderAssetUsages::default()`)
-- `RenderAssetPersistencePolicy::Unload` → `RenderAssetUsages::RENDER_WORLD`
-- For types implementing the `RenderAsset` trait, change `fn persistence_policy(&self) -> RenderAssetPersistencePolicy` to `fn asset_usage(&self) -> RenderAssetUsages`.
-- Change any references to `cpu_persistent_access` (`RenderAssetPersistencePolicy`) to `asset_usage` (`RenderAssetUsage`). This applies to `Image`, `Mesh`, and a few other types.
-
 ### [RenderGraph Labelization](https://github.com/bevyengine/bevy/pull/10644)
 
 <div class="migration-guide-area-tags">


### PR DESCRIPTION
`RenderAssetPersistencePolicy` didn't exist in 0.12, so we don't need to tell users how to migrate it.

The changes described in this section were already applied to the section for the PR that introduced the type in #991.