### PR TITLE
Rebalance Past Donor Visibility

### DIFF
--- a/sass/components/_sponsors.scss
+++ b/sass/components/_sponsors.scss
@@ -80,7 +80,12 @@
 }
 
 
-.past-sponsors-title {
+.past-donors-title {
   font-size: 2.8rem;
   margin-bottom: 16px;
+}
+
+.past-donor {
+  font-size: 1.0rem;
+  color: rgb(150, 150, 150); 
 }

--- a/templates/sponsors.html
+++ b/templates/sponsors.html
@@ -98,8 +98,8 @@
         {% endif %}
     {% endfor %}
     {% if past_donor_exists %}
-        <h2 class="past-sponsors-title">Past Donors</h2>
-        <div>
+        <h2 class="past-donors-title">Past Donors</h2>
+        <div class="past-donor">
         {% for donor in sorted_donors %}
             {% if not donor.past %}
                 {% continue %}


### PR DESCRIPTION
Donors in the Past Donors section are currently too visible relative to actual active donors. This rebalances the size (and aligns the text color with text elsewhere). Smaller text makes sense here because this will likely grow to be pretty large. There might even come a time where we need to remove it entirely (or build a separate page for it).