### PR TITLE
Minor On This Page Script Changes

### DIFF
--- a/static/on-this-page.js
+++ b/static/on-this-page.js
@@ -1,4 +1,10 @@
-//! in nav.on-this-page, sets data-active=true on the li which you're currently looking at
+//! in nav.on-this-page, sets data-active=true on the link to the header you're currently looking at
+
+if(window.location.hash == ""){
+  otp_set_active(document.querySelector("main h2"));
+} else {
+  otp_set_active(window.location.hash.substring(1));
+}
 
 /**
  * remember which elements are on screen. * IntersectionObserver only sends us updates.
@@ -38,6 +44,5 @@ let otp_observer =  new IntersectionObserver(
     threshold: 1.0,
   });
 
-otp_set_active(document.querySelector("main h2"));
 document.querySelectorAll("main h2, main h3")
   .forEach(h => otp_observer.observe(h));

--- a/static/on-this-page.js
+++ b/static/on-this-page.js
@@ -1,10 +1,10 @@
 //! in the page-level navigation, sets data-active=true on the li which you're currently looking at
 
-let page_nav_state = new Map();
+let otp_state = new Map();
 
 /// give data-active=true to the page nav link which points to the given id; set all others to false.
 /// accepts an id string or a DOM node which it will automatically retrieve the id of
-function page_nav_set_active(id_or_node){
+function otp_set_active(id_or_node){
   let id = "";
   if(typeof id_or_node == "object"){
     id = id_or_node.getAttribute("id");
@@ -16,21 +16,21 @@ function page_nav_set_active(id_or_node){
   });
 }
 
-let page_nav_observer =  new IntersectionObserver(
+let otp_observer =  new IntersectionObserver(
   entries => {
     entries.forEach(entry => {
-      page_nav_state.set(entry.target, entry.isIntersecting);
+      otp_state.set(entry.target, entry.isIntersecting);
     });
-    let intersecting = Array.from(page_nav_state).filter(([k,v]) => v == true);
+    let intersecting = Array.from(otp_state).filter(([k,v]) => v == true);
     intersecting.sort(([k,v]) => k.clientTop)
     if (intersecting.length > 0) {
-      page_nav_set_active(intersecting[0][0]);
+      otp_set_active(intersecting[0][0]);
     }
   }, {
     rootMargin: "0px 0px 20% 0px",
     threshold: 1.0,
   });
 
-page_nav_set_active(document.querySelector("main h2"));
+otp_set_active(document.querySelector("main h2"));
 document.querySelectorAll("main h2, main h3")
-  .forEach(h => page_nav_observer.observe(h));
+  .forEach(h => otp_observer.observe(h));

--- a/static/on-this-page.js
+++ b/static/on-this-page.js
@@ -1,9 +1,16 @@
-//! in the page-level navigation, sets data-active=true on the li which you're currently looking at
+//! in nav.on-this-page, sets data-active=true on the li which you're currently looking at
 
+/**
+ * remember which elements are on screen. * IntersectionObserver only sends us updates.
+ * @type {Map<Element, boolean>}
+ */
 let otp_state = new Map();
 
-/// give data-active=true to the page nav link which points to the given id; set all others to false.
-/// accepts an id string or a DOM node which it will automatically retrieve the id of
+/**
+ * give data-active=true to the page nav link which points to the given id; set all others to false.
+ * accepts an id string or a DOM node which it will automatically retrieve the id of
+ * @param {string | HTMLElement} id_or_node 
+ */
 function otp_set_active(id_or_node){
   let id = "";
   if(typeof id_or_node == "object"){

--- a/static/on-this-page.js
+++ b/static/on-this-page.js
@@ -7,7 +7,7 @@ if(window.location.hash == ""){
 }
 
 /**
- * remember which elements are on screen. * IntersectionObserver only sends us updates.
+ * remember which elements are on screen. IntersectionObserver only sends us updates.
  * @type {Map<Element, boolean>}
  */
 let otp_state = new Map();


### PR DESCRIPTION
minor followup to #1147 

I realized that the `on-this-page.js` still referred to it as "page content navigation" or "page_nav" or etc, from before i decided that the one true name:tm: of the feature was "on this page". then i got a bit carried away with jsdoc, and improved the initialization logic.