### PR TITLE
Fix TOC overflow in Migration Guides

### DIFF
--- a/sass/components/_on-this-page.scss
+++ b/sass/components/_on-this-page.scss
@@ -31,6 +31,7 @@
     // copied from .media-content
     text-decoration: none;
     color: $link-color;
+    word-break: break-word;
 
     &:hover {
       text-shadow: 0 0 0.9px $link-hover-shadow-color, 0 0 0.9px $link-hover-shadow-color;

--- a/sass/components/_tree-menu.scss
+++ b/sass/components/_tree-menu.scss
@@ -23,7 +23,7 @@
 
     &__label {
         display: grid;
-        grid-template-columns: auto min-content;
+        grid-template-columns: 1fr min-content;
         border-radius: $border-radius;
         overflow: hidden; // prevent the radii from getting messed up
         margin-bottom: 2px;


### PR DESCRIPTION
Right now TOC is not adding line breaks in the Migrations pages so the text is overflowing:

<img width="345" alt="image" src="https://github.com/bevyengine/bevy-website/assets/188612/5320e167-cf9a-422f-a4f4-918e37a678e4">

---

This is after the fix:

<img width="345" alt="image" src="https://github.com/bevyengine/bevy-website/assets/188612/1c921326-5581-4dae-b5df-2bc0505a228e">
