### PR TITLE
add print styling

### DIFF
--- a/sass/_print.scss
+++ b/sass/_print.scss
@@ -1,0 +1,24 @@
+@media print {
+  .print\:hidden {
+    // stolen from tailwind in case we ever switch
+    display: none !important;
+  }
+
+  .callout {
+    border: 4px solid var(--callout-accent-color);
+  }
+
+  .anchor-link {
+    display: none;
+  }
+
+  h1, h2, h3 {
+    page-break-inside: avoid;
+    page-break-after: avoid;
+    page-break-before: always;
+  }
+
+  p {
+    page-break-inside: avoid;
+  }
+}

--- a/sass/_print.scss
+++ b/sass/_print.scss
@@ -8,7 +8,8 @@
     border: 4px solid var(--callout-accent-color);
   }
 
-  .layout, .page-with-menu {
+  .layout,
+  .page-with-menu {
     // page-break styles don't like flex and grid
     // the top bar and menu are gone anyway so it doesn't matter
     display: block !important;
@@ -18,12 +19,27 @@
     display: none;
   }
 
-  h1, h2, h3 {
+  h1,
+  h2,
+  h3 {
     page-break-inside: avoid;
     page-break-after: avoid;
   }
 
-  p, pre {
+  p,
+  pre {
     page-break-inside: avoid;
   }
+
+  a {
+    &[href]::after {
+      content: " (" attr(href) ")";
+    }
+
+    &[href^="#"]::after,
+    &[href^="javascript:"]::after {
+      content: "";
+    }
+  }
+
 }

--- a/sass/_print.scss
+++ b/sass/_print.scss
@@ -8,6 +8,10 @@
     border: 4px solid var(--callout-accent-color);
   }
 
+  .layout, .page-with-menu {
+    display: block !important;
+  }
+
   .anchor-link {
     display: none;
   }
@@ -15,7 +19,6 @@
   h1, h2, h3 {
     page-break-inside: avoid;
     page-break-after: avoid;
-    page-break-before: always;
   }
 
   p, pre {

--- a/sass/_print.scss
+++ b/sass/_print.scss
@@ -32,6 +32,7 @@
   }
 
   a {
+    // stolen from https://github.com/h5bp/html5-boilerplate/
     &[href]::after {
       content: " (" attr(href) ")";
     }

--- a/sass/_print.scss
+++ b/sass/_print.scss
@@ -18,7 +18,7 @@
     page-break-before: always;
   }
 
-  p {
+  p, pre {
     page-break-inside: avoid;
   }
 }

--- a/sass/_print.scss
+++ b/sass/_print.scss
@@ -9,6 +9,8 @@
   }
 
   .layout, .page-with-menu {
+    // page-break styles don't like flex and grid
+    // the top bar and menu are gone anyway so it doesn't matter
     display: block !important;
   }
 

--- a/sass/_print.scss
+++ b/sass/_print.scss
@@ -18,6 +18,10 @@
   .anchor-link {
     display: none;
   }
+  
+  main {
+    padding-top: 0 !important;
+  }
 
   h1,
   h2,

--- a/sass/site.scss
+++ b/sass/site.scss
@@ -4,6 +4,7 @@
 @import "functions";
 @import "vars";
 @import "mixins";
+@import "print";
 
 // Fonts
 @import "fonts/firamono";

--- a/templates/docs.html
+++ b/templates/docs.html
@@ -112,7 +112,7 @@
         {{ section_or_page.content | safe }}
         {% block docs_content %}{% endblock docs_content %}
       </div>
-      <div class="docs-footer">
+      <div class="docs-footer print:hidden">
         <nav class="docs-footer__nav">
           {% if next_page %}
             <a class="docs-footer__link docs-footer__link--next"

--- a/templates/layouts/base.html
+++ b/templates/layouts/base.html
@@ -79,7 +79,7 @@
   <body>
     <div class="layout">
       <input id="mobile-menu-state" class="hidden" type="checkbox">
-      <header class="layout__header header" data-mobile-menu-state-container>
+      <header class="layout__header header print:hidden" data-mobile-menu-state-container>
         <div class="header__content">
           <label class="main-menu-backdrop" for="mobile-menu-state"></label>
           <label class="header__hamburger button-square button-square--header"

--- a/templates/layouts/base.html
+++ b/templates/layouts/base.html
@@ -192,7 +192,7 @@
           {% block content %}{% endblock content %}
         </div>
       </main>
-      <footer>
+      <footer class="print:hidden">
         {% block footer_extensions %}{% endblock footer_extensions %}
         <div class="footer__social-container">
           <a class="footer__social" href="https://github.com/bevyengine/bevy">

--- a/templates/layouts/page-with-menu.html
+++ b/templates/layouts/page-with-menu.html
@@ -15,7 +15,7 @@
 {% endblock mobile_page_menu_switch %}
 {% block content %}
   <div class="page-with-menu {% block page_with_menu_extra_class %}{% endblock page_with_menu_extra_class %}">
-    <div class="page-with-menu__menu-wrapper">
+    <div class="page-with-menu__menu-wrapper print:hidden">
       <div class="page-with-menu__menu">
         {% block page_menu %}{% endblock page_menu %}
       </div>


### PR DESCRIPTION
- Hides everything but the content
- asks the browser nicely to not put page breaks after headers, inside headers, inside paragraphs, or inside code
- hides anchor links (`#`es beside headers)
- Shows link URLs
- fully outlines callouts

![image](https://github.com/bevyengine/bevy-website/assets/14184826/50e2ca76-48a1-4f32-95bb-cefc212adf22)

example of a whole printed page: [Setup.pdf](https://github.com/bevyengine/bevy-website/files/15383780/Setup.pdf)
