### PR TITLE
Fix On This Page algorithm

### DIFF
--- a/sass/components/_on-this-page.scss
+++ b/sass/components/_on-this-page.scss
@@ -15,25 +15,27 @@
     padding-inline: $h-padding;
   }
 
-  li[data-active="true"] > a {
-    color: #ececec;
-  }
-
   a {
+    $color: #868686;
     display: block;
     text-wrap: balance;
     padding-block: 4px;
-    color: #868686;
+    color: $color;
     text-decoration: none;
     word-break: break-word;
-
-    &:hover {
-      color: lighten(#868686, 20);
-    }
 
     @media ($bp-tablet-portrait-down) {
       // increase hit area for touchscreens
       padding-block: 6px;
     }
+
+    &:hover {
+      color: lighten($color, 20);
+    }
+
+    &[data-active=true] {
+      color: $color-white;
+    }
+
   }
 }

--- a/static/on-this-page.js
+++ b/static/on-this-page.js
@@ -1,7 +1,7 @@
 //! in nav.on-this-page, sets data-active=true on the link to the header you're currently looking at
 
 if(window.location.hash == ""){
-  otp_set_active(document.querySelector("main h2"));
+  otp_set_active(document.querySelector("main h2") || document.querySelector("main h3"));
 } else {
   otp_set_active(window.location.hash.substring(1));
 }
@@ -35,7 +35,7 @@ let otp_observer =  new IntersectionObserver(
       otp_state.set(entry.target, entry.isIntersecting);
     });
     let intersecting = Array.from(otp_state).filter(([k,v]) => v == true);
-    intersecting.sort(([k,v]) => k.clientTop)
+    intersecting.sort(([k,v]) => -k.getBoundingClientRect().y)
     if (intersecting.length > 0) {
       otp_set_active(intersecting[0][0]);
     }

--- a/static/on-this-page.js
+++ b/static/on-this-page.js
@@ -37,7 +37,7 @@ let otp_observer =  new IntersectionObserver(
     let intersecting = Array.from(otp_state)
       .filter(([_el, inter]) => inter)
       .map(([el, _inter]) => el);
-    intersecting.sort((element) => -element.getBoundingClientRect().y)
+    intersecting.sort((element) => -element.getBoundingClientRect().y);
     if (intersecting.length > 0) {
       otp_set_active(intersecting[0]);
     }

--- a/static/on-this-page.js
+++ b/static/on-this-page.js
@@ -25,8 +25,8 @@ function otp_set_active(id_or_node){
     id = id_or_node;
   }
   id = "#" + id;
-  document.querySelectorAll(".on-this-page a").forEach((li) => {
-    li.setAttribute("data-active", li.getAttribute("href") == id);
+  document.querySelectorAll(".on-this-page a").forEach(a => {
+    a.setAttribute("data-active", a.getAttribute("href") == id);
   });
 }
 

--- a/static/on-this-page.js
+++ b/static/on-this-page.js
@@ -24,8 +24,9 @@ function otp_set_active(id_or_node){
   } else {
     id = id_or_node;
   }
-  document.querySelectorAll(".on-this-page li").forEach((li) => {
-    li.setAttribute("data-active", li.getAttribute("data-fragment") == id);
+  id = "#" + id;
+  document.querySelectorAll(".on-this-page a").forEach((li) => {
+    li.setAttribute("data-active", li.getAttribute("href") == id);
   });
 }
 

--- a/static/on-this-page.js
+++ b/static/on-this-page.js
@@ -34,10 +34,12 @@ let otp_observer =  new IntersectionObserver(
     entries.forEach(entry => {
       otp_state.set(entry.target, entry.isIntersecting);
     });
-    let intersecting = Array.from(otp_state).filter(([k,v]) => v == true);
-    intersecting.sort(([k,v]) => -k.getBoundingClientRect().y)
+    let intersecting = Array.from(otp_state)
+      .filter(([_el, inter]) => inter)
+      .map(([el, _inter]) => el);
+    intersecting.sort((element) => -element.getBoundingClientRect().y)
     if (intersecting.length > 0) {
-      otp_set_active(intersecting[0][0]);
+      otp_set_active(intersecting[0]);
     }
   }, {
     rootMargin: "0px 0px 20% 0px",

--- a/templates/macros/docs.html
+++ b/templates/macros/docs.html
@@ -111,14 +111,14 @@
   {# screen readers will read this as 'Navigation: On This Page' #}
   <ul>
   {% for h1 in toc %}
-    <li data-fragment="{{ h1.id }}">
-      <a href="{{ h1.permalink | safe }}">{{ h1.title }}</a>
+    <li>
+      <a href="#{{ h1.id }}">{{ h1.title }}</a>
       {% if h1.children %}
         <ul>
           {% for h2 in h1.children %}
-            <li data-fragment="{{ h2.id }}">
-              <a href="{{ h2.permalink | safe }}">{{ h2.title }}</a>
-            </li>
+          <li>
+            <a href="#{{ h2.id }}">{{ h2.title }}</a>
+          </li>
           {% endfor %}
         </ul>
       {% endif %}


### PR DESCRIPTION
scope-creep edition!

- sort by the actual Y position. and not the top border width.
- sort in the correct direction
- handle the case where there are no `<h2>`s (which is the case on migration guides)
- compare `<a href>` which need to be there anyway instead of `<li data-fragment>`
