### PR TITLE
0.13 Migration: Fix formatting of "simplify conditions" section

### DIFF
--- a/content/learn/migration-guides/0.12-to-0.13.md
+++ b/content/learn/migration-guides/0.12-to-0.13.md
@@ -418,13 +418,15 @@ parent.add_command(move |world: &mut World| {
     <div class="migration-guide-area-tag">ECS</div>
 </div>
 
-- resource_exists<T>() -> resource_exists<T>
-- resource_added<T>() -> resource_added<T>
-- resource_changed<T>() -> resource_changed<T>
-- resource_exists_and_changed<T>() -> resource_exists_and_changed<T>
-- state_exists<S: States>() -> state_exists<S: States>
-- state_changed<S: States>() -> state_changed<S: States>
-- any_with_component<T: Component>() -> any_with_component<T: Component>
+Some common run conditions that were previously closures and needed to be called are now just systems. Remove the parentheses.
+
+- `resource_exists<T>()` -> `resource_exists<T>`
+- `resource_added<T>()` -> `resource_added<T>`
+- `resource_changed<T>()` -> `resource_changed<T>`
+- `resource_exists_and_changed<T>()` -> `resource_exists_and_changed<T>`
+- `state_exists<S: States>()` -> `state_exists<S: States>`
+- `state_changed<S: States>()` -> `state_changed<S: States>`
+- `any_with_component<T: Component>()` -> `any_with_component<T: Component>`
 
 ### [refactor: Simplify lifetimes for `Commands` and related types](https://github.com/bevyengine/bevy/pull/11445)
 


### PR DESCRIPTION
The angle brackets in this section were being treated as html and were not rendered correctly.