### PR TITLE
Remove mention of site rewards on community donate page

### DIFF
--- a/templates/donate-community.html
+++ b/templates/donate-community.html
@@ -42,36 +42,6 @@
         is a good choice. You can <a href="/community/people/">learn more about these roles here</a>.
       </p>
       <p>
-        If you are interested in backing Bevy in a big way (and you would like to <a href="/">see your logo on Bevy's home
-        page</a>),
-        consider supporting one of our <span class="people-role people-role-inline people-role-maintainer">Maintainers</span> at one
-        of the following tiers:
-        <ul>
-          <li>
-            <b>Bronze</b>: $100 / month
-          </li>
-          <li>
-            <b>Silver</b>: $200 / month
-          </li>
-          <li>
-            <b>Gold</b>: $300 / month
-          </li>
-          <li>
-            <b>Platinum</b>: $1000 / month
-          </li>
-          <li>
-            <b>Diamond</b>: $4000 / month
-          </li>
-          <li>
-            <b>Patron</b>: Anything over $100,000 / year
-          </li>
-        </ul>
-        If a maintainer offers these roles in their sponsors page, that counts! If you are interested in Patron sponsorship,
-        contact us directly.
-        Reach out to us <a href="mailto:bevyengine@gmail.com">here</a> if you have any questions about sponsorship or you
-        would like to claim a sponsorship reward.
-      </p>
-      <p>
         All Bevy leaders sign our <a href="/sponsorship-pledge">Sponsorship Pledge</a> to ensure the needs of the Bevy
         Community always come first.
       </p>


### PR DESCRIPTION
Individual maintainer sponsorship is no longer how to add your logo to the Bevy credits, so we should remove this section from the community donation page.