### PR TITLE
Improve logo size configurability and fix mobile scale

### DIFF
--- a/.djlintrc
+++ b/.djlintrc
@@ -1,5 +1,5 @@
 {
 	"profile": "nunjucks",
-	"ignore": "H006,H021,H030,H031,H037",
+	"ignore": "H006,H021,H030,H031,H037,T028",
 	"indent": "2"
 }

--- a/content/donate/individual-sponsors.toml
+++ b/content/donate/individual-sponsors.toml
@@ -3,9 +3,9 @@ name = "Foresight Spatial Labs"
 image = "Foresight_Spatial_Labs.svg"
 link = "https://www.foresightmining.com"
 amount = 4000
-style = "height: 140px"
 source = "direct"
 recipient = "cart"
+logo_scale = 1.5
 
 [[sponsor]]
 name = "Embark Studios"
@@ -20,18 +20,18 @@ name = "Encultured.ai"
 image = "Encultured.png"
 link = "https://www.encultured.ai/"
 amount = 1000
-style = "max-height: 60px"
 source = "github"
 recipient ="cart"
+logo_scale = 0.7
 
 [[sponsor]]
 name = "Roids"
 image = "roids_logo.png"
 link = "https://playroids.com"
 amount = 300
-style = "max-height: 130px"
 source = "github"
 recipient ="cart"
+square_logo = true
 
 [[sponsor]]
 name = "Agile Perception"

--- a/content/donate/tiers.toml
+++ b/content/donate/tiers.toml
@@ -47,7 +47,7 @@ icon = "/assets/sponsor_badges/diamond.svg"
 donate_link = "https://buy.stripe.com/6oEaI49BX16T9wY4gl"
 reward_logo = true
 reward_link = true
-logo_height = "45px"
+logo_height = 45
 
 [[tier]]
 name = "Corporate Bronze"
@@ -57,7 +57,7 @@ icon = "/assets/sponsor_badges/bronze.svg"
 donate_link = "https://buy.stripe.com/bIY7vSeWhaHt7oQ7sy"
 reward_logo = true
 reward_link = true
-logo_height = "70px"
+logo_height = 70
 
 [[tier]]
 name = "Corporate Silver"
@@ -67,7 +67,7 @@ icon = "/assets/sponsor_badges/silver.svg"
 donate_link = "https://buy.stripe.com/14kcQceWh8zleRi4gn"
 reward_logo = true
 reward_link = true
-logo_height = "85px"
+logo_height = 85
 
 [[tier]]
 name = "Corporate Gold"
@@ -77,7 +77,7 @@ icon = "/assets/sponsor_badges/gold.svg"
 donate_link = "https://buy.stripe.com/fZecQcdSd6rd4cEfZ6"
 reward_logo = true
 reward_link = true
-logo_height = "90px"
+logo_height = 90
 
 [[tier]]
 name = "Corporate Platinum"
@@ -87,7 +87,7 @@ icon = "/assets/sponsor_badges/platinum.svg"
 donate_link = "https://buy.stripe.com/fZe03q29vdTFgZq6ox"
 reward_logo = true
 reward_link = true
-logo_height = "95px"
+logo_height = 95
 
 [[tier]]
 name = "Corporate Titanium"
@@ -97,7 +97,7 @@ icon = "/assets/sponsor_badges/titanium.svg"
 donate_link = "https://buy.stripe.com/bIY03qaG1eXJ8sU8wG"
 reward_logo = true
 reward_link = true
-logo_height = "100px"
+logo_height = 100
 
 [[tier]]
 name = "Corporate Diamond"
@@ -107,7 +107,7 @@ icon = "/assets/sponsor_badges/diamond.svg"
 donate_link = "https://buy.stripe.com/00gdUg4hD6rddNe7sD"
 reward_logo = true
 reward_link = true
-logo_height = "120px"
+logo_height = 120
 
 [[tier]]
 name = "Patron"
@@ -117,4 +117,4 @@ icon = "/assets/sponsor_badges/patron.svg"
 donate_link = "mailto:bevyengine@gmail.com"
 reward_logo = true
 reward_link = true
-logo_height = "190px"
+logo_height = 190

--- a/content/donate/tiers.toml
+++ b/content/donate/tiers.toml
@@ -47,6 +47,7 @@ icon = "/assets/sponsor_badges/diamond.svg"
 donate_link = "https://buy.stripe.com/6oEaI49BX16T9wY4gl"
 reward_logo = true
 reward_link = true
+logo_height = "45px"
 
 [[tier]]
 name = "Corporate Bronze"
@@ -56,6 +57,7 @@ icon = "/assets/sponsor_badges/bronze.svg"
 donate_link = "https://buy.stripe.com/bIY7vSeWhaHt7oQ7sy"
 reward_logo = true
 reward_link = true
+logo_height = "70px"
 
 [[tier]]
 name = "Corporate Silver"
