### PR TITLE
Sold in MacOS now is MIT licensed

### DIFF
--- a/content/learn/quick-start/getting-started/setup.md
+++ b/content/learn/quick-start/getting-started/setup.md
@@ -177,7 +177,7 @@ Bevy can be built just fine using default configuration on stable Rust. However 
   * **Fedora**: `sudo dnf install mold clang`
   * **Arch**: `sudo pacman -S mold clang`
   * **Windows**: currently not planned for support [See this tracking issue](https://github.com/rui314/mold/issues/1069#issuecomment-1653436823) for more information.
-  * **MacOS**: is available commercially with [sold](https://github.com/bluewhalesystems/sold)
+  * **MacOS**: available as [sold](https://github.com/bluewhalesystems/sold)
 
     You will also need to add the following to your Cargo config at `YOUR_WORKSPACE/.cargo/config.toml`:
 


### PR DESCRIPTION
It would seem that [`sold`](https://github.com/bluewhalesystems/sold?tab=readme-ov-file#sold-linker) is now licensed as MIT, https://github.com/bluewhalesystems/sold/commit/41b49175f58c73dbc0fc769128581de6b981863d