### PR TITLE
Make demo code consistent with previous tutorial steps

### DIFF
--- a/content/learn/quick-start/getting-started/plugins.md
+++ b/content/learn/quick-start/getting-started/plugins.md
@@ -30,7 +30,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_systems(Startup, add_people)
-        .add_systems(Update, (hello_world, greet_people))
+        .add_systems(Update, (hello_world, (greet_people, update_people).chain()))
         .run();
 }
 ```
@@ -65,7 +65,7 @@ fn main() {
     App::new()
         .add_plugins((DefaultPlugins, HelloPlugin))
         .add_systems(Startup, add_people)
-        .add_systems(Update, (hello_world, greet_people))
+        .add_systems(Update, (hello_world, (greet_people, update_people).chain()))
         .run();
 }
 ```
@@ -77,7 +77,7 @@ Note `add_plugins` can add any number of plugins (or plugin groups like `Default
 impl Plugin for HelloPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(Startup, add_people)
-            .add_systems(Update, (hello_world, greet_people));
+            .add_systems(Update, (hello_world, (greet_people, update_people).chain()));
     }
 }
 

--- a/content/learn/quick-start/getting-started/resources.md
+++ b/content/learn/quick-start/getting-started/resources.md
@@ -67,7 +67,7 @@ impl Plugin for HelloPlugin {
     fn build(&self, app: &mut App) {
         app.insert_resource(GreetTimer(Timer::from_seconds(2.0, TimerMode::Repeating)))
             .add_systems(Startup, add_people)
-            .add_systems(Update, greet_people);
+            .add_systems(Update, (update_people, greet_people).chain());
     }
 }
 ```


### PR DESCRIPTION
The `update_people` related code added in the ECS part of the Getting Started docs was not present in further steps (Plugins and Resources), but no instruction was made to remove it.