### PR TITLE
Make the Query struct link work in getting started ECS page

### DIFF
--- a/content/learn/quick-start/getting-started/ecs.md
+++ b/content/learn/quick-start/getting-started/ecs.md
@@ -142,6 +142,7 @@ The parameters we pass into a "system function" define what data the system runs
 You can interpret the [`Query`] above as: "iterate over every `Name` component for entities that also have a `Person` component".
 
 Now we just register the system in our `App`. Note that you can pass more than one system into an `add_systems` call by using a tuple!
+
 [`Query`]: <https://docs.rs/bevy/latest/bevy/ecs/system/struct.Query.html>
 
 ```rs,hide_lines=1


### PR DESCRIPTION
The reference style markdown links break without new line it seems.