### PR TITLE
fix: book/getting-started doesn't redirect to quick-start

### DIFF
--- a/content/learn/book/getting-started/_index.md
+++ b/content/learn/book/getting-started/_index.md
@@ -2,7 +2,11 @@
 title = "Getting Started"
 template = "docs-section.html"
 insert_anchor_links = "right"
-# Redirect because page already shows in search results. Remove when developing.
+# Redirect since old links, and for a time search results,
+# use this link for what is now the quick start guide.
+# Remove the line below when developing to see the page render
+# on Zola rather than redirecting to quick start guide.
+# Please add it back before committing.
 redirect_to = "/learn/quick-start/introduction"
 [extra]
 weight = 1

--- a/content/learn/book/getting-started/_index.md
+++ b/content/learn/book/getting-started/_index.md
@@ -2,6 +2,7 @@
 title = "Getting Started"
 template = "docs-section.html"
 insert_anchor_links = "right"
+redirect_to = "/learn/quick-start/introduction"
 [extra]
 weight = 1
 status = 'hidden'

--- a/content/learn/book/getting-started/_index.md
+++ b/content/learn/book/getting-started/_index.md
@@ -2,6 +2,7 @@
 title = "Getting Started"
 template = "docs-section.html"
 insert_anchor_links = "right"
+# Redirect because page already shows in search results. Remove when developing.
 redirect_to = "/learn/quick-start/introduction"
 [extra]
 weight = 1

--- a/content/learn/quick-start/getting-started/_index.md
+++ b/content/learn/quick-start/getting-started/_index.md
@@ -2,7 +2,6 @@
 title = "Getting Started"
 template = "docs-section.html"
 insert_anchor_links = "right"
-aliases = ["learn/book/getting-started"]
 [extra]
 weight = 2
 +++


### PR DESCRIPTION
Fixes https://github.com/bevyengine/bevy-website/issues/1088 by adding a redirect from the Book page and removing the unused alias on the Quick Start page. The latter is not necessary for functionality, but included for clarity.