### PR TITLE
Normalize migration guide whitespace

### DIFF
--- a/generate-release/src/migration_guides.rs
+++ b/generate-release/src/migration_guides.rs
@@ -148,8 +148,9 @@ fn write_migration_file(file_path: &PathBuf, pr_body: &str) -> anyhow::Result<()
     if section.ends_with("\n---\n") {
         section = section.replace("\n---\n", "");
     }
-    // Strip trailing whitespace and add a newline at the end
-    section = section.trim_end().to_string() + "\n";
+
+    // Strip leading and trailing whitespace and add a newline at the end
+    section = section.trim_start().trim_end().to_string() + "\n";
 
     write!(file, "{}", section)?;
     Ok(())

--- a/generate-release/src/migration_guides.rs
+++ b/generate-release/src/migration_guides.rs
@@ -148,6 +148,9 @@ fn write_migration_file(file_path: &PathBuf, pr_body: &str) -> anyhow::Result<()
     if section.ends_with("\n---\n") {
         section = section.replace("\n---\n", "");
     }
+    // Strip trailing whitespace and add a newline at the end
+    section = section.trim_end().to_string() + "\n";
+
     write!(file, "{}", section)?;
     Ok(())
 }

--- a/generate-release/src/migration_guides.rs
+++ b/generate-release/src/migration_guides.rs
@@ -150,7 +150,7 @@ fn write_migration_file(file_path: &PathBuf, pr_body: &str) -> anyhow::Result<()
     }
 
     // Strip leading and trailing whitespace and add a newline at the end
-    section = section.trim_start().trim_end().to_string() + "\n";
+    section = section.trim().to_string() + "\n";
 
     write!(file, "{}", section)?;
     Ok(())


### PR DESCRIPTION
> Bit of a nit, but I'm not a fan of all the white space inconsistency in the migration guide. How easy would it be to call str::trim on the file contents, then write an extra \n?

- @BD103 in https://github.com/bevyengine/bevy-website/pull/1191#issuecomment-2126861114

Progress towards #1195.

