### PR TITLE
bypass the loading bar as much as possible for 404s

### DIFF
--- a/static/tools.js
+++ b/static/tools.js
@@ -27,6 +27,7 @@ async function progressiveFetch(resource, callbacks={}) {
     // don't hang on error
     if (response.status !== 200) {
         cb.finish({ filename, lengthBytes: 0 });
+        return response;
     }
 
     function update() {


### PR DESCRIPTION
Try to not display the loading bar on 404s for meta files on wasm examples on the website

I can't reproduce the issue locally, but this seems to close the loading bar even faster in case of 404

Hopefully fixes #1128 and fixes #1119