### PR TITLE
0.13 migration: remove leftover `all(...)` `cfg` attribute

### DIFF
--- a/content/learn/migration-guides/0.12-to-0.13.md
+++ b/content/learn/migration-guides/0.12-to-0.13.md
@@ -577,7 +577,7 @@ Calls to `fn map_entities(&mut self, entity_mapper: &mut EntityMapper)` need to 
 The `PipelinedRendering` plugin is no longer exported on wasm. If you are including it in your wasm builds you should remove it.
 
 ```rust
-#[cfg(all(not(target_arch = "wasm32"))]
+#[cfg(not(target_arch = "wasm32"))]
 app.add_plugins(bevy_render::pipelined_rendering::PipelinedRenderingPlugin);
 ```
 


### PR DESCRIPTION
```rust
#[cfg(all(not(target_arch = "wasm32")))]
app.add_plugins(bevy_render::pipelined_rendering::PipelinedRenderingPlugin);
```

There's no point surrounding a single `cfg` boolean with `all(...)`, so this PR removes it.