### PR TITLE
Cache `generate-assets` output in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,27 +86,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/cache@v4
+      - name: Restore cached assets
+        id: restore-cached-assets
+        uses: actions/cache/restore@v4
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            generate-assets/target/
-          key: ${{ runner.os }}-generate-assets-${{ hashFiles('generate-assets/Cargo.toml') }}
-
-      - name: Get cache key
-        id: cache-key
-        run: echo "key=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
-
-      - name: Get crates.io datadump from cache
-        uses: actions/cache@v4
-        with:
-          path: generate-assets/data
-          key: ${{ runner.os }}-${{ steps.cache-key.outputs.key }}
+          # Must be kept in sync with deploy.yml
+          path: content/assets
+          key: assets-${{ hashFiles('generate-assets/**/*.rs', 'generate-assets/Cargo.toml', 'generate-assets/generate_assets.sh') }}
 
       - name: "Build Bevy Assets"
+        # Only run if no cache was found
+        if: ${{ !steps.restore-cached-assets.outputs.cache-hit }}
         run: >
           cd generate-assets &&
           export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} &&

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Uses the generate-assets cache, which is updated in deploy.yml
       - name: Restore cached assets
         id: restore-cached-assets
         uses: actions/cache/restore@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
       # Uses the generate-assets cache, which is updated in deploy.yml
       - name: Restore cached assets
         # Do not use cache when in merge queue
@@ -95,7 +99,7 @@ jobs:
         with:
           # Must be kept in sync with deploy.yml
           path: content/assets
-          key: assets-${{ hashFiles('generate-assets/**/*.rs', 'generate-assets/Cargo.toml', 'generate-assets/generate_assets.sh') }}
+          key: assets-${{ steps.date.outputs.date }}-${{ hashFiles('generate-assets/**/*.rs', 'generate-assets/Cargo.toml', 'generate-assets/generate_assets.sh') }}
 
       - name: "Build Bevy Assets"
         # Only run if in merge queue or if no cache was found

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,10 +97,10 @@ jobs:
       - name: "Build Bevy Assets"
         # Only run if no cache was found
         if: ${{ !steps.restore-cached-assets.outputs.cache-hit }}
-        run: >
-          cd generate-assets &&
-          export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} &&
-          ./generate_assets.sh
+        working-directory: generate-assets
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./generate_assets.sh
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,8 @@ jobs:
 
       # Uses the generate-assets cache, which is updated in deploy.yml
       - name: Restore cached assets
+        # Do not use cache when in merge queue
+        if: ${{ github.event_name != 'merge_group' }}
         id: restore-cached-assets
         uses: actions/cache/restore@v4
         with:
@@ -96,8 +98,8 @@ jobs:
           key: assets-${{ hashFiles('generate-assets/**/*.rs', 'generate-assets/Cargo.toml', 'generate-assets/generate_assets.sh') }}
 
       - name: "Build Bevy Assets"
-        # Only run if no cache was found
-        if: ${{ !steps.restore-cached-assets.outputs.cache-hit }}
+        # Only run if in merge queue or if no cache was found
+        if: ${{ github.event_name == 'merge_group' || !steps.restore-cached-assets.outputs.cache-hit }}
         working-directory: generate-assets
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Cache multiple crates.io datadump
+        uses: actions/cache@v4
+        with:
+          path: generate-assets/data
+          key: ${{ runner.os }}-${{ steps.date.outputs.date }}
+
       - name: "Build Bevy Assets"
         run: cd generate-assets && ./generate_assets.sh
         env:
@@ -38,10 +48,6 @@ jobs:
           PAGES_BRANCH: gh-pages
           BUILD_DIR: .
           TOKEN: ${{ secrets.CART_PAT }}
-
-      - name: Get current date
-        id: date
-        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
       # Caches output of generate-assets for use in ci.yml
       - name: Update generate-assets cache

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,7 @@ jobs:
           BUILD_DIR: .
           TOKEN: ${{ secrets.CART_PAT }}
 
+      # Caches output of generate-assets for use in ci.yml
       - name: Update generate-assets cache
         uses: actions/cache/save@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,16 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Get current date
-        id: date
-        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
-
-      - name: Cache multiple crates.io datadump
-        uses: actions/cache@v4
-        with:
-          path: generate-assets/data
-          key: ${{ runner.os }}-${{ steps.date.outputs.date }}
-
       - name: "Build Bevy Assets"
         run: cd generate-assets && ./generate_assets.sh
         env:
@@ -48,6 +38,10 @@ jobs:
           PAGES_BRANCH: gh-pages
           BUILD_DIR: .
           TOKEN: ${{ secrets.CART_PAT }}
+
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
       # Caches output of generate-assets for use in ci.yml
       - name: Update generate-assets cache

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,3 +48,9 @@ jobs:
           PAGES_BRANCH: gh-pages
           BUILD_DIR: .
           TOKEN: ${{ secrets.CART_PAT }}
+
+      - name: Update generate-assets cache
+        uses: actions/cache/save@v4
+        with:
+          path: content/assets
+          key: assets-${{ hashFiles('generate-assets/**/*.rs', 'generate-assets/Cargo.toml', 'generate-assets/generate_assets.sh') }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,4 +54,4 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: content/assets
-          key: assets-${{ hashFiles('generate-assets/**/*.rs', 'generate-assets/Cargo.toml', 'generate-assets/generate_assets.sh') }}
+          key: assets-${{ steps.date.outputs.date }}-${{ hashFiles('generate-assets/**/*.rs', 'generate-assets/Cargo.toml', 'generate-assets/generate_assets.sh') }}


### PR DESCRIPTION
Closes #1066.

This adds a cache for `generate-assets`, which is the CI job currently takes the longest at ~7 minutes, and reduces its runtime to 11 seconds. The cache is updated ever time the website is deployed using `deploy.yml`. The cache is then used in `ci.yml` when no run in the merge queue.