### PR TITLE
show [DRAFT] in the <title> of draft pages

### DIFF
--- a/templates/layouts/base.html
+++ b/templates/layouts/base.html
@@ -85,7 +85,7 @@
     <link rel="shortcut icon" type="image/png" href="/assets/favicon.png">
     <link rel="stylesheet" href="/site.css" />
     <link href="/atom.xml" rel="alternate" type="application/atom+xml" />
-    <title>{{ page_title }}</title>
+    <title>{% if page.extra.public_draft or section.extra.public_draft %}[DRAFT] {% endif -%}{{ page_title }}</title>
     {% block head_extensions %}{% endblock head_extensions %}
   </head>
   <body>


### PR DESCRIPTION
https://canary.discord.com/channels/691052431525675048/695741366520512563/1245150398663360542

![image](https://github.com/bevyengine/bevy-website/assets/14184826/382b0935-f378-43a7-af23-54aac45a5ac0)

so i did it:

![image](https://github.com/bevyengine/bevy-website/assets/14184826/76eda906-accf-4bfd-a31d-9e6c63775399)
