### PR TITLE
0.14 migration: Show new paths to state types

### DIFF
--- a/release-content/0.14/migration-guides/13216_Separate_state_crate.md
+++ b/release-content/0.14/migration-guides/13216_Separate_state_crate.md
@@ -1,5 +1,17 @@
 States were moved to a separate crate which is gated behind the `bevy_state` feature. Projects that use state but don't use Bevy's `default-features` will need to add that feature to their `Cargo.toml`.
 
-Projects that use `bevy_ecs` directly and use states will need to add the `bevy_state` crate as a dependency.
+Projects that use `bevy_ecs` directly and use states will need to add the `bevy_state` **crate** as a dependency.
 
-Projects that use `bevy_app` directly and use states will need to add the `bevy_state` feature.
+Projects that use `bevy_app` directly and use states will need to add the `bevy_state` **feature**.
+
+Users should update imports that referenced the old location.
+
+```rust
+// 0.13
+use bevy::ecs::schedule::{NextState, OnEnter, OnExit, OnTransition, State, States}
+use bevy::ecs::schedule::common_conditions::in_state
+
+// 0.14
+use bevy::state::state::{NextState, OnEnter, OnExit, OnTransition, State, States}
+use bevy::state::condition::in_state;
+```


### PR DESCRIPTION
Minor, but this might save someone a second, or help them find the right section with ctrl-f.

Also added emphasis to `crate` and `feature` in lines above, as I remember that being misread by someone.