### PR TITLE
Increase TOC spacing between entries (again)

### DIFF
--- a/sass/components/_on-this-page.scss
+++ b/sass/components/_on-this-page.scss
@@ -27,7 +27,7 @@
   a {
     display: block;
     text-wrap: balance;
-    padding-block: 3px;
+    padding-block: 5px;
     // copied from .media-content
     text-decoration: none;
     color: $link-color;

--- a/sass/components/_on-this-page.scss
+++ b/sass/components/_on-this-page.scss
@@ -33,7 +33,7 @@
 
     @media ($bp-tablet-portrait-down) {
       // increase hit area for touchscreens
-      padding-block: 3px;
+      padding-block: 6px;
     }
   }
 }


### PR DESCRIPTION
#1175 made the sidebar table of contents less dense, but it still looks too dense. It's hard to distinguish between what is a different entry or just an entry with a name that spans multiple lines, and it just looks a bit out of place with the rest of the layout being more spacious.

Before:

![kuva](https://github.com/bevyengine/bevy-website/assets/57632562/5c2493a2-5eac-459d-acfd-73d61175c0aa)

After:

![kuva](https://github.com/bevyengine/bevy-website/assets/57632562/d5ac4cb4-c607-44f1-acb2-10569423aee0)

Note: The screenshots above use the text styling from #1176, but these changes are not included in this PR.