### PR TITLE
Move public draft meta tags to base template

### DIFF
--- a/templates/docs.html
+++ b/templates/docs.html
@@ -11,10 +11,6 @@
     {% endif %}
   {% endfor %}
 
-  {% if ancestor_is_public_draft or section_or_page and section_or_page.extra and section_or_page.extra.public_draft %}
-    <meta name="robots" content="noindex, nofollow, noarchive">
-  {% endif %}
-
   <script src="/optional-helpers.js"></script>
   <script defer src="/on-this-page.js"></script>
 {% endblock head_extensions %}

--- a/templates/layouts/base.html
+++ b/templates/layouts/base.html
@@ -85,6 +85,10 @@
     <link rel="shortcut icon" type="image/png" href="/assets/favicon.png">
     <link rel="stylesheet" href="/site.css" />
     <link href="/atom.xml" rel="alternate" type="application/atom+xml" />
+    {% if ancestor_is_public_draft or section_or_page and section_or_page.extra and section_or_page.extra.public_draft %}
+    <meta name="robots" content="noindex, nofollow, noarchive">
+    {% endif %}
+
     <title>{% if page.extra.public_draft or section.extra.public_draft %}[DRAFT] {% endif -%}{{ page_title }}</title>
     {% block head_extensions %}{% endblock head_extensions %}
   </head>


### PR DESCRIPTION
Since public draft no longer applies only to docs pages, these tags should be in a universal place. Otherwise, for example, the news posts would still be visible to search engines generally.

Issue pointed out on Discord here by HopelessPlatonic / SIGSTACKFAULT: https://discord.com/channels/691052431525675048/695741366520512563/1245168247368712212