### PR TITLE
Add initial release notes for commands + exclusive world access

### DIFF
--- a/release-content/0.14/release-notes/11823_Immediately_apply_deferred_system_params_in_Systemrun.md
+++ b/release-content/0.14/release-notes/11823_Immediately_apply_deferred_system_params_in_Systemrun.md
@@ -1,1 +1,18 @@
-TODO
+Working with `Commands` when you have exclusive world access has always been a pain.
+Create a `CommandQueue`, generate a `Commands` out of that, send your commands and then apply it?
+Not exactly the most intuitive solution.
+
+Now, you can access the `World`'s own command queue:
+
+```rust
+let mut world = World::new();
+let mut commands = world.commands();
+commands.spawn(TestComponent);
+world.flush_commands();
+```
+
+While this isn't the most performant approach (just apply the mutations directly to the world and skip the indirection),
+this API can be great for quickly prototyping with or easily testing your custom commands (and is used internally to power lifecycle hooks).
+
+As a bonus, one-shot systems now apply their commands (and other deferred system params) immediately when run!
+We already have exclusive world access: why introduce delays and subtle bugs?

--- a/release-content/0.14/release-notes/_release-notes.toml
+++ b/release-content/0.14/release-notes/_release-notes.toml
@@ -18,8 +18,8 @@ url = "https://github.com/bevyengine/bevy/pull/12013"
 file_name = "12013_Upstreaming_bevy_color.md"
 
 [[release_notes]]
-title = "Immediately apply deferred system params in System::run"
-authors = ["@james7132","@alice-i-cecile"]
+title = "`Commands` and exclusive world access: working together in harmony"
+authors = ["@james7132", "@james-j-obrien"]
 url = "https://github.com/bevyengine/bevy/pull/11823"
 file_name = "11823_Immediately_apply_deferred_system_params_in_Systemrun.md"
 


### PR DESCRIPTION
I've agglomerated the changes from https://github.com/bevyengine/bevy/pull/11823 and added one of the convenient side effects of https://github.com/bevyengine/bevy/pull/10756 to round it out.

These felt related to me, and the new `World::commands` API is something I've wanted for years :)