### PR TITLE
Group `typos` with linters in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
           echo 'You can find the extension here: https://marketplace.visualstudio.com/items?itemName=tekumara.typos-vscode'
 
   generate-assets:
-    needs: [mega-linter, test-code-examples, lint-tools, check-hide-lines]
+    needs: [mega-linter, test-code-examples, lint-tools, check-hide-lines, typos]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -119,7 +119,7 @@ jobs:
           retention-days: 1
 
   generate-errors:
-    needs: [mega-linter, test-code-examples, lint-tools, check-hide-lines]
+    needs: [mega-linter, test-code-examples, lint-tools, check-hide-lines, typos]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -146,7 +146,7 @@ jobs:
           retention-days: 1
 
   generate-wasm-examples:
-    needs: [mega-linter, test-code-examples, lint-tools, check-hide-lines]
+    needs: [mega-linter, test-code-examples, lint-tools, check-hide-lines, typos]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -173,7 +173,7 @@ jobs:
           retention-days: 1
 
   generate-community:
-    needs: [mega-linter, test-code-examples, lint-tools, check-hide-lines]
+    needs: [mega-linter, test-code-examples, lint-tools, check-hide-lines, typos]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -201,7 +201,7 @@ jobs:
 
   build-website:
     runs-on: ubuntu-latest
-    needs: [mega-linter, test-code-examples, lint-tools, check-hide-lines, generate-assets, generate-errors, generate-wasm-examples, generate-community]
+    needs: [mega-linter, test-code-examples, lint-tools, check-hide-lines, typos, generate-assets, generate-errors, generate-wasm-examples, generate-community]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
In CI, all of the linters are grouped together and run before any of the `generate-*` jobs, except for typos.

<img width="1074" alt="typos is by itself here" src="https://github.com/bevyengine/bevy-website/assets/59022059/b39a36a4-a09d-4f69-8495-db9b08c74cc6">

Typos was added in #1057. I [originally praised it](https://github.com/bevyengine/bevy-website/pull/1057#pullrequestreview-1901511010) for being separate from the rest of the linters, to increase parallelism. Unfortunately, increasing parallelism is not a viable solution ([as pointed out](https://github.com/bevyengine/bevy-website/pull/1061#issuecomment-1969742951) by mockersf in #1061) because only a limited amount of job runners are allowed per organization. Increasing parallelism for the website would only steal runners from the main Bevy repo, which arguably needs them more.

Since lints should all be run before the longer `generate-*` jobs, this PR adds `typos` to their `needs` attributes. Realistically this change is only visual, because `typos` is the fastest lint we have (most recently finishing in only 10 seconds).