### PR TITLE
More migration guides! (Yippee)

### DIFF
--- a/release-content/0.14/migration-guides/11707_Rework_animation_to_be_done_in_two_phases.md
+++ b/release-content/0.14/migration-guides/11707_Rework_animation_to_be_done_in_two_phases.md
@@ -1,7 +1,9 @@
-- `AnimationClip` now uses UUIDs instead of hierarchical paths based on the `Name` component to refer to bones. This has several consequences:
-  - A new component, `AnimationTarget`, should be placed on each bone that you wish to animate, in order to specify its UUID and the associated `AnimationPlayer`. The glTF loader automatically creates these components as necessary, so most uses of glTF rigs shouldn’t need to change.
-  - Moving a bone around the tree, or renaming it, no longer prevents an `AnimationPlayer` from affecting it.
-  - Dynamically changing the `AnimationPlayer` component will likely require manual updating of the `AnimationTarget` components.
+`AnimationClip` now uses UUIDs instead of hierarchical paths based on the `Name` component to refer to bones. This has several consequences:
 
-- Entities with `AnimationPlayer` components may now possess descendants that also have `AnimationPlayer` components. They may not, however, animate the same bones.
-- As they aren’t specific to `TypeId`s, `bevy_reflect::utility::NoOpTypeIdHash` and `bevy_reflect::utility::NoOpTypeIdHasher` have been renamed to `bevy_reflect::utility::NoOpHash` and `bevy_reflect::utility::NoOpHasher` respectively.
+- A new component, `AnimationTarget`, should be placed on each bone that you wish to animate, in order to specify its UUID and the associated `AnimationPlayer`. The glTF loader automatically creates these components as necessary, so most uses of glTF rigs shouldn’t need to change.
+- Moving a bone around the tree, or renaming it, no longer prevents an `AnimationPlayer` from affecting it.
+- Dynamically changing the `AnimationPlayer` component will likely require manual updating of the `AnimationTarget` components.
+
+Entities with `AnimationPlayer` components may now possess descendants that also have `AnimationPlayer` components. They may not, however, animate the same bones.
+
+Furthermore, `NoOpTypeIdHash` and `NoOpTypeIdHasher` have been renamed to `NoOpHash` and `NoOpHasher`.

--- a/release-content/0.14/migration-guides/12557_refactor_separate_out_PanicHandlerPlugin.md
+++ b/release-content/0.14/migration-guides/12557_refactor_separate_out_PanicHandlerPlugin.md
@@ -1,1 +1,9 @@
-- If you used `MinimalPlugins` with `LogPlugin` for a WASM-target build, you will need to add the new `PanicHandlerPlugin` to set the panic behavior to output to the console. Otherwise, you will see the default panic handler (opaque, `unreachable` errors in the console).
+`LogPlugin` used to silenty override the panic handler on WASM targets. This functionality has now been split out into the new `PanicHandlerPlugin`, which was added to `DefaultPlugins`.
+
+If you want nicer error messages on WASM but don't use `DefaultPlugins`, make sure to manually add `PanicHandlerPlugin` to the app.
+
+```rust
+App::new()
+    .add_plugins((MinimalPlugins, PanicHandlerPlugin))
+    .run();
+```

--- a/release-content/0.14/migration-guides/12575_Color_maths_4.md
+++ b/release-content/0.14/migration-guides/12575_Color_maths_4.md
@@ -1,1 +1,54 @@
-- Users of scalar mul/div for `LinearRgba` need to be aware of the change and maybe use the `.clamp()` methods or manually set the `alpha` channel.
+Multiplying and dividing a `LinearRgba` by an `f32` used to skip the alpha channel, but now it is modified.
+
+```rust
+// Before
+let color = LinearRgba {
+    red: 1.0,
+    green: 1.0,
+    blue: 1.0,
+    alpha: 1.0,
+} * 0.5;
+
+// Alpha is preserved, ignoring the multiplier.
+assert_eq!(color.alpha, 1.0);
+
+// After
+let color = LinearRgba {
+    red: 1.0,
+    green: 1.0,
+    blue: 1.0,
+    alpha: 1.0,
+} * 0.5;
+
+// Alpha is included in multiplication.
+assert_eq!(color.alpha, 0.5);
+```
+
+If you need the alpha channel to remain within the valid range from 0.0 to 1.0, consider clamping it:
+
+```rust
+let mut color = LinearRgba {
+    red: 1.0,
+    green: 1.0,
+    blue: 1.0,
+    alpha: 1.0,
+} * 10.0;
+
+color.alpha = color.alpha.clamp(0.0, 1.0);
+```
+
+Note that in some cases, such as rendering sprites, the alpha is automatically clamped so you do not need to do it manually.
+
+If you need the alpha channel to remain constant, consider overwriting it:
+
+```rust
+let color = LinearRgba {
+    red: 1.0,
+    green: 1.0,
+    blue: 1.0,
+    alpha: 1.0,
+};
+
+// Overwrite the alpha to always be 1.0.
+let new_color = (color / 2.0).with_alpha(1.0);
+```

