### PR TITLE
Change text colors for "On This Page" section

### DIFF
--- a/sass/components/_on-this-page.scss
+++ b/sass/components/_on-this-page.scss
@@ -1,7 +1,6 @@
 /// internal page navigation
 /// i.e., the "On This Page" section
 
-
 .on-this-page {
   $h-padding: 12px;
   padding-block: calc($h-padding/2);
@@ -12,29 +11,24 @@
     padding-inline-start: $h-padding;
   }
 
-  >ul {
+  > ul {
     padding-inline: $h-padding;
   }
 
-  li[data-active=true] {
-    font-weight: bolder;
-
-    li {
-      font-weight: normal;
-    }
+  li[data-active="true"] > a {
+    color: #ececec;
   }
 
   a {
     display: block;
     text-wrap: balance;
     padding-block: 3px;
-    // copied from .media-content
+    color: #868686;
     text-decoration: none;
-    color: $link-color;
     word-break: break-word;
 
     &:hover {
-      text-shadow: 0 0 0.9px $link-hover-shadow-color, 0 0 0.9px $link-hover-shadow-color;
+      color: lighten(#868686, 20);
     }
 
     @media ($bp-tablet-portrait-down) {


### PR DESCRIPTION
The new "On This Page" section for the sidebar has blue links, which feel out of place and look a bit distracting.

This PR changes the text colors to gray for non-active items and a near-white for active items, also removing the on-hover text shadow in favor of simply lightening the text color.

Before:

https://github.com/bevyengine/bevy-website/assets/57632562/4a3948a2-543b-48f8-9e3f-4d7526d3b119

After:

https://github.com/bevyengine/bevy-website/assets/57632562/d7bdc83f-eb5d-4df7-98a1-df7ced88dcc6

Note that the whole website appears lighter in the above videos for some color encoding reasons, and don't perfectly reflect what it actually looks like.

Here are close-up screenshots with more accurate colors:

![kuva](https://github.com/bevyengine/bevy-website/assets/57632562/283ad866-8cd2-4838-af64-20a319ef0528)
![kuva](https://github.com/bevyengine/bevy-website/assets/57632562/14faec2f-1e36-4c08-8a73-41d9a334eb5f)

(ignore that black border on the right and bottom, not sure what that's about)