### PR TITLE
0.14 migration: Slightly more help for users who had their colors changed

### DIFF
--- a/release-content/0.14/migration-guides/12163_Migrate_from_LegacyColor_to_bevy_colorColor.md
+++ b/release-content/0.14/migration-guides/12163_Migrate_from_LegacyColor_to_bevy_colorColor.md
@@ -133,7 +133,7 @@ Please note that `palettes::css` is not necessarily 1:1 with the constants defin
 
 |0.13|0.14|
 |-|-|
-|`GREEN`|`LIME_GREEN`|
+|`GREEN`|`LIMEGREEN`|
 |`PINK`|`DEEP_PINK`|
 |`DARK_GRAY`|`Srgba::gray(0.25)`|
 

--- a/release-content/0.14/migration-guides/12163_Migrate_from_LegacyColor_to_bevy_colorColor.md
+++ b/release-content/0.14/migration-guides/12163_Migrate_from_LegacyColor_to_bevy_colorColor.md
@@ -117,7 +117,7 @@ Alpha, also known as transparency, used to be referred to by the letter `a`. It 
 
 #### CSS Constants
 
-The various CSS color constants are no longer stored directly on `Color`. Instead, they’re defined in the `Srgba` color space, and accessed via `bevy::color::palettes`. Call `.into()` on them to convert them into a `Color` for quick debugging use. Please note that these palettes are not necessarily 1:1 with the constants defined previously as some names and colors have been changed. If you need the same color as before, consider copying the constant into your own code.
+The various CSS color constants are no longer stored directly on `Color`. Instead, they’re defined in the `Srgba` color space, and accessed via `bevy::color::palettes`. Call `.into()` on them to convert them into a `Color` for quick debugging use.
 
 ```rust
 // Before
@@ -128,6 +128,14 @@ use bevy::color::palettes::css::BLUE;
 
 let color = BLUE;
 ```
+
+Please note that `palettes::css` is not necessarily 1:1 with the constants defined previously as some names and colors have been changed to conform with the css spec. If you need the same color as before, consult the table below or use the color values from the [old constants](https://github.com/bevyengine/bevy/blob/v0.13.2/crates/bevy_render/src/color/mod.rs#L60).
+
+|0.13|0.14|
+|-|-|
+|`GREEN`|`LIME_GREEN`|
+|`PINK`|`DEEP_PINK`|
+|`DARK_GRAY`|`Srgba::gray(0.25)`|
 
 #### Switch to `LinearRgba`
 

--- a/release-content/0.14/migration-guides/12163_Migrate_from_LegacyColor_to_bevy_colorColor.md
+++ b/release-content/0.14/migration-guides/12163_Migrate_from_LegacyColor_to_bevy_colorColor.md
@@ -129,7 +129,7 @@ use bevy::color::palettes::css::BLUE;
 let color = BLUE;
 ```
 
-Please note that `palettes::css` is not necessarily 1:1 with the constants defined previously as some names and colors have been changed to conform with the css spec. If you need the same color as before, consult the table below or use the color values from the [old constants](https://github.com/bevyengine/bevy/blob/v0.13.2/crates/bevy_render/src/color/mod.rs#L60).
+Please note that `palettes::css` is not necessarily 1:1 with the constants defined previously as some names and colors have been changed to conform with the CSS spec. If you need the same color as before, consult the table below or use the color values from the [old constants](https://github.com/bevyengine/bevy/blob/v0.13.2/crates/bevy_render/src/color/mod.rs#L60).
 
 |0.13|0.14|
 |-|-|


### PR DESCRIPTION
These are simple changes to migrate, but we are asking users to do a lot of research and could be helping them out a bit more.

I think these three colors were the extent of the damage for "color values getting changed," though maybe we could also throw "colors that simply had their names changed" into the table as well.

Do we have a handy list of those? I thought they were listed in some iteration of the migration guide previously.

For reference:

https://github.com/bevyengine/bevy/pull/12451
https://github.com/bevyengine/bevy/pull/12333
https://github.com/bevyengine/bevy/pull/12328