### PR TITLE
0.13 migration: Use clippy-approved ReceivedCharacter advice

### DIFF
--- a/content/learn/migration-guides/0.12-to-0.13.md
+++ b/content/learn/migration-guides/0.12-to-0.13.md
@@ -1450,6 +1450,19 @@ Common examples of the updated variants are as follows:
 
 See the relevant [documentation](https://docs.rs/bevy/0.13.0/bevy/input/keyboard/enum.KeyCode.html) for more information.
 
+#### ReceivedCharacter changes
+
+The `char` field of [`ReceivedCharacter`] is now a [`SmolStr`], and _could_ contain multiple characters. See these [winit docs] for details.
+
+A simple workaround if you need a `char` is to call `.chars().last()`.
+
+It's now possible to use [`KeyEvent::logical_key`]'s `Character` variant instead if you need consistent cross-platform behavior and/or a unified event stream with non-character events.
+
+[winit docs]: https://docs.rs/winit/0.29.10/winit/event/struct.KeyEvent.html#structfield.text
+[`SmolStr`]: https://docs.rs/smol_str/0.2.1/smol_str/struct.SmolStr.html
+[`ReceivedCharacter`]: https://docs.rs/bevy/latest/bevy/prelude/struct.ReceivedCharacter.html
+[`KeyEvent::logical_key`]: https://docs.rs/bevy/latest/bevy/input/keyboard/struct.KeyboardInput.html#structfield.logical_key
+
 ### [Remove CanvasParentResizePlugin](https://github.com/bevyengine/bevy/pull/11057)
 
 <div class="migration-guide-area-tags">
@@ -1487,14 +1500,6 @@ Consider changing usage:
 </div>
 
 `Window` has a new [`name`](https://docs.rs/bevy/latest/bevy/prelude/struct.Window.html#structfield.name) field for specifying the "window class name." If you don't need this, set it to `None`.
-
-### [ReceivedCharacter.char is now SmolStr instead of char]
-
-<div class="migration-guide-area-tags">
-    <div class="migration-guide-area-tag">Windowing</div>
-</div>
-
-To restore the previous behavior, use `.chars().nth(0)`
 
 ### [delete methods deprecated in 0.12](https://github.com/bevyengine/bevy/pull/10693)
 


### PR DESCRIPTION
And other improvements. I went in there to fix the clippy thing and things sort of snowballed.

- Moved the text to a subsection of the PR that caused the breakage
- Added some context about why it's not a `char` and what else might be in there.
- Added a sentence about a new alternative to `ReceivedCharacter` that folks may want to use instead.
- Modified the previous advice so that it is Clippy-approved.

  The previous advice would result in:
  
  ```
  warning: called `.nth(0)` on a `std::iter::Iterator`, when `.next()` is equivalent
     --> src/typing.rs:126:30
      |
  126 |             let Some(char) = event.char.chars().nth(0) else {
      |                              ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try calling `.next()` instead of `.nth(0)`: `event.char.chars().next()`
      |
      = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#iter_nth_zero
      = note: `#[warn(clippy::iter_nth_zero)]` on by default
  ```

  Clippy suggests `.next()`, but based on the [winit docs](https://docs.rs/winit/0.29.10/winit/event/struct.KeyEvent.html#structfield.text), it seems like `.last()` might be the way to go to me. In the cases where there's more than one char, folks probably want the last one.

Some of this stuff should probably make its way into Bevy's docs or a bevy issue.

