### PR TITLE
Increase TOC spacing between entries

### DIFF
--- a/sass/components/_on-this-page.scss
+++ b/sass/components/_on-this-page.scss
@@ -27,7 +27,7 @@
   a {
     display: block;
     text-wrap: balance;
-    padding-block: 1px;
+    padding-block: 3px;
     // copied from .media-content
     text-decoration: none;
     color: $link-color;


### PR DESCRIPTION
TOC is quite dense and sometimes is difficult to identify the different entries. This PR increases the space between the TOC entries so it's more legible.

See discussion and screenshots in https://github.com/bevyengine/bevy-website/pull/1171#issuecomment-2116859193.