### PR TITLE
Use documentation MegaLinter flavor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           # Full git history is needed to get a proper list of changed files within `mega-linter`
           fetch-depth: 0
       - name: Run Mega Linter
-        uses: oxsecurity/megalinter/flavors/javascript@v7
+        uses: oxsecurity/megalinter/flavors/documentation@v7
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main


### PR DESCRIPTION
We currently use the [Javascript](https://megalinter.io/latest/flavors/javascript/) MegaLinter flavor, which is 857 MB in size and takes 58s ± 2s in CI.

This PR switches it for the [Documentation](https://megalinter.io/latest/flavors/documentation/) flavor, which not only is more fitting for the project but also is only 844 MB. (13 less than Javascript!) When used in CI, it improves speed by about 1 second (lol).