### PR TITLE
Increase CI parallelism

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
       - 'trying'
 
 jobs:
+  # Lints Markdown and SCSS files
   super-linter:
     runs-on: ubuntu-latest
     steps:
@@ -24,6 +25,7 @@ jobs:
           VALIDATE_EDITORCONFIG: true
           DEFAULT_BRANCH: main
 
+  # Runs the code-validation tool
   test-code-examples:
     runs-on: ubuntu-latest
     steps:
@@ -38,6 +40,7 @@ jobs:
       - name: Build & run doc tests
         run: cd code-validation && cargo test
 
+  # Runs the write-rustdoc-hide-lines tool
   check-hide-lines:
     runs-on: ubuntu-latest
     steps:
@@ -49,6 +52,7 @@ jobs:
       - name: Check hide-lines
         run: cd write-rustdoc-hide-lines && cargo run --release -- check ../content
 
+  # Runs Clippy and rustfmt
   lint-tools:
     runs-on: ubuntu-latest
     steps:
@@ -66,6 +70,7 @@ jobs:
       - name: Check clippy
         run: cargo clippy --workspace -- -Dwarnings
 
+  # Checks for spelling typos
   typos:
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -82,6 +87,7 @@ jobs:
           echo 'if you use VSCode, you can also install `Typos Spell Checker'
           echo 'You can find the extension here: https://marketplace.visualstudio.com/items?itemName=tekumara.typos-vscode'
 
+  # Builds the Bevy Assets page
   generate-assets:
     runs-on: ubuntu-latest
     steps:
@@ -119,6 +125,7 @@ jobs:
           path: content/assets
           retention-days: 1
 
+  # Builds the errors page
   generate-errors:
     runs-on: ubuntu-latest
     steps:
@@ -145,6 +152,7 @@ jobs:
           path: content/learn/errors
           retention-days: 1
 
+  # Builds the list of online WebAssembly examples
   generate-wasm-examples:
     runs-on: ubuntu-latest
     steps:
@@ -187,6 +195,7 @@ jobs:
           path: content/examples-webgpu
           retention-days: 1
 
+  # Builds the list of community members
   generate-community:
     runs-on: ubuntu-latest
     steps:
@@ -213,6 +222,7 @@ jobs:
           path: content/community/people
           retention-days: 1
 
+  # Test builds the website using Zola
   build-website:
     runs-on: ubuntu-latest
     needs: [generate-assets, generate-errors, generate-wasm-examples, generate-community]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,6 @@ jobs:
           echo 'You can find the extension here: https://marketplace.visualstudio.com/items?itemName=tekumara.typos-vscode'
 
   generate-assets:
-    needs: [super-linter, test-code-examples, lint-tools, check-hide-lines]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -121,7 +120,6 @@ jobs:
           retention-days: 1
 
   generate-errors:
-    needs: [super-linter, test-code-examples, lint-tools, check-hide-lines]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -148,7 +146,6 @@ jobs:
           retention-days: 1
 
   generate-wasm-examples:
-    needs: [super-linter, test-code-examples, lint-tools, check-hide-lines]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -191,7 +188,6 @@ jobs:
           retention-days: 1
 
   generate-community:
-    needs: [super-linter, test-code-examples, lint-tools, check-hide-lines]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -219,8 +215,7 @@ jobs:
 
   build-website:
     runs-on: ubuntu-latest
-    needs: [super-linter, test-code-examples, lint-tools, check-hide-lines, generate-assets, generate-errors, generate-wasm-examples, generate-community]
-
+    needs: [generate-assets, generate-errors, generate-wasm-examples, generate-community]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
This change removes the requirement for `super-linter`, `test-code-examples`, `lint-tools`, and `check-hide-lines` to be run before any of the `generate-*` jobs. While those linters are important, they should not prevent the generation examples from starting.

The only job requirement is `build-website`, while requires `generate-*` to ensure the assets, community, and other pages are built correctly.