### PR TITLE
Change homepage `Get Started` link so that users don't miss the "Stability Warning"

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -16,7 +16,7 @@
       <br />
       Free and Open Source Forever!
       <br />
-      <a class="button button--big" href="/learn/quick-start/getting-started/">Get Started</a>
+      <a class="button button--big" href="/learn/quick-start/introduction/">Get Started</a>
     </div>
     <div class="feature-list">
       <div class="feature-container">


### PR DESCRIPTION
Some users might miss the _Stability Warning_ because the homepage `Getting Started` link skips the _Introduction_ and directly points to _Getting Started_. Change the link so there are more chances of seeing the warning.