### PR TITLE
wasm examples: update the GitHub actions

### DIFF
--- a/.github/workflows/build-wasm-examples.yml
+++ b/.github/workflows/build-wasm-examples.yml
@@ -7,13 +7,31 @@ env:
   PER_PAGE: 50
 
 jobs:
+  prepare-pages:
+    name: Get Pages
+    runs-on: ubuntu-latest
+    outputs:
+      pages: ${{ steps.pages.outputs.pages }}
+    steps:
+      - name: Checkout Bevy main branch
+        uses: actions/checkout@v4
+        with:
+          repository: 'bevyengine/bevy'
+          ref: 'latest'
+      - name: Get Pages
+        id: pages
+        run: |
+          example_count=`cat Cargo.toml | grep '\[\[example\]\]' | wc -l`
+          page_count=$((example_count / ${{ env.PER_PAGE }} + 1))
+          echo "pages=`python -c \"import json; print(json.dumps([i for i in range($page_count)]))\"`" >> $GITHUB_OUTPUT
+ 
   wasm-examples:
     name: Build WASM Examples
+    needs: prepare-pages
     runs-on: macos-latest
     strategy:
       matrix:
-        # if all examples are not built, add a new page here
-        page: [0, 1, 2]
+        page: ${{ fromJSON(needs.prepare-pages.outputs.pages) }}
         api: [webgl2, webgpu]
     steps:
 

--- a/.github/workflows/build-wasm-examples.yml
+++ b/.github/workflows/build-wasm-examples.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Get Pages
         id: pages
         run: |
-          example_count=`cat Cargo.toml | grep '\[\[example\]\]' | wc -l`
+          example_count=`cat Cargo.toml | grep 'wasm = true' | wc -l`
           page_count=$((example_count / ${{ env.PER_PAGE }} + 1))
           echo "pages=`jq -n -c \"[range($page_count)]\"`" >> $GITHUB_OUTPUT
  

--- a/.github/workflows/build-wasm-examples.yml
+++ b/.github/workflows/build-wasm-examples.yml
@@ -23,18 +23,6 @@ jobs:
           repository: 'bevyengine/bevy'
           ref: 'latest'
 
-      # temporary: fetch tools from main branch
-      - name: Checkout Bevy Tools
-        uses: actions/checkout@v4
-        with:
-          repository: 'bevyengine/bevy'
-          ref: 'main'
-          path: 'bevy-tools'
-      - name: Copy Bevy tools to latest
-        run: |
-          cp -r bevy-tools/tools/ tools
-          rm -rf bevy-tools
-
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/build-wasm-examples.yml
+++ b/.github/workflows/build-wasm-examples.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           example_count=`cat Cargo.toml | grep '\[\[example\]\]' | wc -l`
           page_count=$((example_count / ${{ env.PER_PAGE }} + 1))
-          echo "pages=`python -c \"import json; print(json.dumps([i for i in range($page_count)]))\"`" >> $GITHUB_OUTPUT
+          echo "pages=`jq -n -c \"[range($page_count)]\"`" >> $GITHUB_OUTPUT
  
   wasm-examples:
     name: Build WASM Examples

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           example_count=`cat Cargo.toml | grep '\[\[example\]\]' | wc -l`
           page_count=$((example_count / ${{ env.PER_PAGE }} + 1))
-          echo "pages=`python -c \"import json; print(json.dumps([i for i in range($page_count)]))\"`" >> $GITHUB_OUTPUT
+          echo "pages=`jq -n -c \"[range($page_count)]\"`" >> $GITHUB_OUTPUT
  
   take-screenshots:
     name: Take Screenshots

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -7,13 +7,31 @@ env:
   PER_PAGE: 20
 
 jobs:
+  prepare-pages:
+    name: Get Pages
+    runs-on: ubuntu-latest
+    outputs:
+      pages: ${{ steps.pages.outputs.pages }}
+    steps:
+      - name: Checkout Bevy main branch
+        uses: actions/checkout@v4
+        with:
+          repository: 'bevyengine/bevy'
+          ref: 'latest'
+      - name: Get Pages
+        id: pages
+        run: |
+          example_count=`cat Cargo.toml | grep '\[\[example\]\]' | wc -l`
+          page_count=$((example_count / ${{ env.PER_PAGE }} + 1))
+          echo "pages=`python -c \"import json; print(json.dumps([i for i in range($page_count)]))\"`" >> $GITHUB_OUTPUT
+ 
   take-screenshots:
     name: Take Screenshots
+    needs: prepare-pages
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # if all examples are not built, add a new page here
-        page: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        page: ${{ fromJSON(needs.prepare-pages.outputs.pages) }}
     steps:
 
       - name: Checkout Bevy latest tag


### PR DESCRIPTION
update the script to not use the tools from main. the tools from latest should work, and main has patches that no longer work on latest

compute the number of pages to run the build in a required job