### PR TITLE
Fix wrong docs section name showing up in the mobile page menu

### DIFF
--- a/templates/docs.html
+++ b/templates/docs.html
@@ -1,5 +1,6 @@
 {% extends "layouts/page-with-menu.html" %}
 {% import "macros/docs.html" as docs_macros %}
+{% import "macros/base.html" as base_macros %}
 
 {% block head_extensions %}
   {% set_global ancestor_is_public_draft = false %}
@@ -30,21 +31,7 @@
 {% endblock page_menu %}
 
 {% block page_name %}
-  {% if section_or_page %}
-    {% if section_or_page.path is starting_with("/learn/book/") %}
-      The Book
-    {% elif section_or_page.path is starting_with("/learn/migration-guides/") %}
-      Migration Guides
-    {% elif section_or_page.path is starting_with("/learn/errors/") %}
-      Bevy Errors
-    {% elif section_or_page.path is starting_with("/learn/quick-start/") %}
-      Quick Start
-    {% elif section_or_page.path is starting_with("/learn/advanced-examples") %}
-      Advanced Examples
-    {% elif section_or_page.path is starting_with("/contributing/") %}
-      Contributing Guide
-    {% endif %}
-  {% endif %}
+  {{ base_macros::page_header_message(section_or_page=section_or_page) }}
 {% endblock page_name %}
 
 {% block page_content %}

--- a/templates/docs.html
+++ b/templates/docs.html
@@ -30,10 +30,20 @@
 {% endblock page_menu %}
 
 {% block page_name %}
-  {% if section_or_page and section_or_page.path is starting_with("/learn/book/") %}
-    The Book
-  {% else %}
-    Migration Guides
+  {% if section_or_page %}
+    {% if section_or_page.path is starting_with("/learn/book/") %}
+      The Book
+    {% elif section_or_page.path is starting_with("/learn/migration-guides/") %}
+      Migration Guides
+    {% elif section_or_page.path is starting_with("/learn/errors/") %}
+      Bevy Errors
+    {% elif section_or_page.path is starting_with("/learn/quick-start/") %}
+      Quick Start
+    {% elif section_or_page.path is starting_with("/learn/advanced-examples") %}
+      Advanced Examples
+    {% elif section_or_page.path is starting_with("/contributing/") %}
+      Contributing Guide
+    {% endif %}
   {% endif %}
 {% endblock page_name %}
 

--- a/templates/layouts/base.html
+++ b/templates/layouts/base.html
@@ -1,5 +1,6 @@
 {% import "macros/header.html" as header_macros %}
 {% import "macros/public_draft.html" as public_draft %}
+{% import "macros/base.html" as base_macros %}
 
 {# Shortcut to get the section/page. This variable will have a value except in some special pages like `404.html`. #}
 {% set_global section_or_page = false %}
@@ -8,6 +9,7 @@
 {% endif %}
 
 {% set current_path = current_path | default(value="/") %}
+
 {% if section and section.title %}
   {% if section.path is starting_with("/learn/book/") %}
     {% set page_title = "Bevy Book: " ~ section.title %}
@@ -31,6 +33,7 @@
 {% else %}
   {% set page_title = "Bevy Engine" %}
 {% endif %}
+
 {% if section and section.path %}
   {% set path = "/" ~ section.path %}
 {% elif page and page.path %}
@@ -38,6 +41,7 @@
 {% else %}
   {% set path = "" %}
 {% endif %}
+
 {% if section %}
   {% if section.path is starting_with("/learn/book/") %}
     {% set show_nav_toggle = true %}
@@ -56,6 +60,7 @@
     {% set show_nav_toggle = true %}
   {% endif %}
 {% endif %}
+
 {% set newline = "
 " %}
 <!DOCTYPE html>
@@ -98,31 +103,7 @@
                     height="130">
             </a>
             <div class="header__message">
-              {% if section and section.extra.header_message %}
-                {{ section.extra.header_message }}
-              {% elif page and page.extra.header_message %}
-                {{ page.extra.header_message }}
-              {% elif section and section.path is starting_with("/learn/book/") or page and page.path is
-                starting_with("/learn/book/") %}
-                The Book
-              {% elif section and section.path is starting_with("/learn/quick-start/") or page and page.path is
-                starting_with("/learn/quick-start/") %}
-                Quick Start
-              {% elif section and section.path is starting_with("/learn/migration-guides/") or page and page.path is
-                starting_with("/learn/migration-guides/") %}
-                Migration Guides
-              {% elif section and section.path is starting_with("/learn/errors/") or page and page.path is
-                starting_with("/learn/errors/") %}
-                Errors
-              {% elif section and section.path is starting_with("/contributing/") or page and page.path is starting_with("/contributing/") %}
-                Contributing
-              {% elif section and section.path is starting_with("/news/") %}
-                News
-              {% elif page and page.path is starting_with("/news/") %}
-                News
-              {% else %}
-                Features
-              {% endif %}
+              {{ base_macros::page_header_message(section_or_page=section_or_page) }}
             </div>
           </div>
           {% block mobile_page_menu_state %}{% endblock mobile_page_menu_state %}

--- a/templates/macros/base.html
+++ b/templates/macros/base.html
@@ -1,0 +1,23 @@
+{% macro page_header_message(section_or_page) %}
+  {% if section_or_page %}
+    {% if section_or_page.extra.header_message %}
+      {{ section_or_page.extra.header_message }}
+    {% elif section_or_page.path is starting_with("/learn/book/") %}
+      The Book
+    {% elif section_or_page.path is starting_with("/learn/migration-guides/") %}
+      Migration Guides
+    {% elif section_or_page.path is starting_with("/learn/errors/") %}
+      Errors
+    {% elif section_or_page.path is starting_with("/learn/quick-start/") %}
+      Quick Start
+    {% elif section_or_page.path is starting_with("/learn/advanced-examples") %}
+      Advanced Examples
+    {% elif section_or_page.path is starting_with("/contributing/") %}
+      Contributing Guide
+    {% elif section_or_page.path is starting_with("/news/") %}
+      News
+    {% elif section_or_page.path == "/" %}
+      Features
+    {% endif %}
+  {% endif %}
+{% endmacro page_header_message %}


### PR DESCRIPTION
Before in the mobile page menu the page name / docs section name for the menu was showing as Migration Guides for all but the Book since the page name hadn't been updated as new docs sections has been added.