### PR TITLE
Make foundation logo responsive to avoid horizontal scrollbar on mobile

### DIFF
--- a/sass/pages/_foundation.scss
+++ b/sass/pages/_foundation.scss
@@ -3,7 +3,8 @@
 }
 
 .foundation-logo {
-    height: 110px;
+    max-height: 110px;
+    max-width: 100%;
     margin-top: 2.2rem;
     margin-bottom: 0.8rem;
 }


### PR DESCRIPTION
Currently, the foundation page has a horizontal scrollbar on most mobile devices due to the foundation logo having a fixed size larger than the page width.

![Screen Shot 2024-06-03 at 16 13 34](https://github.com/bevyengine/bevy-website/assets/11900073/81bee83e-903e-4ce4-b240-818562734ea8)

This PR adds a maximum width of 100% to the logo style to avoid this issue.