### PR TITLE
AtlasImageBundle field name typo in migration guide

### DIFF
--- a/content/learn/migration-guides/0.12-to-0.13.md
+++ b/content/learn/migration-guides/0.12-to-0.13.md
@@ -938,7 +938,7 @@ fn my_system(
 -           flip_y: false,
 -       },
 -      texture_atlas: atlas_handle,
-+      atlas: TextureAtlas {
++      texture_atlas: TextureAtlas {
 +         layout: layout_handle,
 +         index: 0
 +      },


### PR DESCRIPTION
The [AtlasImageBundle struct](https://docs.rs/bevy/latest/bevy/prelude/struct.AtlasImageBundle.html#structfield.texture_atlas) does not have a `atlas` field of type `TextureAtlas`, it does however have the `texture_atlas` field.
I think the migration guide did a copy/paste from the [SpriteSheetBundle](https://docs.rs/bevy/latest/bevy/prelude/struct.SpriteSheetBundle.html#structfield.atlas) guide, where the field was renamed to `atlas`