--- a/release-content/0.14/migration-guides/12575_Color_maths_4.md
+++ b/release-content/0.14/migration-guides/12575_Color_maths_4.md
@@ -2,7 +2,7 @@ Multiplying and dividing a `LinearRgba` by an `f32` used to skip the alpha chann
 
 ```rust
 // Before
-let color = LinearRgba {
+let color = Color::RgbaLinear {
     red: 1.0,
     green: 1.0,
     blue: 1.0,
@@ -10,7 +10,7 @@ let color = LinearRgba {
 } * 0.5;
 
 // Alpha is preserved, ignoring the multiplier.
-assert_eq!(color.alpha, 1.0);
+assert_eq!(color.a(), 1.0);
 
 // After
 let color = LinearRgba {
@@ -23,21 +23,6 @@ let color = LinearRgba {
 // Alpha is included in multiplication.
 assert_eq!(color.alpha, 0.5);
 ```
-
-If you need the alpha channel to remain within the valid range from 0.0 to 1.0, consider clamping it:
-
-```rust
-let mut color = LinearRgba {
-    red: 1.0,
-    green: 1.0,
-    blue: 1.0,
-    alpha: 1.0,
-} * 10.0;
-
-color.alpha = color.alpha.clamp(0.0, 1.0);
-```
-
-Note that in some cases, such as rendering sprites, the alpha is automatically clamped so you do not need to do it manually.
 
 If you need the alpha channel to remain constant, consider overwriting it:
 
@@ -52,3 +37,19 @@ let color = LinearRgba {
 // Overwrite the alpha to always be 1.0.
 let new_color = (color / 2.0).with_alpha(1.0);
 ```
+
+If you need the alpha channel to remain within the range of 0.0 to 1.0, consider clamping it:
+
+```rust
+let mut color = LinearRgba {
+    red: 1.0,
+    green: 1.0,
+    blue: 1.0,
+    alpha: 1.0,
+} * 10.0;
+
+color.alpha = color.alpha.clamp(0.0, 1.0);
+```
+
+<!-- TODO: I want this to be a callout, but shortcodes don't work here. -->
+Note that in some cases, such as rendering sprites, the alpha is automatically clamped so you do not need to do it manually.

--- a/release-content/0.14/migration-guides/_guides.toml
+++ b/release-content/0.14/migration-guides/_guides.toml
@@ -11,19 +11,19 @@ areas = []
 file_name = "12512_update_to_fixedbitset_05.md"
 
 [[guides]]
-title = "refactor: separate out `PanicHandlerPlugin`"
+title = "Move WASM panic handler from `LogPlugin` to `PanicHandlerPlugin`"
 url = "https://github.com/bevyengine/bevy/pull/12557"
 areas = []
 file_name = "12557_refactor_separate_out_PanicHandlerPlugin.md"
 
 [[guides]]
-title = "Rework animation to be done in two phases."
+title = "`AnimationClip` now uses UUIDs and `NoOpTypeIdHash` is now `NoOpHash`"
 url = "https://github.com/bevyengine/bevy/pull/11707"
 areas = ["Animation"]
 file_name = "11707_Rework_animation_to_be_done_in_two_phases.md"
 
 [[guides]]
-title = "Color maths 4"
+title = "Multiplying `LinearRgba` by `f32` no longer ignores alpha channel"
 url = "https://github.com/bevyengine/bevy/pull/12575"
 areas = ["Animation","Color","Math","Rendering"]
 file_name = "12575_Color_maths_4.md"


### PR DESCRIPTION
Here's another round of migration guides! I'm going to get a few more done before marking it as ready-for-review.

## Open questions

- Shortcodes don't seem to work in migration guides. I tried using `{% callout() %}`, but it just rendered as plain text. This should probably be turned into an issue, though I don't know how easily it would be solved.
- I don't know much about Bevy's animation, and thus cannot accurately provide code samples for `11707_Rework_animation_to_be_done_in_two_phases.md`. Would someone with more experience be able to help me here? (cc @pcwalton, if you have the time 😄)