### PR TITLE
Explain that `App` is not `Send` anymore

### DIFF
--- a/release-content/0.14/migration-guides/9202_Refactor_App_and_SubApp_internals_for_better_separation.md
+++ b/release-content/0.14/migration-guides/9202_Refactor_App_and_SubApp_internals_for_better_separation.md
@@ -42,6 +42,8 @@ app.insert_sub_app(MySubApp, sub_app);
 
 #### `App` changes
 
+`App` is not `Send` anymore, but `SubApp` still is.
+
 Due to the separation of `App` and `SubApp`, a few other methods have been changed.
 
 First, `App::world` as a property is no longer directly accessible. Instead use the getters `App::world` and `App::world_mut`.


### PR DESCRIPTION
See https://github.com/bevyengine/bevy/pull/13754#issuecomment-2158517375

App is not `Send` anymore, because `App` will contain the Non-Send resources (so that World and SubApp can be completely Send)