### PR TITLE
Mention StatesPlugin in the migration docs

### DIFF
--- a/release-content/0.14/migration-guides/13216_Separate_state_crate.md
+++ b/release-content/0.14/migration-guides/13216_Separate_state_crate.md
@@ -4,4 +4,4 @@ Projects that use `bevy_ecs` directly and use states will need to add the `bevy_
 
 Projects that use `bevy_app` directly and use states will need to add the `bevy_state` feature.
 
-To enable state functionality to your app, you will need to add the `StatesPlugin`.
+If you do not use `DefaultPlugins`, you will need to add the `StatesPlugin` manually to your app.

--- a/release-content/0.14/migration-guides/13216_Separate_state_crate.md
+++ b/release-content/0.14/migration-guides/13216_Separate_state_crate.md
@@ -3,3 +3,5 @@ States were moved to a separate crate which is gated behind the `bevy_state` fea
 Projects that use `bevy_ecs` directly and use states will need to add the `bevy_state` crate as a dependency.
 
 Projects that use `bevy_app` directly and use states will need to add the `bevy_state` feature.
+
+To enable state functionality to your app, you will need to add the `StatesPlugin`.


### PR DESCRIPTION
I was blocked for a while when migrating to 0.14 because I didn't realize that on top of adding the `bevy_state` feature you need to add the `StatesPlugin`

I'm actually a bit confused as to why adding the `StatesPlugin` was needed:
- https://github.com/bevyengine/bevy/blob/main/crates/bevy_state/src/app.rs#L193 it doesn't seem to do much apart from inserting an empty `StateTransition`  schedule
- but then inserting a new state (https://github.com/cBournhonesque/bevy/blob/a4f324fdb490d75d808fd8cb54690a7b35af2f9d/crates/bevy_state/src/state/transitions.rs#L148-L148) doesn't add the sets inside the `StateTransition` schedule

Is it correct that we need the  `StatesPlugin` for states to work? It seemed to me that states did not work if I was just using the MinimalPlugins