### PR TITLE
Make donor logos take up available height

### DIFF
--- a/sass/components/_sponsors.scss
+++ b/sass/components/_sponsors.scss
@@ -76,16 +76,15 @@
         ('tier': 'corporate_platinum', 'height': 100px),
         ('tier': 'corporate_gold', 'height': 90px),
         ('tier': 'corporate_silver', 'height': 85px),
-        ('tier': 'corporate_bronze', 'height': 80px),
-        ('tier': 'diamond', 'height': 80px),
+        ('tier': 'corporate_bronze', 'height': 70px),
+        ('tier': 'diamond', 'height': 45px),
     );
 
 @each $tier in $tiers {
     &--#{map-get($tier, 'tier')} {
         .sponsors {
             &__logo {
-                width: 100%;
-                max-height: map-get($tier, 'height');
+                height: map-get($tier, 'height');
             }
         }
     }


### PR DESCRIPTION
Currently logos that are smaller than the available height will not use the space given to them. This is problematic for SVGs hard-coded to smaller heights.

I've also adjusted the existing heights for diamond and corporate bronze accordingly.