### PR TITLE
Describe the MIT-Apache dual license in the quick start guide.

### DIFF
--- a/content/learn/quick-start/introduction.md
+++ b/content/learn/quick-start/introduction.md
@@ -14,7 +14,7 @@ If you came here because you wanted to learn how to make 2D / 3D games, visualiz
 
 A bevy is a group of birds!
 
-But Bevy is also a refreshingly simple data-driven game engine built in Rust. It is [free and open-source](https://github.com/bevyengine/bevy) forever.
+But Bevy is also a refreshingly simple data-driven game engine built in Rust. It is [free and open-source](https://github.com/bevyengine/bevy) forever under your choice of the MIT or Apache 2.0 licenses.
 
 Bevy has the following design goals:
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,7 +1,7 @@
 {% extends "layouts/base.html" %}
 {% block head_extensions %}
   <meta name="description"
-        content="A refreshingly simple data-driven game engine built in Rust. Free and Open Source Forever!" />
+        content="A refreshingly simple data-driven game engine built in Rust. Free and Open Source Forever Under Your Choice of the MIT or Apache 2.0 Licenses." />
   <link href="https://mastodon.social/@bevy" rel="me" />
 {% endblock head_extensions %}
 {% block content %}
@@ -14,7 +14,7 @@
     <div class="bevy-description">
       A refreshingly simple data-driven game engine built in Rust
       <br />
-      Free and Open Source Forever!
+      Free and Open Source Forever Under Your Choice of the MIT or Apache 2.0 Licenses
       <br />
       <a class="button button--big" href="/learn/quick-start/getting-started/">Get Started</a>
     </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,7 +1,7 @@
 {% extends "layouts/base.html" %}
 {% block head_extensions %}
   <meta name="description"
-        content="A refreshingly simple data-driven game engine built in Rust. Free and Open Source Forever Under Your Choice of the MIT or Apache 2.0 Licenses." />
+        content="A refreshingly simple data-driven game engine built in Rust. Free and Open Source Forever!" />
   <link href="https://mastodon.social/@bevy" rel="me" />
 {% endblock head_extensions %}
 {% block content %}
@@ -14,7 +14,7 @@
     <div class="bevy-description">
       A refreshingly simple data-driven game engine built in Rust
       <br />
-      Free and Open Source Forever Under Your Choice of the MIT or Apache 2.0 Licenses
+      Free and Open Source Forever!
       <br />
       <a class="button button--big" href="/learn/quick-start/getting-started/">Get Started</a>
     </div>


### PR DESCRIPTION
Updates the wording to correspond with current Bevy licensing.

Fixes #190 