### PR TITLE
Combine `Change light defaults & fix light examples` migration guide with `New Exposure and Lighting Defaults (and calibrate examples) `

### DIFF
--- a/content/learn/migration-guides/0.12-to-0.13.md
+++ b/content/learn/migration-guides/0.12-to-0.13.md
@@ -1232,19 +1232,6 @@ Some render graph and Node related types and methods now have additional lifetim
 
   For efficiency reasons, some meshes in the render world may not have corresponding `Entity` IDs anymore. As a result, the `entity` parameter to `RenderCommand::render()` is now wrapped in an `Option`. Custom rendering code may need to be updated to handle the case in which no `Entity` exists for an object that is to be rendered.
 
-### [Change light defaults & fix light examples](https://github.com/bevyengine/bevy/pull/11581)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">Rendering</div>
-</div>
-
-Many default lighting values were changed:
-
-- `PointLight`'s default intensity is now 2000.0
-- `SpotLight`'s default intensity is now 2000.0
-- `DirectionalLight`'s default illuminance is now light_consts::lux::OVERCAST_DAY (1000.)
-- `AmbientLight`'s default brightness is now 20.0
-
 ### [New Exposure and Lighting Defaults (and calibrate examples)](https://github.com/bevyengine/bevy/pull/11868)
 
 <div class="migration-guide-area-tags">
@@ -1252,6 +1239,13 @@ Many default lighting values were changed:
 </div>
 
 The increased `Exposure::ev100` means that all existing 3D lighting will need to be adjusted to match (DirectionalLights, PointLights,  SpotLights, EnvironmentMapLights, etc). Or alternatively, you can adjust the `Exposure::ev100` on your cameras to work nicely with your current lighting values. If you are currently relying on default intensity values, you might need to change the intensity to achieve the same effect. Note that in Bevy 0.12, point/spot lights had a different hard coded ev100 value than directional lights. In Bevy 0.13, they use the same ev100, so if you have both in your scene, the _scale_ between these light types has changed and you will likely need to adjust one or both of them.
+
+Many default lighting values were changed:
+
+- `PointLight`'s default intensity is now `1_000_000.0`
+- `SpotLight`'s default intensity is now `1_000_000.0`
+- `DirectionalLight`'s default illuminance is now light_consts::lux::AMBIENT_DAYLIGHT (intensity: `10_000.`)
+- `AmbientLight`'s default brightness is now `80.0`
 
 ### [Unload render assets from RAM](https://github.com/bevyengine/bevy/pull/10520)
 

--- a/content/learn/migration-guides/0.12-to-0.13.md
+++ b/content/learn/migration-guides/0.12-to-0.13.md
@@ -1244,7 +1244,7 @@ Many default lighting values were changed:
 
 - `PointLight`'s default intensity is now `1_000_000.0`
 - `SpotLight`'s default intensity is now `1_000_000.0`
-- `DirectionalLight`'s default illuminance is now light_consts::lux::AMBIENT_DAYLIGHT (intensity: `10_000.`)
+- `DirectionalLight`'s default illuminance is now light_consts::lux::AMBIENT_DAYLIGHT (`10_000.`)
 - `AmbientLight`'s default brightness is now `80.0`
 
 ### [Unload render assets from RAM](https://github.com/bevyengine/bevy/pull/10520)


### PR DESCRIPTION
This takes the statement of default values from the first section and adds them with updated values to the second section.

Fixes #1034 