### PR TITLE
Hard-code possible docs template root sections

### DIFF
--- a/templates/docs.html
+++ b/templates/docs.html
@@ -20,13 +20,11 @@
 {% endblock head_extensions %}
 
 {% block mobile_page_menu %}
-  {% set root_section_path = section_or_page.components | slice(end=2) | concat(with="_index.md") | join(sep="/") %}
-  {{ docs_macros::docs_menu(prefix="mobile-menu", root=get_section(path=root_section_path) ) }}
+  {{ docs_macros::docs_menu(prefix="mobile-menu", root=root_section) }}
 {% endblock mobile_page_menu %}
 
 {% block page_menu %}
-  {% set root_section_path = section_or_page.components | slice(end=2) | concat(with="_index.md") | join(sep="/") %}
-  {{ docs_macros::docs_menu(prefix="page-menu", root=get_section(path=root_section_path) ) }}
+  {{ docs_macros::docs_menu(prefix="page-menu", root=root_section ) }}
 {% endblock page_menu %}
 
 {% block page_name %}
@@ -41,8 +39,6 @@
   <div class="docs-page">
     <div class="docs-content">
       {% set is_migration_guide = current_path is starting_with("/learn/migration-guides") %}
-      {% set root_section_path = section_or_page.components | slice(end=2) | concat(with="_index.md") | join(sep="/") %}
-      {% set root_section = get_section(path=root_section_path) %}
 
       {# Create an array of sections and pages in reading order #}
       {% set all_pages = [] %}

--- a/templates/layouts/base.html
+++ b/templates/layouts/base.html
@@ -7,6 +7,18 @@
   {% set_global section_or_page = section | default(value=page) %}
 {% endif %}
 
+{% if section_or_page %}
+  {# Possible docs root section paths. A temporary workdown. TODO: find a better solution #}
+  {% set_global root_section_paths = ["learn/quick-start", "learn/book", "learn/migration-guides", "learn/advanced-examples", "contributing"] %}
+  {% for root_section_path in root_section_paths %}
+    {% set components = root_section_path | split(pat="/") %}
+    {% if section_or_page.components | slice(end=components | length) == components %}
+      {% set_global root_section = get_section(path=root_section_path ~ "/_index.md") %}
+      {% break %}
+    {% endif %}
+  {% endfor %}
+{% endif %}
+
 {% set current_path = current_path | default(value="/") %}
 {% if section and section.title %}
   {% if section.path is starting_with("/learn/book/") %}

--- a/templates/layouts/base.html
+++ b/templates/layouts/base.html
@@ -8,7 +8,7 @@
 {% endif %}
 
 {% if section_or_page %}
-  {# Possible docs root section paths. A temporary workaround. TODO: find a better solution #}
+  {# Possible docs root section paths. A temporary workaround. TODO: issue #1181(https://github.com/bevyengine/bevy-website/issues/1181) find a better solution #}
   {% set_global root_section_paths = ["learn/quick-start", "learn/book", "learn/migration-guides", "learn/advanced-examples", "learn/errors", "contributing"] %}
   {% for root_section_path in root_section_paths %}
     {% set components = root_section_path | split(pat="/") %}

--- a/templates/layouts/base.html
+++ b/templates/layouts/base.html
@@ -8,7 +8,7 @@
 {% endif %}
 
 {% if section_or_page %}
-  {# Possible docs root section paths. A temporary workdown. TODO: find a better solution #}
+  {# Possible docs root section paths. A temporary workaround. TODO: find a better solution #}
   {% set_global root_section_paths = ["learn/quick-start", "learn/book", "learn/migration-guides", "learn/advanced-examples", "contributing"] %}
   {% for root_section_path in root_section_paths %}
     {% set components = root_section_path | split(pat="/") %}

--- a/templates/layouts/base.html
+++ b/templates/layouts/base.html
@@ -9,7 +9,7 @@
 
 {% if section_or_page %}
   {# Possible docs root section paths. A temporary workaround. TODO: find a better solution #}
-  {% set_global root_section_paths = ["learn/quick-start", "learn/book", "learn/migration-guides", "learn/advanced-examples", "contributing"] %}
+  {% set_global root_section_paths = ["learn/quick-start", "learn/book", "learn/migration-guides", "learn/advanced-examples", "learn/errors", "contributing"] %}
   {% for root_section_path in root_section_paths %}
     {% set components = root_section_path | split(pat="/") %}
     {% if section_or_page.components | slice(end=components | length) == components %}


### PR DESCRIPTION
Hopefully should unblock #1178 

The previous, more procedural, way of determining docs root sections did not take into consideration possible docs sections outside of `/learn/*`. I would've done a better procedural way, but the lack of while loops in Tera threw a wrench in that plan, so for now this is the best I can do without further blocking progress on the contributing guide.