### PR TITLE
0.14 migration: Fix formatting of LoadStateFailed migration

### DIFF
--- a/release-content/0.14/migration-guides/12709_Error_info_has_been_added_to_LoadStateFailed.md
+++ b/release-content/0.14/migration-guides/12709_Error_info_has_been_added_to_LoadStateFailed.md
@@ -1,3 +1,14 @@
-Added [AssetLoadError](https://docs.rs/bevy/latest/bevy/asset/enum.AssetLoadError.html) to [LoadState::Failed](https://docs.rs/bevy/latest/bevy/asset/enum.LoadState.html) option
+Added [AssetLoadError](https://docs.rs/bevy/latest/bevy/asset/enum.AssetLoadError.html) to the [LoadState::Failed](https://docs.rs/bevy/latest/bevy/asset/enum.LoadState.html) variant.
+
+If you're comparing for equality with `LoadState::Failed`, you'll need to use pattern matching instead.
+
+```rust
+// 0.13
+if state == LoadState::Failed {}
+// 0.14
+if matches!(state, LoadState::Failed(_)) {}
+```
+
 Removed `Copy`, `Ord` and `PartialOrd` implementations for [LoadState](https://docs.rs/bevy/latest/bevy/asset/enum.LoadState.html) enum
+
 Added `Eq` and `PartialEq` implementations for [MissingAssetSourceError](https://docs.rs/bevy/latest/bevy/asset/io/struct.MissingAssetSourceError.html), [MissingProcessedAssetReaderError](https://docs.rs/bevy/latest/bevy/asset/io/struct.MissingProcessedAssetReaderError.html), [DeserializeMetaError](https://docs.rs/bevy/latest/bevy/asset/enum.DeserializeMetaError.html), [LoadState](https://docs.rs/bevy/latest/bevy/asset/enum.LoadState.html), [AssetLoadError](https://docs.rs/bevy/latest/bevy/asset/enum.AssetLoadError.html), [MissingAssetLoaderForTypeNameError](https://docs.rs/bevy/latest/bevy/asset/struct.MissingAssetLoaderForTypeNameError.html) and [MissingAssetLoaderForTypeIdError](https://docs.rs/bevy/latest/bevy/asset/struct.MissingAssetLoaderForTypeIdError.html)


### PR DESCRIPTION
It looks like these three separate sentences were intended to have some line breaks. In the current rendered migration guide, they end up all smooshed into one big crazy paragraph.

I also added a small code block for one specific scenario I encountered.

This section might need some more work (is the third item even breaking?) but I'm not really sure what to suggest for people who were ordering `LoadState` because I don't understand why someone would have needed to do that.

Happy to implement suggestions / nuke the third line, but would prefer to get this formatting improvement in without doing more research on this changeset.