### PR TITLE
Use Javascript `mega-linter` flavor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           # Full git history is needed to get a proper list of changed files within `mega-linter`
           fetch-depth: 0
       - name: Run Mega Linter
-        uses: oxsecurity/megalinter@v7
+        uses: oxsecurity/megalinter/flavors/javascript@v7
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -2,3 +2,6 @@ ENABLE_LINTERS:
   - HTML_DJLINT
   - MARKDOWN_MARKDOWNLINT
   - EDITORCONFIG_EDITORCONFIG_CHECKER
+
+# We use the Javascript flavor, which does not include all of the linters.
+FAIL_IF_MISSING_LINTER_IN_FLAVOR: true


### PR DESCRIPTION
Closes #1087.

This configures the `mega-linter` CI check to use the [Javascript](https://megalinter.io/latest/flavors/javascript/) flavor, as suggested by Trial in https://github.com/bevyengine/bevy-website/issues/1087#issuecomment-1987113660. Flavors are customized version of the default image are smaller and more specialized.

~~The goal of this PR is to decrease the `mega-linter` runtime from 3 minutes to at least 2 minutes, so it will no longer be the slowest job.~~ This appears to decrease the runtime for the `mega-linter` job from 3 minutes to <1 minute!