### PR TITLE
0.13 migration: Add note about `new_absolute` and `new_relative` being removed

### DIFF
--- a/content/learn/migration-guides/0.12-to-0.13.md
+++ b/content/learn/migration-guides/0.12-to-0.13.md
@@ -110,7 +110,7 @@ This means users who want to migrate their .meta files will have to add the `inc
     <div class="migration-guide-area-tag">Audio</div>
 </div>
 
-The option to ignore the global volume using `Volume::Absolute` has been removed and `Volume` now stores the volume level directly, removing the need for the `VolumeLevel` struct.
+The option to ignore the global volume using `Volume::Absolute` has been removed and [`Volume`](https://docs.rs/bevy/0.13.0/bevy/audio/struct.Volume.html) now stores the volume level directly, removing the need for the `VolumeLevel` struct.
 
 `Volume::new_absolute` and `Volume::new_relative` were removed. Use `Volume::new(0.5)`.
 

--- a/content/learn/migration-guides/0.12-to-0.13.md
+++ b/content/learn/migration-guides/0.12-to-0.13.md
@@ -115,6 +115,7 @@ The option to ignore the global volume using `Volume::Absolute` has been removed
 `Volume::new_absolute` and `Volume::new_relative` were removed. Use `Volume::new(0.5)`.
 
 [`Volume`]: https://docs.rs/bevy/0.13.0/bevy/audio/struct.Volume.html
+
 ### [Optional override for global spatial scale](https://github.com/bevyengine/bevy/pull/10419)
 
 <div class="migration-guide-area-tags">

--- a/content/learn/migration-guides/0.12-to-0.13.md
+++ b/content/learn/migration-guides/0.12-to-0.13.md
@@ -112,6 +112,8 @@ This means users who want to migrate their .meta files will have to add the `inc
 
 The option to ignore the global volume using `Volume::Absolute` has been removed and `Volume` now stores the volume level directly, removing the need for the `VolumeLevel` struct.
 
+`Volume::new_absolute` and `Volume::new_relative` were removed. Use `Volume::new(0.5)`.
+
 ### [Optional override for global spatial scale](https://github.com/bevyengine/bevy/pull/10419)
 
 <div class="migration-guide-area-tags">

--- a/content/learn/migration-guides/0.12-to-0.13.md
+++ b/content/learn/migration-guides/0.12-to-0.13.md
@@ -110,10 +110,11 @@ This means users who want to migrate their .meta files will have to add the `inc
     <div class="migration-guide-area-tag">Audio</div>
 </div>
 
-The option to ignore the global volume using `Volume::Absolute` has been removed and [`Volume`](https://docs.rs/bevy/0.13.0/bevy/audio/struct.Volume.html) now stores the volume level directly, removing the need for the `VolumeLevel` struct.
+The option to ignore the global volume using `Volume::Absolute` has been removed and [`Volume`] now stores the volume level directly, removing the need for the `VolumeLevel` struct.
 
 `Volume::new_absolute` and `Volume::new_relative` were removed. Use `Volume::new(0.5)`.
 
+[`Volume`]: https://docs.rs/bevy/0.13.0/bevy/audio/struct.Volume.html
 ### [Optional override for global spatial scale](https://github.com/bevyengine/bevy/pull/10419)
 
 <div class="migration-guide-area-tags">


### PR DESCRIPTION
This is somewhat implied, but I would have having this all spelled out would have saved me a moment.