### PR TITLE
Fix docs footer navigation

### DIFF
--- a/templates/docs-base.html
+++ b/templates/docs-base.html
@@ -97,8 +97,6 @@
         {% if found_current %}
           {% if p.extra and p.extra.public_draft %}
             {% continue %}
-          {% elif parent_section.extra and parent_section.extra.public_draft %}
-            {% continue %}
           {% endif %}
           {% set_global next_page = p %}
           {% break %}
@@ -108,8 +106,6 @@
           {% continue %}
         {% endif %}
         {% if p.extra and p.extra.public_draft %}
-          {% continue %}
-        {% elif parent_section.extra and parent_section.extra.public_draft %}
           {% continue %}
         {% endif %}
         {% set_global prev_page = p %}


### PR DESCRIPTION
There are some cases where the footer links don't show up, or show the incorrect link, for example:

- Previous Page link not showing: https://bevyengine.org/learn/book/getting-started/why-bevy/
- Next page link incorrect: https://bevyengine.org/learn/book/getting-started/bevy-community/

This PR fixes these issues. I've double checked in all the other pages and it seems to work correctly (e.g. `Breakout` draft page doesn't show up).

### Demo

On this branch.

First case (previous page correct):

<img width="1230" alt="image" src="https://github.com/bevyengine/bevy-website/assets/188612/f9d7ca34-d57c-46cc-b639-906b46cf6b4f">

Second case (next page correct):

<img width="1233" alt="image" src="https://github.com/bevyengine/bevy-website/assets/188612/8f8cf044-b922-46c6-a072-88852591f721">