### PR TITLE
Fix reversed logic in ReceivedCharacter section

### DIFF
--- a/release-content/0.14/migration-guides/12868_Deprecate_ReceivedCharacter.md
+++ b/release-content/0.14/migration-guides/12868_Deprecate_ReceivedCharacter.md
@@ -1,28 +1,30 @@
 `ReceivedCharacter` is now deprecated, use `KeyboardInput` instead.
 
-Before:
-
 ```rust
+// 0.13
 fn listen_characters(events: EventReader<ReceivedCharacter>) {
   for event in events.read() {
     info!("{}", event.char);
   }
 }
-```
 
-After:
-
-```rust
+// 0.14
 fn listen_characters(events: EventReader<KeyboardInput>) {
   for event in events.read() {
     // Only check for characters when the key is pressed.
-    if event.state == ButtonState::Released {
+    if !event.state.is_pressed() {
       continue;
     }
     // Note that some keys such as `Space` and `Tab` won't be detected as before.
     // Instead, check for them with `Key::Space` and `Key::Tab`.
-    if let Key::Character(character) = &event.logical_key {
-      info!("{}", character);
+    match &event.logical_key {
+        Key::Character(character) => {
+            info!("{} pressed.", character);
+        }
+        Key::Space => {
+            info!("Space pressed.");
+        }
+        _ => {}
     }
   }
 }


### PR DESCRIPTION
This primarily fixes an issue where the behavior in the code was not matching this comment:

```
// Only check for characters when the key is pressed.
```

I believe the comment is correct. In places where users were previously using `ReceivedChar`, they would want the character immediately upon the key being pressed rather than waiting for release.
