### PR TITLE
Cancel in progress CI jobs on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
       - 'staging'
       - 'trying'
 
+concurrency:
+  group: ${{github.workflow}}-${{github.ref}}
+  cancel-in-progress: ${{github.event_name == 'pull_request'}}
+
 jobs:
   mega-linter:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,10 @@ on:
       - 'trying'
 
 concurrency:
-  group: ${{github.workflow}}-${{github.ref}}
-  cancel-in-progress: ${{github.event_name == 'pull_request'}}
+  # Only the same workflows on the same branch can cancel each other.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Only cancel runs in a PR; we don't want to cancel commit checks on main.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   mega-linter:


### PR DESCRIPTION
At the moment if you commit multiple times to a PR while CI is still going it takes up the amount of jobs that can be run at once. Instead we should cancel in progress jobs on new pushes to a PR.