### PR TITLE
Add release notes for PR #5781: bevy_reflect: Recursive registration

### DIFF
--- a/release-content/0.14/release-notes/5781_bevy_reflect_Recursive_registration.md
+++ b/release-content/0.14/release-notes/5781_bevy_reflect_Recursive_registration.md
@@ -1,1 +1,39 @@
-TODO
+Bevy uses reflection in order to dynamically process data for things like serialization and deserialization.
+This often requires Bevy to know that a type even exists.
+This is why users need to register their types into the `TypeRegistry`.
+
+```rust
+#[derive(Reflect)]
+struct Data<T> {
+  value: T,
+}
+
+#[derive(Reflect)]
+struct Blob {
+  contents: Vec<u8>,
+}
+
+app
+  .register_type::<Data<Blob>>()
+  .register_type::<Blob>()
+  .register_type::<Vec<u8>>()
+```
+
+In the code above, `Data<Blob>` depends on `Blob` which depends on `Vec<u8>`,
+which means that all three types need to be manually registered—
+even if we only care about `Data<Blob>`.
+
+This is both tedious and error-prone, especially when these type dependencies are only
+used in the context of other types (i.e. they aren't used as standalone types).
+
+In 0.14, any type that derives `Reflect` will automatically register all of its type dependencies.
+So when we register `Data<Blob>`, `Blob` will be registered as well (which will register `Vec<u8>`),
+thus simplifying our registration down to a single line:
+
+```rust
+app.register_type::<Data<Blob>>()
+```
+
+Note that removing the registration for `Data<Blob>` now also means that `Blob` and `Vec<u8>` may 
+not be registered either, unless they were registered some other way. 
+If those types are needed as standalone types, they should be registered separately.

--- a/release-content/0.14/release-notes/5781_bevy_reflect_Recursive_registration.md
+++ b/release-content/0.14/release-notes/5781_bevy_reflect_Recursive_registration.md
@@ -1,4 +1,4 @@
-Bevy uses reflection in order to dynamically process data for things like serialization and deserialization.
+Bevy uses [reflection](https://docs.rs/bevy_reflect/latest/bevy_reflect/) in order to dynamically process data for things like serialization and deserialization.
 This often requires Bevy to know that a type even exists.
 This is why users need to register their types into the `TypeRegistry`.
 

--- a/release-content/0.14/release-notes/5781_bevy_reflect_Recursive_registration.md
+++ b/release-content/0.14/release-notes/5781_bevy_reflect_Recursive_registration.md
@@ -1,6 +1,6 @@
 Bevy uses [reflection](https://docs.rs/bevy_reflect/latest/bevy_reflect/) in order to dynamically process data for things like serialization and deserialization.
-This often requires Bevy to know that a type even exists.
-This is why users need to register their types into the `TypeRegistry`.
+A Bevy app has a `TypeRegistry` to keep track of which types exist.
+Users can register their custom types when initializing the app or plugin.
 
 ```rust
 #[derive(Reflect)]


### PR DESCRIPTION
Fixes #1236 

Adds release notes for recursive registration in `bevy_reflect`.

---

There's a small amount of nuance that I chose to gloss over such as why we're doing this instead of using `inventory` or `linkme`, or which specific things actually rely on these registrations.

I also chose not to go into detail about how this works under the hood via changes to `GetTypeRegistration` since most users probably don't even know that trait exists.

I did, however, mention that there is still an opportunity for a footgun if a type that's used on its own (i.e. a component, a resource, etc.) is implicitly registered by another type. This is hopefully a lot less likely to occur than forgetting to register an internal type, but still a possibility. This isn't required information, so we can remove it if its too much or detracts from the rest of the feature, but I thought it might still be good to draw attention to.

Anyways, let me know if there's anything that should be added/changed/removed!