### PR TITLE
create logging page

### DIFF
--- a/content/learn/book/development-practices/logging.md
+++ b/content/learn/book/development-practices/logging.md
@@ -1,0 +1,16 @@
++++
+title = "Logging"
+insert_anchor_links = "right"
+[extra]
+weight = 3
+status = 'hidden'
++++
+
+{% todo() %}
+
+* Explain `dotenv`
+* Explain configuring LogPlugin
+  * with the `filter` and `level` fields
+  * with `update_subscriber`
+
+{% end %}


### PR DESCRIPTION
I figured that there should be a page on logging. so i added one under Development Practices.

![image](https://github.com/bevyengine/bevy-website/assets/14184826/8d4922a0-c317-4472-8673-7b9978ec8166)

it's just a placeholder; i just wanted to get it in the book so it's not forgotten.