### PR TITLE
0.14 migration: Fix example code for moved commands module

### DIFF
--- a/release-content/0.14/migration-guides/12234_Move_commands_module_into_bevyecsworld.md
+++ b/release-content/0.14/migration-guides/12234_Move_commands_module_into_bevyecsworld.md
@@ -2,7 +2,7 @@
 
 ```rust
 // 0.13
-use bevy::ecs::world::{Command, CommandQueue};
-// 0.14
 use bevy::ecs::system::{Command, CommandQueue};
+// 0.14
+use bevy::ecs::world::{Command, CommandQueue};
 ```


### PR DESCRIPTION
The description and code example for the [Move commands module migration guide](https://bevyengine.org/learn/migration-guides/0-13-to-0-14/#move-commands-module-into-bevy-ecs-world ) did not match. Checked that the example was wrong and changed it.