### PR TITLE
Add `pa11y-ci` for accesibility linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,3 +239,57 @@ jobs:
           BUILD_DIR: .
           BUILD_ONLY: true
           TOKEN: fake-secret
+
+  pa11y:
+    runs-on: ubuntu-latest
+    needs: [super-linter, test-code-examples, lint-tools, check-hide-lines, generate-assets, generate-errors, generate-wasm-examples, generate-community]
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: generated-assets
+          path: content/assets
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: generated-errors
+          path: content/learn/errors
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: generated-wasm-examples
+          path: content/examples
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: generated-wasm-examples-webgpu
+          path: content/examples-webgpu
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: generated-community
+          path: content/community/people
+
+      - name: Install NPM
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Install Google Chrome
+        id: setup-chrome
+        uses: browser-actions/setup-chrome@v1
+        with:
+          chrome-version: stable
+
+      - name: Install Pa11y-CI
+        runs: npm install pa11y-ci
+
+      - name: Create Pa11y-CI Config
+        uses: finnp/create-file-action@master
+        env:
+          FILE_NAME: ".pa11yci"
+          FILE_DATA: "{\n  \"defaults\": {\n    \"chromeLaunchConfig\": {\n      \"executablePath\": \"${{ steps.setup-chrome.outputs.chrome-path }} \"\n    }\n  }\n}"
+
+      - name: Run Pa11y-CI
+        runs: zola serve & npx pa11y-ci --sitemap http://127.0.0.1:1111/sitemap.xml


### PR DESCRIPTION
This adds a new CI job for `pa11y-ci` in order to automate checking if the site, or PR to the site, satisfies basic accessibility guidelines.

Closes #396 