### PR TITLE
0.13 migration: Remove name serialization section

### DIFF
--- a/content/learn/migration-guides/0.12-to-0.13.md
+++ b/content/learn/migration-guides/0.12-to-0.13.md
@@ -746,14 +746,6 @@ If you were making use `collide_aabb::Collision`, see the new `collide_with_side
 - Users of `#[reflect(Component)]` and `#[reflect(Bundle)]` may now want to also add `FromWorld` to the list of reflected traits in case their `FromReflect` implementation may fail.
 - Users of `ReflectComponent` will now need to pass a `&TypeRegistry` to its `insert`, `apply_or_insert` and `copy` methods.
 
-### [Fix reflected serialization/deserialization on `Name` component](https://github.com/bevyengine/bevy/pull/11447)
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">Reflection</div>
-</div>
-
-Existing scene files containing the former (incorrect) serialization of the `Name` component will require patching. Search for `bevy_core::name::Name`, and replace the following structure `( "name": "My Entity Name", "hash": ... )` with just a string: `"My Entity Name"`.
-
 ### [Remove TypeUuid](https://github.com/bevyengine/bevy/pull/11497)
 
 <div class="migration-guide-area-tags">


### PR DESCRIPTION
This migration isn't required, and following it would break your scenes.

Fixes #1030