### PR TITLE
Add READMEs to `code-validation` and `generate-assets`

### DIFF
--- a/code-validation/README.md
+++ b/code-validation/README.md
@@ -1,0 +1,81 @@
+# Code Validation
+
+This tool checks that all code examples on the website compile and execute correctly through the use of Rust's [documentation tests].
+
+[documentation tests]: https://doc.rust-lang.org/rustdoc/write-documentation/documentation-tests.html
+
+To run code validation, you can simply run `cargo test`:
+
+```shell
+cargo test -p code-validation
+```
+
+## Validating New Pages
+
+Anytime a new page is added to the website with code examples, it should be added here as well. Each page is represented by a module (`mod`) whose documentation comments are the page itself.
+
+```rust
+mod learn {
+    // Include the entire contents of the getting started section as this module's documentation.
+    #[doc = include_str!("../../content/learn/quick-start/_index.md")]
+    mod quick_start {
+        // This is a page.
+        #[doc = include_str!("../../content/learn/quick-start/introduction.md")]
+        mod introduction {}
+
+        // This is a section with subpages.
+        #[doc = include_str!("../../content/learn/quick-start/getting-started/_index.md")]
+        mod getting_started {
+            // ...
+        }
+    }
+
+    // ...
+}
+```
+
+When `cargo test` is run, Cargo automatically loads the specified Markdown files and runs all Rust code blocks. Be warned Cargo will assume that a code block without a language attribute is Rust by default.
+
+`````markdown
+This is run:
+
+```rust
+assert!(true);
+```
+
+So is this:
+
+```
+assert_eq!(3, 1 + 2);
+```
+
+This is not:
+
+```text
+Unoxidized text...
+```
+`````
+
+## Ignoring Examples
+
+If there is a code example that should not be validated, you can add the `ignore` attribute.
+
+`````markdown
+```ignore
+const COMPILE_ERROR: u32 = false;
+```
+`````
+
+If there is a code example that should not be run, but might benefit from being compiled, you can add the `no_run` attribute.
+
+`````markdown
+```no_run
+loop {
+    // An infinite loop! Oh no...
+}
+```
+`````
+
+For a full list of attributes, see the [rustdoc book].
+
+[rustdoc book]: https://doc.rust-lang.org/rustdoc/write-documentation/documentation-tests.html#attributes

--- a/generate-assets/README.md
+++ b/generate-assets/README.md
@@ -11,4 +11,4 @@ To generate the assets page, run `generate_assets.sh`:
 ./generate_assets.sh
 ```
 
-The shell script clones [`bevy-assets`] and runs the Rust program in this directory, `generate-assets`. `generate-assets` reads the TOML file of each asset and downloads associated information from crates.io, Github, and Gitlab. When the program finishes, it will populate the `content/assets` folder. It can also be used to validate the TOML files, as used in [`bevy-assets`]'s CI.
+The shell script clones [`bevy-assets`] and runs the `generate` binary. `generate` reads the TOML file of each asset and downloads associated information from crates.io, Github, and Gitlab. When the program finishes, it will populate the `content/assets` folder. It can also be used to validate the TOML files, as used in [`bevy-assets`]'s CI, by running the `validate` binary.

--- a/generate-assets/README.md
+++ b/generate-assets/README.md
@@ -1,0 +1,14 @@
+# Bevy-Assets Generation
+
+This tool generates the [assets page] using the content in [`bevy-assets`].
+
+[assets page]: https://bevyengine.org/assets/
+[`bevy-assets`]: https://github.com/bevyengine/bevy-assets
+
+To generate the assets page, run `generate_assets.sh`:
+
+```shell
+generate_assets.sh
+```
+
+The shell script clones [`bevy-assets`] and runs the Rust program in this directory, `generate-assets`. `generate-assets` reads the TOML file of each asset and downloads associated information from crates.io, Github, and Gitlab. When the program finishes, it will populate the `content/assets` folder. It can also be used to validate the TOML files, as used in [`bevy-assets`]'s CI.

--- a/generate-assets/README.md
+++ b/generate-assets/README.md
@@ -8,7 +8,7 @@ This tool generates the [assets page] using the content in [`bevy-assets`].
 To generate the assets page, run `generate_assets.sh`:
 
 ```shell
-generate_assets.sh
+./generate_assets.sh
 ```
 
 The shell script clones [`bevy-assets`] and runs the Rust program in this directory, `generate-assets`. `generate-assets` reads the TOML file of each asset and downloads associated information from crates.io, Github, and Gitlab. When the program finishes, it will populate the `content/assets` folder. It can also be used to validate the TOML files, as used in [`bevy-assets`]'s CI.

--- a/write-rustdoc-hide-lines/README.md
+++ b/write-rustdoc-hide-lines/README.md
@@ -1,4 +1,4 @@
-# Write `rustdoc` `hide_lines` annotations
+# Write `rustdoc` `hide_lines` Annotations
 
 <!-- markdownlint-disable-next-line MD038 -->
 This utility recursively iterates over all Markdown files in a given folder. It will update the [`hide_lines` Zola annotation] on all `rust` and `rs` code blocks to match [rustdoc hidden lines]. It will match all lines that start with `# `. A space after the hashtag is required, or else it would accidentally hide attributes like `#[derive(...)]`. If `hide_lines` is out of date, this tool can automatically update it.


### PR DESCRIPTION
Part of #1059.

This adds a `README.md` file for the `code-validation` and `generate-assets` tools. It also partially modifies `write-rustdoc-hide-lines`'s `README.md` for consistency.