### PR TITLE
Rename Rotation2d

### DIFF
--- a/release-content/0.14/changelog.toml
+++ b/release-content/0.14/changelog.toml
@@ -1198,7 +1198,7 @@ number = 11681
 title = "Add note about rotations for `Aabb3d`"
 number = 12315
 [[areas.prs]]
-title = "Add `Rotation2d`"
+title = "Add `Rot2`"
 number = 11658
 [[areas.prs]]
 title = "Add `scale_around_center` method to `BoundingVolume` trait"

--- a/release-content/0.14/changelog.toml
+++ b/release-content/0.14/changelog.toml
@@ -1198,7 +1198,7 @@ number = 11681
 title = "Add note about rotations for `Aabb3d`"
 number = 12315
 [[areas.prs]]
-title = "Add `Rot2`"
+title = "A 2D rotation type"
 number = 11658
 [[areas.prs]]
 title = "Add `scale_around_center` method to `BoundingVolume` trait"

--- a/release-content/0.14/release-notes/11658_Add_Rotation2d.md
+++ b/release-content/0.14/release-notes/11658_Add_Rotation2d.md
@@ -1,10 +1,10 @@
 Ever wanted to work with rotations in 2D and get frustrated with having to choose between quaternions and a raw `f32`?
 Us too!
 
-We've added a convenient [`Rotation2d`](https://dev-docs.bevyengine.org/bevy/math/struct.Rotation2d.html) type for you, with plenty of helper methods.
+We've added a convenient [`Rot2`](https://dev-docs.bevyengine.org/bevy/math/struct.Rot2.html) type for you, with plenty of helper methods.
 Feel free to replace that helper type you wrote, and submit little PRs for any useful functionality we're missing.
 
-`Rotation2d` is a great complement to the [`Dir2`](https://dev-docs.bevyengine.org/bevy/math/struct.Dir2.html) type (formerly `Direction2d`).
+`Rot2` is a great complement to the [`Dir2`](https://dev-docs.bevyengine.org/bevy/math/struct.Dir2.html) type (formerly `Direction2d`).
 The former represents an angle, while the latter is a unit vector.
 These types are similar but not interchangeable, and the choice of representation depends heavily on the task at hand. You can rotate a direction using `direction = rotation * Dir2::X`. To recover the rotation, use `Dir2::X::rotation_to(direction)` or in this case the helper `Dir2::rotation_from_x(direction)`.
 


### PR DESCRIPTION
Following the rename in https://github.com/bevyengine/bevy/pull/13694 update the release notes accordingly.