### PR TITLE
Release notes for 12672: Dynamic linking no-op on WASM

### DIFF
--- a/release-content/0.14/release-notes/12672_Make_dynamic_linking_a_noop_on_wasm_targets.md
+++ b/release-content/0.14/release-notes/12672_Make_dynamic_linking_a_noop_on_wasm_targets.md
@@ -1,1 +1,8 @@
-TODO
+WASM does not support dynamic libraries that can be linked to during runtime. Before, Bevy would fail to compile if you enabled the `dynamic_linking` feature.
+
+```bash
+$ cargo build --target wasm32-unknown-unknown --features bevy/dynamic_linking
+error: cannot produce dylib for `bevy_dylib v0.13.2` as the target `wasm32-unknown-unknown` does not support these crate types
+```
+
+This has been changed so that Bevy will fallback to statically linking at compile time for all WASM platforms. If you enable `dynamic_linking` for development, you no longer need to disable it for WASM.

--- a/release-content/0.14/release-notes/12672_Make_dynamic_linking_a_noop_on_wasm_targets.md
+++ b/release-content/0.14/release-notes/12672_Make_dynamic_linking_a_noop_on_wasm_targets.md
@@ -5,4 +5,4 @@ $ cargo build --target wasm32-unknown-unknown --features bevy/dynamic_linking
 error: cannot produce dylib for `bevy_dylib v0.13.2` as the target `wasm32-unknown-unknown` does not support these crate types
 ```
 
-This has been changed so that Bevy will fallback to statically linking at compile time for all WASM platforms. If you enable `dynamic_linking` for development, you no longer need to disable it for WASM.
+Now, Bevy will fallback to static linking for all WASM targets. If you enable `dynamic_linking` for development, you no longer need to disable it for WASM.

--- a/release-content/0.14/release-notes/_release-notes.toml
+++ b/release-content/0.14/release-notes/_release-notes.toml
@@ -221,7 +221,7 @@ url = "https://github.com/bevyengine/bevy/pull/12755"
 file_name = "12755_Meshlet_continuous_LOD.md"
 
 [[release_notes]]
-title = "Make dynamic_linking a no-op on wasm targets"
+title = "Make dynamic_linking a no-op on WASM targets"
 authors = ["@james7132","@BD103"]
 url = "https://github.com/bevyengine/bevy/pull/12672"
 file_name = "12672_Make_dynamic_linking_a_noop_on_wasm_targets.md"


### PR DESCRIPTION
Closes #1304.

I fear this may be too brief, but it gets the point across.