### PR TITLE
Fix doc pages title with special characters

### DIFF
--- a/templates/docs.html
+++ b/templates/docs.html
@@ -103,7 +103,7 @@
         {% set_global prev_page = p %}
       {% endfor %}
       <h1>
-        {{ section_or_page.extra.long_title | default(value=section_or_page.title) }}
+        {{ section_or_page.extra.long_title | default(value=section_or_page.title) | safe }}
         {% if section_or_page.extra.subtitle %}
           <span class="docs-page-subtitle">{{ section_or_page.extra.subtitle }}</span>
         {% endif %}


### PR DESCRIPTION
https://github.com/bevyengine/bevy-website/pull/1149 introduced a bug in docs page titles. See: https://bevyengine.org/learn/quick-start/plugin-development/

**BEFORE**
<img width="400" alt="image" src="https://github.com/bevyengine/bevy-website/assets/188612/ae787098-19c0-4a6d-936f-436248cbfd30">

**AFTER**
<img width="350" alt="image" src="https://github.com/bevyengine/bevy-website/assets/188612/ddc5486f-139a-4621-815a-843c606bfa57">

Fixes #1173.
