### PR TITLE
Improve `generate_wasm_examples.sh`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,16 +137,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            generate-wasm-examples/bevy/target/
-            content/examples/**/*.wasm
-          key: ${{ runner.os }}-generate-wasm-examples-${{ hashFiles('generate-wasm-examples/bevy/Cargo.toml') }}
+      # - uses: actions/cache@v4
+      #   with:
+      #     path: |
+      #       ~/.cargo/bin/
+      #       ~/.cargo/registry/index/
+      #       ~/.cargo/registry/cache/
+      #       ~/.cargo/git/db/
+      #       generate-wasm-examples/bevy/target/
+      #       content/examples/**/*.wasm
+      #     key: ${{ runner.os }}-generate-wasm-examples-${{ hashFiles('generate-wasm-examples/bevy/Cargo.toml') }}
 
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,17 +137,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # - uses: actions/cache@v4
-      #   with:
-      #     path: |
-      #       ~/.cargo/bin/
-      #       ~/.cargo/registry/index/
-      #       ~/.cargo/registry/cache/
-      #       ~/.cargo/git/db/
-      #       generate-wasm-examples/bevy/target/
-      #       content/examples/**/*.wasm
-      #     key: ${{ runner.os }}-generate-wasm-examples-${{ hashFiles('generate-wasm-examples/bevy/Cargo.toml') }}
-
       - uses: dtolnay/rust-toolchain@stable
         with:
           target: wasm32-unknown-unknown

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,11 +137,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: "Clone Bevy"
-        run: >
-          cd generate-wasm-examples &&
-          ./clone_bevy.sh
-
       - uses: actions/cache@v4
         with:
           path: |

--- a/generate-wasm-examples/clone_bevy.sh
+++ b/generate-wasm-examples/clone_bevy.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-# Switch to script's directory, letting it be called from any folder.
-cd $(dirname $0)
-
-git clone --depth=1 --branch=latest https://github.com/bevyengine/bevy bevy

--- a/generate-wasm-examples/generate_wasm_examples.sh
+++ b/generate-wasm-examples/generate_wasm_examples.sh
@@ -12,7 +12,6 @@ if [[ -d bevy ]]; then
     cd bevy
 
     # Attempts to fetch the latest commits, which should only happen every Bevy release.
-    git switch latest
     git pull --depth=1
 else
     echo Bevy folder does not exist, cloning repository.

--- a/generate-wasm-examples/generate_wasm_examples.sh
+++ b/generate-wasm-examples/generate_wasm_examples.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 echo Generating WASM example list...
 

--- a/generate-wasm-examples/generate_wasm_examples.sh
+++ b/generate-wasm-examples/generate_wasm_examples.sh
@@ -12,6 +12,7 @@ if [[ -d bevy ]]; then
     cd bevy
 
     # Attempts to fetch the latest commits, which should only happen every Bevy release.
+    git switch latest
     git pull --depth=1
 else
     echo Bevy folder does not exist, cloning repository.

--- a/generate-wasm-examples/generate_wasm_examples.sh
+++ b/generate-wasm-examples/generate_wasm_examples.sh
@@ -1,26 +1,39 @@
 #!/bin/sh
 
+echo Generating WASM example list...
+
 # Switch to script's directory, letting it be called from any folder.
 cd $(dirname $0)
 
-./clone_bevy.sh
+# If Bevy folder already exists, pull the latest changes.
+if [[ -d bevy ]]; then
+    echo Bevy folder already exists, attempting to fetch latest changes.
 
-# temporary: fetch tools from main branch
-git clone --depth=1 https://github.com/bevyengine/bevy bevy-tools
+    cd bevy
 
-rm -rf bevy/tools
-cp -r bevy-tools/tools bevy
-rm -rf bevy-tools
-cd bevy
+    # Attempts to fetch the latest commits, which should only happen every Bevy release.
+    git pull --depth=1
+else
+    echo Bevy folder does not exist, cloning repository.
 
-cargo run -p example-showcase -- build-website-list --content-folder content --api webgl2
-mv content ../../content/examples
+    # Clone Bevy's latest branch from scratch, only downloading the latest commit.
+    git clone --depth=1 --branch=latest https://github.com/bevyengine/bevy bevy
 
