### PR TITLE
Show the mobile header on tablet-landscape

### DIFF
--- a/sass/_vars.scss
+++ b/sass/_vars.scss
@@ -57,7 +57,7 @@ $border-radius: 10px;
   --header-height: 60px;
   --scroll-padding-top: calc(var(--header-height) + 16px);
 
-  @media #{$bp-tablet-landscape-up} {
+  @media #{$bp-desktop-up} {
     --header-height: 72px;
   }
 }

--- a/sass/components/_header.scss
+++ b/sass/components/_header.scss
@@ -1,7 +1,7 @@
 .header {
   padding-right: 8px;
 
-  @media #{$bp-tablet-landscape-up} {
+  @media #{$bp-desktop-up} {
     padding: 0 16px;
   }
 
@@ -18,7 +18,7 @@
   &__hamburger {
     flex-shrink: 0;
 
-    @media #{$bp-tablet-landscape-up} {
+    @media #{$bp-desktop-up} {
       display: none;
     }
   }

--- a/sass/components/_logo.scss
+++ b/sass/components/_logo.scss
@@ -4,7 +4,7 @@
   height: 28px;
   width: auto;
 
-  @media #{$bp-tablet-landscape-up} {
+  @media #{$bp-desktop-up} {
     height: 40px;
   }
 }

--- a/sass/components/_main-menu.scss
+++ b/sass/components/_main-menu.scss
@@ -54,7 +54,7 @@
 }
 
 // MODE: Off-Canvas Mobile Menu
-@media #{$bp-tablet-portrait-down} {
+@media #{$bp-tablet-landscape-down} {
   .main-menu {
     $padding: 8px;
     $bottom-buffer: 60px; // Add extra length to compensate for address-bar
@@ -139,9 +139,7 @@
       border-radius: $border-radius;
     }
   }
-}
 
-@media #{$bp-tablet-portrait-down} {
   @include state-checked("mobile-menu") {
     .main-menu {
       transform: translateX($mobile-menu-width);
@@ -163,7 +161,7 @@
 }
 
 // MODE: Desktop Menu
-@media #{$bp-tablet-landscape-up} {
+@media #{$bp-desktop-up} {
   .main-menu {
 
     &__header,


### PR DESCRIPTION
Since there are more items in the header this sometimes leads to overflowing issues for tablet-landscape:

<img width="1103" alt="image" src="https://github.com/bevyengine/bevy-website/assets/188612/057aa6d6-865b-421a-a3e8-ee73442bd692">

<img width="1106" alt="image" src="https://github.com/bevyengine/bevy-website/assets/188612/41021d7c-e945-4a50-ac4f-e0719cf84477">


This PR changes the breakpoint settings so that the mobile menu shows earlier. Now, in tablet-landscape (e.g. ipads landscape) we should see the mobile menu:

<img width="1101" alt="image" src="https://github.com/bevyengine/bevy-website/assets/188612/d299a666-bc2d-4af9-8cd6-076447769d76">

We will eventually need to rethink the header, but this way this can be postponed. 😅 
