### PR TITLE
Fix default version filter

### DIFF
--- a/static/assets.js
+++ b/static/assets.js
@@ -1,6 +1,6 @@
 let filters_state = {
     search_terms: [''],
-    version: '*'
+    version: 'all_versions'
 }
 
 const check_filters = (filters) => (node) => {


### PR DESCRIPTION
Fixes #1183

The default value for the version filter was `*`, but the filtering code is looking for `all_versions` as a filter bypass.

This might be indicative of some sort of deeper issue with version comparison.

Either way, `all_versions` seems like the correct value given the following relevant code:

https://github.com/bevyengine/bevy-website/blob/070dfd1a11b4fd684e07a58aa085a78db150c299/static/assets.js#L114-L116

https://github.com/bevyengine/bevy-website/blob/070dfd1a11b4fd684e07a58aa085a78db150c299/templates/assets.html#L18