@@ -65,6 +67,7 @@ icon = "/assets/sponsor_badges/silver.svg"
 donate_link = "https://buy.stripe.com/14kcQceWh8zleRi4gn"
 reward_logo = true
 reward_link = true
+logo_height = "85px"
 
 [[tier]]
 name = "Corporate Gold"
@@ -74,6 +77,7 @@ icon = "/assets/sponsor_badges/gold.svg"
 donate_link = "https://buy.stripe.com/fZecQcdSd6rd4cEfZ6"
 reward_logo = true
 reward_link = true
+logo_height = "90px"
 
 [[tier]]
 name = "Corporate Platinum"
@@ -83,6 +87,7 @@ icon = "/assets/sponsor_badges/platinum.svg"
 donate_link = "https://buy.stripe.com/fZe03q29vdTFgZq6ox"
 reward_logo = true
 reward_link = true
+logo_height = "95px"
 
 [[tier]]
 name = "Corporate Titanium"
@@ -92,6 +97,7 @@ icon = "/assets/sponsor_badges/titanium.svg"
 donate_link = "https://buy.stripe.com/bIY03qaG1eXJ8sU8wG"
 reward_logo = true
 reward_link = true
+logo_height = "100px"
 
 [[tier]]
 name = "Corporate Diamond"
@@ -101,6 +107,7 @@ icon = "/assets/sponsor_badges/diamond.svg"
 donate_link = "https://buy.stripe.com/00gdUg4hD6rddNe7sD"
 reward_logo = true
 reward_link = true
+logo_height = "120px"
 
 [[tier]]
 name = "Patron"
@@ -110,3 +117,4 @@ icon = "/assets/sponsor_badges/patron.svg"
 donate_link = "mailto:bevyengine@gmail.com"
 reward_logo = true
 reward_link = true
+logo_height = "190px"

--- a/sass/components/_sponsors.scss
+++ b/sass/components/_sponsors.scss
@@ -63,32 +63,13 @@
 
     &__logo {
         object-fit: contain;
+        width: 100%;
         transition: transform .2s; /* Animation */
     }
 
     &__logo:hover {
         transform: scale(1.05); /* (150% zoom - Note: if the zoom is too large, it will go outside of the viewport) */
       }
