### PR TITLE
0.14 migration: Touch up SpriteSheetBundle deprecation section

### DIFF
--- a/release-content/0.14/migration-guides/12218_Deprecate_SpriteSheetBundle_and_AtlasImageBundle.md
+++ b/release-content/0.14/migration-guides/12218_Deprecate_SpriteSheetBundle_and_AtlasImageBundle.md
@@ -1,2 +1,49 @@
-- `SpriteSheetBundle` has been deprecated. Use `TextureAtlas` alongside a `SpriteBundle` instead.
-- `AtlasImageBundle` has been deprecated. Use `TextureAtlas` alongside an `ImageBundle` instead.
+`SpriteSheetBundle` has been deprecated. Insert the `TextureAtlas` component alongside a `SpriteBundle` instead.
+
+```rust
+// 0.13
+commands.spawn(SpriteSheetBundle {
+    texture,
+    atlas: TextureAtlas {
+        layout,
+        ..default()
+    },
+    ..default()
+});
+// 0.14
+commands.spawn((
+    SpriteBundle {
+        texture,
+        ..default()
+    },
+    TextureAtlas {
+        layout,
+        ..default()
+    },
+));
+```
+
+`AtlasImageBundle` has been deprecated. Insert the `TextureAtlas` component alongside an `ImageBundle` instead.
+
+```rust
+// 0.13
+commands.spawn(AtlasImageBundle {
+    image,
+    atlas: TextureAtlas {
+        layout,
+        ..default()
+    },
+    ..default()
+});
+// 0.14
+commands.spawn((
+    ImageBundle {
+        image,
+        ..default()
+    },
+    TextureAtlas {
+        layout,
+        ..default()
+    },
+));
+```


### PR DESCRIPTION
The code blocks may be a bit too much. I'm not attached to them.

But I found the previous wording somewhat unclear.