-rm -rf content
+    cd bevy
+fi
 
-cargo run -p example-showcase -- build-website-list --content-folder content --api webgpu
-mv content ../../content/examples-webgpu
+# Build WebGL2 example list.
+rm -rf ../../content/examples
+cargo run -p example-showcase -- build-website-list --content-folder ../../content/examples --api webgl2
 
-# remove markdown files from assets so that they don't get picked up by Zola
+# Build WebGPU example list.
+rm -rf ../../content/examples-webgpu
+cargo run -p example-showcase -- build-website-list --content-folder ../../content/examples-webgpu --api webgpu
+
+# Remove Markdown files from assets so that they don't get picked up by Zola.
 find assets -type f -name '*.md' -exec rm {} +
+
+# Copy remaining assets to examples folder.
 cp -r assets/ ../../static/assets/examples/
+
+echo Finished generating WASM example list! \(WebGL2 + WebGPU\)

--- a/generate-wasm-examples/generate_wasm_examples.sh
+++ b/generate-wasm-examples/generate_wasm_examples.sh
@@ -24,11 +24,17 @@ fi
 
 # Build WebGL2 example list.
 rm -rf ../../content/examples
-cargo run -p example-showcase -- build-website-list --content-folder ../../content/examples --api webgl2
+# HACK: build in ./content before moving examples to correct folder in order for `extra.code_path`
+# to be formatted correctly.
+cargo run -p example-showcase -- build-website-list --content-folder content --api webgl2
+mv content ../../content/examples
 
 # Build WebGPU example list.
 rm -rf ../../content/examples-webgpu
-cargo run -p example-showcase -- build-website-list --content-folder ../../content/examples-webgpu --api webgpu
+# HACK: build in ./content before moving examples to correct folder in order for `extra.code_path`
+# to be formatted correctly.
+cargo run -p example-showcase -- build-website-list --content-folder content --api webgpu
+mv content ../../content/examples-webgpu
 
 # Remove Markdown files from assets so that they don't get picked up by Zola.
 find assets -type f -name '*.md' -exec rm {} +


### PR DESCRIPTION
There are several small things that can be done to improve `generate_wasm_examples.sh`, the main entrypoint for generating the WebGL2 and WebGPU examples pages.

### Summary

- Adds more logging about what the script is doing.
  - There are now a few `echo` commands scattered throughout the script.
- Adds comments and update existing ones.
- Deletes `clone_bevy.sh`, merging its contents into the main script.
  - `clone_bevy.sh` was likely created so that multiple scripts could all use it for shared functionality. It was only used in CI, so I merged the two scripts into one and updated Github Actions.
- Fetches latest commit if Bevy was already cloned.
  - This is primarily for local copies. If you have the `bevy` folder cloned already, it will try to fetch the latest commits. Since it targets the `latest` branch, this will only update if a new Bevy release is published.
- Deletes built example folders if they already exist.
  - `rm -rf ../../content/examples`. Without this being called, files could be leftover from old builds.
- Removes temporary main branch tools patch.
  - As commented by @mockersf, this is [no longer necessary](https://github.com/bevyengine/bevy-website/pull/1017#issuecomment-1951464244).
- ~~Removes unecessary `mv content` call because `cargo run` supports `--content-folder`.~~
  - ~~There's no point in build the examples to a specific folder if you're going to immediately `mv` it somewhere else. This instead directly builds it to the destination folder.~~
  - This is needed due to a quirk in `showcase-examples`. See d1043083b546d638764f66184542636721a624a1.
- Removes caching of `generate-wasm-examples` in CI.
  - `generate-wasm-examples` only takes 30 seconds, as compared to `generate-assets` that takes 7 minutes. Caching isn't saving time because other jobs take longer.
  - A cache miss adds about 10 seconds to the runtime, and it happens [relatively frequently](https://github.com/bevyengine/bevy-website/actions/caches?query=key%3ALinux-generate-wasm+).
  - A cache hit has similar performance to generating the examples list from scratch, especially when the cache is outdated.
  - Caching also makes it harder to diagnose CI issues, especially when code that generates the cached content gets changed. I don't think it's worth keeping in this specific circumstance.

You may find [this website](https://devhints.io/bash) useful for Bash scripting, especially the odd `if` / `else` syntax. :)