### PR TITLE
Add `--font-family-*` tokens

### DIFF
--- a/sass/_vars.scss
+++ b/sass/_vars.scss
@@ -54,6 +54,11 @@ $border-radius: 10px;
 
 // CSS Vars
 :root {
+  // Typography
+  --font-family-sans: "Fira Sans", sans-serif;
+  --font-family-mono: "Fira Mono", monospace;
+
+  // Header
   --header-height: 60px;
   --scroll-padding-top: calc(var(--header-height) + 16px);
 

--- a/sass/elements/_html.scss
+++ b/sass/elements/_html.scss
@@ -1,7 +1,7 @@
 html {
   color: $default-color;
   color-scheme: dark;
-  font-family: "Fira Sans", sans-serif;
+  font-family: var(--font-family-sans);
   font-size: calc-rem($size-body-mobile);
   background-color: $color-grey-900;
   scroll-padding-top: var(--scroll-padding-top);

--- a/sass/fonts/_firamono.scss
+++ b/sass/fonts/_firamono.scss
@@ -3,11 +3,11 @@
   font-family: "Fira Mono";
   font-style: normal;
   font-weight: 400;
-  src: url("../fonts/fira-mono-v8-latin-regular.eot"); /* IE9 Compat Modes */
+  src: url("/assets/fonts/fira-mono-v8-latin-regular.eot"); /* IE9 Compat Modes */
   src: local("Fira Mono Regular"), local("FiraMono-Regular"),
-    url("../fonts/fira-mono-v8-latin-regular.eot?#iefix") format("embedded-opentype"), /* IE6-IE8 */
-    url("../fonts/fira-mono-v8-latin-regular.woff2") format("woff2"), /* Super Modern Browsers */
-    url("../fonts/fira-mono-v8-latin-regular.woff") format("woff"), /* Modern Browsers */
-    url("../fonts/fira-mono-v8-latin-regular.ttf") format("truetype"), /* Safari, Android, iOS */
-    url("../fonts/fira-mono-v8-latin-regular.svg#FiraMono") format("svg"); /* Legacy iOS */
+    url("/assets/fonts/fira-mono-v8-latin-regular.eot?#iefix") format("embedded-opentype"), /* IE6-IE8 */
+    url("/assets/fonts/fira-mono-v8-latin-regular.woff2") format("woff2"), /* Super Modern Browsers */
+    url("/assets/fonts/fira-mono-v8-latin-regular.woff") format("woff"), /* Modern Browsers */
+    url("/assets/fonts/fira-mono-v8-latin-regular.ttf") format("truetype"), /* Safari, Android, iOS */
+    url("/assets/fonts/fira-mono-v8-latin-regular.svg#FiraMono") format("svg"); /* Legacy iOS */
 }

--- a/sass/pages/_content.scss
+++ b/sass/pages/_content.scss
@@ -34,7 +34,7 @@ $content-font-size: 1.22rem;
   }
 
   pre {
-    font-family: "Fira Code", monospace;
+    font-family: var(--font-family-mono);
     font-variant-ligatures: none;
     padding: 10px;
     padding-left: 15px;
@@ -48,7 +48,7 @@ $content-font-size: 1.22rem;
   a:active code,
   a:visited code,
   a:link code {
-    font-family: "Fira Code", monospace;
+    font-family: var(--font-family-mono);
     font-variant-ligatures: none;
     color: #e4c151;
     font-style: normal;
@@ -56,7 +56,7 @@ $content-font-size: 1.22rem;
   }
 
   code {
-    font-family: "Fira Code", monospace;
+    font-family: var(--font-family-mono);
     font-variant-ligatures: none;
     font-size: 1.05rem;
     color: #c8c8c8;


### PR DESCRIPTION
This is just some clean-up. It adds two CSS variables (design tokens) for the website's font families. I would eventually like to add more design tokens (variables/palettes) and use those in the CSS. But for now, let's start small.

This also fixes the paths for `Fira Mono` and uses that font in the code examples.