-
-    $tiers: (
-        ('tier': 'patron', 'height': 190px),
-        ('tier': 'corporate_diamond', 'height': 120px),
-        ('tier': 'corporate_platinum', 'height': 100px),
-        ('tier': 'corporate_gold', 'height': 90px),
-        ('tier': 'corporate_silver', 'height': 85px),
-        ('tier': 'corporate_bronze', 'height': 70px),
-        ('tier': 'diamond', 'height': 45px),
-    );
-
-@each $tier in $tiers {
-    &--#{map-get($tier, 'tier')} {
-        .sponsors {
-            &__logo {
-                height: map-get($tier, 'height');
-            }
-        }
-    }
-  }
 }
 
 .sponsors-section {

--- a/templates/individual-sponsors.html
+++ b/templates/individual-sponsors.html
@@ -45,14 +45,20 @@
     <div class="sponsors__content">
         {% for sponsor in sponsors_in_tier %}
         {% if tier.reward_logo %}
+            {% set_global logo_height = tier.logo_height %}
+            {% if sponsor.square_logo %}
+                {% set_global logo_height = logo_height * 1.666 %}
+            {% endif %}
+            {% if sponsor.logo_scale %}
+                {% set_global logo_height = logo_height * sponsor.logo_scale %}
+            {% endif %}
         <a class="sponsors__link" href="{{ sponsor.link }}">
             <img
                 class="sponsors__logo"
-                style="height:
-                    calc({{ tier.logo_height }}{% if sponsor.square_logo %}* 1.666{% endif %}{% if sponsor.logo_scale %} * {{ sponsor.logo_scale }}{% endif %});
-                    {% if sponsor.style %}
-                        {{ sponsor.style }}
-                    {% endif %}"
+                height="{{ logo_height }}"
+                {% if sponsor.style %}
+                style="{{ sponsor.style }}"
+                {% endif %}
                 src="/assets/sponsors/{{ sponsor.image }}"
                 alt="{{ sponsor.name }} logo"
             />

--- a/templates/individual-sponsors.html
+++ b/templates/individual-sponsors.html
@@ -46,8 +46,16 @@
         {% for sponsor in sponsors_in_tier %}
         {% if tier.reward_logo %}
         <a class="sponsors__link" href="{{ sponsor.link }}">
-            <img class="sponsors__logo" {% if sponsor.style %}style="{{ sponsor.style }}"{% endif %} src="/assets/sponsors/{{ sponsor.image }}"
-                alt="{{ sponsor.name }} logo" />
+            <img
+                class="sponsors__logo"
+                style="height:
+                    calc({{tier.logo_height}}{% if sponsor.square_logo %}* 1.666{% endif %}{% if sponsor.logo_scale %} * {{sponsor.logo_scale}}{% endif %});
+                    {% if sponsor.style %}
+                        {{ sponsor.style }}
+                    {% endif %}"
+                src="/assets/sponsors/{{ sponsor.image }}"
+                alt="{{ sponsor.name }} logo"
+            />
         </a>
         {% elif tier.reward_link %}
         <a class="sponsors__name sponsors__link" href="{{ sponsor.link }}">

--- a/templates/individual-sponsors.html
+++ b/templates/individual-sponsors.html
@@ -49,7 +49,7 @@
             <img
                 class="sponsors__logo"
                 style="height:
-                    calc({{tier.logo_height}}{% if sponsor.square_logo %}* 1.666{% endif %}{% if sponsor.logo_scale %} * {{sponsor.logo_scale}}{% endif %});
+                    calc({{ tier.logo_height }}{% if sponsor.square_logo %}* 1.666{% endif %}{% if sponsor.logo_scale %} * {{ sponsor.logo_scale }}{% endif %});
                     {% if sponsor.style %}
                         {{ sponsor.style }}
                     {% endif %}"

--- a/templates/sponsors.html
+++ b/templates/sponsors.html
@@ -56,14 +56,20 @@
     <div class="sponsors__content">
         {% for donor in donors_in_tier %}
         {% if tier.reward_logo and donor.logo %}
+            {% set_global logo_height = tier.logo_height %}
+            {% if donor.square_logo %}
+                {% set_global logo_height = logo_height * 1.666 %}
+            {% endif %}
+            {% if donor.logo_scale %}
+                {% set_global logo_height = logo_height * donor.logo_scale %}
+            {% endif %}
         <a class="sponsors__link" {% if donor.link %}href="{{ donor.link }}"{% endif %}>
             <img
                 class="sponsors__logo"
-                style="height:
-                    calc({{ tier.logo_height }}{% if donor.square_logo %}* 1.666{% endif %}{% if donor.logo_scale %} * {{ donor.logo_scale }}{% endif %});
-                    {% if donor.style %}
-                        {{ donor.style }}
-                    {% endif %}"
+                height="{{ logo_height }}"
+                {% if donor.style %}
+                style="{{ donor.style }}"
+                {% endif %}
                 src="/assets/donor_logos/{{ donor.logo }}"
                 {% if donor.name %}
                 alt="{{ donor.name }} logo"

--- a/templates/sponsors.html
+++ b/templates/sponsors.html
@@ -60,7 +60,7 @@
             <img
                 class="sponsors__logo"
                 style="height:
-                    calc({{tier.logo_height}}{% if donor.square_logo %}* 1.666{% endif %}{% if donor.logo_scale %} * {{donor.logo_scale}}{% endif %});
+                    calc({{ tier.logo_height }}{% if donor.square_logo %}* 1.666{% endif %}{% if donor.logo_scale %} * {{ donor.logo_scale }}{% endif %});
                     {% if donor.style %}
                         {{ donor.style }}
                     {% endif %}"

--- a/templates/sponsors.html
+++ b/templates/sponsors.html
@@ -57,8 +57,18 @@
         {% for donor in donors_in_tier %}
         {% if tier.reward_logo and donor.logo %}
         <a class="sponsors__link" {% if donor.link %}href="{{ donor.link }}"{% endif %}>
-            <img class="sponsors__logo" {% if donor.style %}style="{{ donor.style }}"{% endif %} src="/assets/donor_logos/{{ donor.logo }}"
-                {% if donor.name %} alt="{{ donor.name }} logo"{% endif %} />
+            <img
+                class="sponsors__logo"
+                style="height:
+                    calc({{tier.logo_height}}{% if donor.square_logo %}* 1.666{% endif %}{% if donor.logo_scale %} * {{donor.logo_scale}}{% endif %});
+                    {% if donor.style %}
+                        {{ donor.style }}
+                    {% endif %}"
+                src="/assets/donor_logos/{{ donor.logo }}"
+                {% if donor.name %}
+                alt="{{ donor.name }} logo"
+                {% endif %}
+            />
         </a>
         {% elif tier.reward_link and donor.name %}
         <a class="sponsors__name sponsors__link" {% if donor.link %}href="{{ donor.link }}"{% endif %}>


### PR DESCRIPTION
1. Moves base logo sizing config to `tiers.toml`
2. Uses css `calc()` per-logo to calculate the max-height
3. Adds `square_logo` to sponsor config to give square logos a fair area bump relative to wider aspect ratios. This is nice because it removes the need for direct style overrides and makes the rules consistent across sponsors.
4. Adds `logo_scale` which will further scale the final result. This can be configured per-sponsor
5. Fixes mobile clipping introduced in #1120 

In general this allows us to move away from direct style overrides (although they are still supported)