### PR TITLE
Update bevy version on `learn` chapters

### DIFF
--- a/content/learn/quick-start/getting-started/_index.md
+++ b/content/learn/quick-start/getting-started/_index.md
@@ -38,7 +38,7 @@ Note: depending on your platform, you may have to [install additional dependenci
     # use the latest Bevy release
     git checkout latest
     # or a specific version
-    git checkout v0.11.0
+    git checkout v0.13.0
     ```
 
 4. Try the examples in the [examples folder](https://github.com/bevyengine/bevy/tree/latest/examples#examples)
@@ -61,7 +61,7 @@ Alternatively, you can manually add it to your project's Cargo.toml like this:
 
 ```toml
 [dependencies]
-bevy = "0.12" # make sure this is the latest version
+bevy = "0.13" # make sure this is the latest version
 ```
 
 Make sure to use the latest `bevy` crate version ([![Crates.io](https://img.shields.io/crates/v/bevy.svg)](https://crates.io/crates/bevy)).

--- a/content/learn/quick-start/getting-started/setup.md
+++ b/content/learn/quick-start/getting-started/setup.md
@@ -107,7 +107,7 @@ version = "0.1.0"
 edition = "2021" # this needs to be 2021, or you need to set "resolver=2"
 
 [dependencies]
-bevy = "0.12" # make sure this is the latest version
+bevy = "0.13" # make sure this is the latest version
 ```
 
 Make sure to use the latest `bevy` crate version ([![Crates.io](https://img.shields.io/crates/v/bevy.svg)](https://crates.io/crates/bevy)).
@@ -155,7 +155,7 @@ Bevy can be built just fine using default configuration on stable Rust. However 
 
   ```toml
   [dependencies]
-  bevy = { version = "0.12.0", features = ["dynamic_linking"] }
+  bevy = { version = "0.13.0", features = ["dynamic_linking"] }
   ```
 
   NOTE: Remember to revert this before releasing your game! Otherwise you will need to include `libbevy_dylib` alongside your game if you want it to run. If you remove the "dynamic" feature, your game executable can run standalone.

--- a/content/learn/quick-start/plugin-development.md
+++ b/content/learn/quick-start/plugin-development.md
@@ -84,8 +84,8 @@ Indicating which version of your plugin works with which version of Bevy can be 
 ```markdown
 | bevy  | bevy_awesome_plugin |
 |-------|---------------------|
-| 0.12  | 0.3                 |
-| 0.11  | 0.1                 |
+| 0.13  | 0.3                 |
+| 0.12  | 0.1                 |
 ```
 
 ## Main Branch Tracking


### PR DESCRIPTION
I've noticed that bevy is still not updated to `0.13` in the learning sections. A comment to check for new versions is always included but I still think, that this section should use the newest major bevy release