### PR TITLE
Remove confusing logging about "migration guide not found"

### DIFF
--- a/generate-release/src/markdown.rs
+++ b/generate-release/src/markdown.rs
@@ -72,7 +72,6 @@ pub fn write_markdown_section(
         // Someone didn't write a migration guide 😢
         if write_todo {
             writeln!(output, "\n<!-- TODO -->")?;
-            println!("\x1b[93m{section_header} not found!\x1b[0m");
         }
         Ok((output, false))
     } else {


### PR DESCRIPTION
Fixes #1190.

Poking through the code here, this is the only form of logging of this sort found. Since a TODO section is added anyways, there's no value in manually logging this error case.

We could instead log which PR this was associated with, but that's noisy and unhelpful: all of these need to be manually checked anyways and a stub is generated already.