### PR TITLE
Add `callout` shortcode

### DIFF
--- a/content/learn/quick-start/getting-started/_index.md
+++ b/content/learn/quick-start/getting-started/_index.md
@@ -13,7 +13,7 @@ This section will help you get started on your Bevy journey as quickly as possib
 If you want to dive in immediately and you already have a working Rust setup, feel free to follow this "quick start" guide. Otherwise, move on to the next page.
 
 {% callout() %}
-**Note**: depending on your platform, you may have to [install additional dependencies].
+Depending on your platform, you may have to [install additional dependencies].
 You can also speed up compile times by following the ["fast compiles"] section.
 
 [install additional dependencies]: /learn/quick-start/getting-started/setup/#installing-os-dependencies

--- a/content/learn/quick-start/getting-started/_index.md
+++ b/content/learn/quick-start/getting-started/_index.md
@@ -12,10 +12,13 @@ This section will help you get started on your Bevy journey as quickly as possib
 
 If you want to dive in immediately and you already have a working Rust setup, feel free to follow this "quick start" guide. Otherwise, move on to the next page.
 
-Note: depending on your platform, you may have to [install additional dependencies]. You can also speed up compile times by following the ["fast compiles"] section.
+{% callout() %}
+**Note**: depending on your platform, you may have to [install additional dependencies].
+You can also speed up compile times by following the ["fast compiles"] section.
 
 [install additional dependencies]: /learn/quick-start/getting-started/setup/#installing-os-dependencies
 ["fast compiles"]: /learn/quick-start/getting-started/setup/#enable-fast-compiles-optional
+{% end %}
 
 ### Try the Examples
 

--- a/content/learn/quick-start/introduction.md
+++ b/content/learn/quick-start/introduction.md
@@ -29,13 +29,13 @@ Bevy is [built in the open by volunteers](/learn/quick-start/contributing) using
 
 For a more in-depth introduction, check out the [Introducing Bevy](/news/introducing-bevy/) blog post.
 
-<h2 class="warning">
-    Stability Warning
-</h2>
+{% callout(type="warning") %}
+## Stability Warning
 
 Bevy is still in the early stages of development. Important features are missing. Documentation is sparse. A new version of Bevy containing breaking changes to the API is released [approximately once every 3 months](https://bevyengine.org/news/bevy-0-6/#the-train-release-schedule). We provide [migration guides](https://bevyengine.org/learn/book/migration-guides/), but we can't guarantee migrations will always be easy. Use only if you are willing to work in this environment.
 
 If you are currently trying to pick an engine for your Next Big Project™, we recommend that you check out [Godot Engine](https://godotengine.org). It is currently much more feature-complete and stable. And it is also free, open-source, and [scriptable with Rust](https://github.com/godot-rust/gdext)!
+{% end %}
 
 The Quick Start Guide is not a comprehensive guide to Bevy and the next section [Getting Started](/learn/quick-start/getting-started/) will help you with the setup of Bevy and learning the basics, but it does not cover most of Bevy's features. In the future you can use the Bevy Book to gain a better understanding, until then see the last page [Next Steps](/learn/quick-start/next-steps) for more exhaustive and complex resources on Bevy.
 

--- a/sass/components/_callout.scss
+++ b/sass/components/_callout.scss
@@ -1,0 +1,35 @@
+.callout {
+  margin-block: 32px;
+  padding: 16px;
+  border-radius: 4px;
+  background-color: var(--callout-bg-color);
+  border-top: 4px solid var(--callout-accent-color);
+  color: var(--callout-color);
+
+  >:first-child {
+    margin-top: 0;
+  }
+
+  >:last-child {
+    margin-bottom: 0;
+  }
+
+  &,
+  &--info {
+    --callout-accent-color: #5944e0;
+    --callout-bg-color: #2f2745;
+    --callout-color: #f0effb;
+  }
+
+  &--caution {
+    --callout-accent-color: #e82f5a;
+    --callout-bg-color: #591626;
+    --callout-color: #eed5db;
+  }
+
+  &--warning {
+    --callout-accent-color: #e4c151;
+    --callout-bg-color: #513903;
+    --callout-color: #fdfdec;
+  }
+}

--- a/sass/site.scss
+++ b/sass/site.scss
@@ -28,6 +28,7 @@
 @import "components/docs-footer";
 @import "components/button-square";
 @import "components/button";
+@import "components/callout";
 @import "components/card";
 @import "components/container";
 @import "components/example";

--- a/templates/shortcodes/callout.html
+++ b/templates/shortcodes/callout.html
@@ -1,0 +1,3 @@
+<div class="callout callout--{{ type | default(value="info")}}">
+  {{ body | markdown | safe }}
+</div>

--- a/templates/shortcodes/callout.html
+++ b/templates/shortcodes/callout.html
@@ -1,3 +1,3 @@
-<div class="callout callout--{{ type | default(value="info")}}">
+<div class="callout callout--{{ type | default(value="info") }}">
   {{ body | markdown | safe }}
 </div>


### PR DESCRIPTION
This PR adds a new `callout()` shortcode. Wrap some markdown in it to show it as a callout/alert/admonition… It implements three styles:

### `info` (default)
<img width="600" alt="image" src="https://github.com/bevyengine/bevy-website/assets/188612/ee66ccc9-478d-46f2-b259-8a90774c7425">

### `warning`
<img width="600" alt="image" src="https://github.com/bevyengine/bevy-website/assets/188612/b5143303-1d96-4606-8dc6-9399f815e598">

### `caution`
<img width="600" alt="image" src="https://github.com/bevyengine/bevy-website/assets/188612/f30763a5-52e2-4699-a210-2dc0fe6e0562">
