### PR TITLE
Fix a couple of typos and improve style in `generate-release` README

### DIFF
--- a/generate-release/README.md
+++ b/generate-release/README.md
@@ -4,19 +4,19 @@ This CLI tool is used to generate all the skeleton files required to create a ne
 
 For a bit more background see this issue: <https://github.com/bevyengine/bevy-website/issues/1163>
 
-All commands assume they are ran in the `./generate-release` folder.
+All commands assume they are ran in the `/generate-release` folder.
 
 Each command will generate files in the `/release-content/{release-version}` folder. The `release-version` is an argument to all commands.
 
-Each command have a `--from` and `--to` argument. You can pass it a git tag or a git commit.
+Each command have a `--from` and `--to` argument. You can pass it a Git branch, tag, or commit.
 
-Before running the command, you'll need to generate a github api token at <https://github.com/settings/tokens>. It's easeier to use classic tokens and you don't need any specific role, just the default is enough. Then add it to a file called `.env` like so:
+Before running the command, you'll need to generate a GitHub API token at <https://github.com/settings/tokens>. It's easier to use classic tokens and you don't need any specific role, just the default is enough. Then add it to a file called `.env` like so:
 
 ```env
 GITHUB_TOKEN=token_string_copied_from_github
 ```
 
-Here's an example for the commands used to generate the 0.14 release:
+Here's an example for the commands used to generate the `0.14` release:
 
 ```shell
 cargo run -- --from v0.13.0 --to main --release-version 0.14 migration-guides
@@ -27,7 +27,7 @@ cargo run -- --from v0.13.0 --to main --release-version 0.14 contributors
 
 ## Generating a release
 
-To generate a release from scratch, run all these commands then add the new migration guide and blog post to their respective `/content` folder. When doing so, it's important to use the `public_draft` feature to hide those pages until the day of the release. For the public_draft feature, you'll need to provide it a github issue number, it's recommended to point it to an issue tracker for the current release being worked on. The issue needs to be on the bevy-website repo.
+To generate a release from scratch, run all these commands then add the new migration guide and blog post to their respective `/content` folder. When doing so, it's important to use the `public_draft` feature to hide those pages until the day of the release. For the `public_draft` feature, you'll need to provide it a GitHub issue number, it's recommended to point it to an issue tracker for the current release being worked on. The issue needs to be on the `bevy-website` repo.
 
 The following sections go in more details on each parts of the process.
 
@@ -36,7 +36,7 @@ The following sections go in more details on each parts of the process.
 The `migration-guides` command will generate the `/release-content/{release-version}/migration-guides` folder.
 Inside will be a single `_guides.toml` that contains metadata needed for each guides. Then each guide will be a separate markdown file inside that folder.
 
-Once the files are generated, you can easily add a new migration guide by adding a new file in `content/learn/migration-guides`.
+Once the files are generated, you can easily add a new migration guide by adding a new file in `/content/learn/migration-guides`.
 
 Inside that file, you should have something that looks like this:
 
@@ -64,10 +64,10 @@ The release notes is a bit more complicated since it has multiple parts that nee
 You'll need to use the `release-notes`, `changelog`, and `contributors` commands.
 
 - `release-notes` will generate the `/release-content/{release-version}/release-notes` folder. Inside will be a single `_release-notes.toml` file that contains the list of file names that will be combined into the final blog post. Each PR that needs a release note will then have a file generated.
-- `changelog` generates a `changelog.md` file with a list of all PRs merged sorted by main area.
-- `contributors` generates a `contributors.md` file with a list of all the usernames that authored a PR for the specified release.
+- `changelog` generates a `changelog.toml` file with a list of all PRs merged sorted by main area.
+- `contributors` generates a `contributors.toml` file with a list of all the usernames that authored a PR for the specified release.
 
-Once all those files are generated you'll need to create a new blog post in `content/news`. The content of the `index.md` file should look something like this:
+Once all those files are generated you'll need to create a new blog post in `/content/news`. The content of the `index.md` file should look something like this:
 
 ```markdown
 +++
@@ -92,4 +92,4 @@ public_draft = _release tracking issue number_
 {{ changelog(version="0.14")}}
 ```
 
-The most important part of this is the `combine_release_notes`, `changelog`, and `contributors` shortcodes. `combine_release_notes` will get the list of release notes from the `_release_notes.toml` file and combine all the separate file and add them to this file. `contributors()` will load the `contributors.md` file and generate the necessary markup. `changelog()` will load the `changelog.md` file and generate the necessary markup.
+The most important part of this is the `release_notes`, `changelog`, and `contributors` shortcodes. `release_notes` will get the list of release notes from the `_release_notes.toml` file and combine all the separate file and add them to this file. `contributors()` will load the `contributors.toml` file and generate the necessary markup. `changelog()` will load the `changelog.toml` file and generate the necessary markup.


### PR DESCRIPTION
There were a couple of typos and some shortcodes/paths were outdated. I've added some extra backticks also.