### PR TITLE
 Github Actions improvements for `write-rustdoc-hide-lines` (v2)

### DIFF
--- a/content/learn/book/ecs/entities-components.md
+++ b/content/learn/book/ecs/entities-components.md
@@ -26,7 +26,7 @@ Spawning and despawning entities can have far-reaching effects, and so cannot be
 As a result, we must use [`Commands`], which queue up work to do later.
 
 ```rust,hide_lines=1
-# use bevy::ecs::system::Commands;
+use bevy::ecs::system::Commands;
 // The `Commands` system parameter allows us to generate commands
 // which operate on the `World` once all of the current systems have finished running
 fn spawning_system(mut commands: Commands){

--- a/content/learn/book/ecs/entities-components.md
+++ b/content/learn/book/ecs/entities-components.md
@@ -26,7 +26,7 @@ Spawning and despawning entities can have far-reaching effects, and so cannot be
 As a result, we must use [`Commands`], which queue up work to do later.
 
 ```rust,hide_lines=1
-use bevy::ecs::system::Commands;
+# use bevy::ecs::system::Commands;
 // The `Commands` system parameter allows us to generate commands
 // which operate on the `World` once all of the current systems have finished running
 fn spawning_system(mut commands: Commands){

--- a/write-rustdoc-hide-lines/src/main.rs
+++ b/write-rustdoc-hide-lines/src/main.rs
@@ -50,7 +50,7 @@ fn check(folders: impl Iterator<Item = PathBuf> + ExactSizeIterator) -> ExitCode
             Ok(mut unformatted) => unformatted_files.append(&mut unformatted),
             Err(error) => {
                 if is_ci {
-                    // End group if an error occured, so it is not hidden.
+                    // End group if an error occurred, so it is not hidden.
                     println!("::endgroup::");
                 }
 

--- a/write-rustdoc-hide-lines/src/main.rs
+++ b/write-rustdoc-hide-lines/src/main.rs
@@ -47,11 +47,23 @@ fn check(folders: impl Iterator<Item = PathBuf> + ExactSizeIterator) -> ExitCode
     }
 
     if !unformatted_files.is_empty() {
+        // Detect if we're running through Github Actions or not.
+        // https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+        let is_ci = env::var("GITHUB_ACTIONS").is_ok_and(|x| x == "true");
+
         eprintln!("\nThe following files are not formatted:");
 
         for path in unformatted_files {
-            eprintln!("- {:?}", path);
+            if is_ci {
+                // Print custom error message, formatted in Github Actions.
+                // https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message
+                println!("::error file={0:?},title=File is not formatted with correct hide-lines annotations::- {0:?}", path);
+            } else {
+                eprintln!("- {:?}", path);
+            }
         }
+
+        println!("\nRun write_rustdoc_hide_lines.sh to automatically fix these errors.");
 
         ExitCode::FAILURE
     } else {

--- a/write-rustdoc-hide-lines/src/main.rs
+++ b/write-rustdoc-hide-lines/src/main.rs
@@ -1,30 +1,6 @@
 use std::{env, path::PathBuf, process::ExitCode};
 use write_rustdoc_hide_lines::formatter;
 
-/// Generates `hide_lines` annotations to Rust code blocks.
-///
-/// In most cases you can just call `write_rustdoc_hide_lines.sh`, which will automatically handle
-/// formatting all files.
-///
-/// ```shell
-/// $ cd write-rustdoc-hide-lines
-/// $ ./write_rustdoc_hide_lines.sh
-/// ```
-///
-/// You can also run the executable manually.
-///
-/// ```shell
-/// $ cd write-rustdoc-hide-lines
-///
-/// # Format one folder.
-/// $ cargo run -- format ../content/learn/book
-///
-/// # Format multiple folders.
-/// $ cargo run -- format ../content/learn/book ../content/learn/quick-start
-///
-/// # Check one folder, but don't overwrite it.
-/// $ cargo run -- check ../content/learn/book
-/// ```
 fn main() -> ExitCode {
     // The first argument is usually the executable path, so we skip that to just get arguments.
     let mut args = env::args().skip(1);

--- a/write-rustdoc-hide-lines/src/main.rs
+++ b/write-rustdoc-hide-lines/src/main.rs
@@ -66,7 +66,7 @@ fn check(folders: impl Iterator<Item = PathBuf> + ExactSizeIterator) -> ExitCode
     }
 
     if !unformatted_files.is_empty() {
-        eprintln!("\nThe following files are not formatted:");
+        println!("\nThe following files are not formatted:");
 
         for path in unformatted_files {
             if is_ci {
@@ -74,7 +74,7 @@ fn check(folders: impl Iterator<Item = PathBuf> + ExactSizeIterator) -> ExitCode
                 // https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message
                 println!("::error file={0:?},title=File is not formatted with correct hide-lines annotations::- {0:?}", path);
             } else {
-                eprintln!("- {:?}", path);
+                println!("- {:?}", path);
             }
         }
 


### PR DESCRIPTION
Alternative to #1069.

### Annotations

This makes `write-rustdoc-hide-lines` emit error annotations using [workflow commands](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message) when a file is not formatted correctly and when running through Github Actions. These annotations show up in the job summary:

<img width="1067" alt="image" src="https://github.com/bevyengine/bevy-website/assets/59022059/a36a6aeb-59ec-4e7a-9d29-6bbf35efe5e7">

### Group files checked

This additionally groups the list of files checked into a collapsible section when running in Github Actions, so they are not confused with the files that need formatting. Fixes #1100.

Collapsed:

<img width="373" alt="image" src="https://github.com/bevyengine/bevy-website/assets/59022059/44578f74-f153-4ba6-87c2-0e3c57b5df06">

Expanded:

<img width="492" alt="image" src="https://github.com/bevyengine/bevy-website/assets/59022059/6ba76467-2ac8-42cd-a7d6-f811d5fe4065">

In order for this to work, I needed to switch some `eprintln` calls to `println`, because Github Actions was not detecting them sequentially and error messages were being hidden.

### How to fix errors

When `write-rustdoc-hide-lines` fails, it will now print a message saying how to fix the error:

```
Run write_rustdoc_hide_lines.sh to automatically fix these errors.
```

### Removed `main` documentation

In #923 I wrote some documentation for `main` on how to use the program. With the introduction of `README.md`, I think this should be removed. It will be hard to keep the instructions up to date if it is duplicated. (Also `README.md`, in my opinion, is easier to work with.)