### PR TITLE
The Bevy of birds are migrating south for the summer

### DIFF
--- a/release-content/0.14/migration-guides/11823_Immediately_apply_deferred_system_params_in_Systemrun.md
+++ b/release-content/0.14/migration-guides/11823_Immediately_apply_deferred_system_params_in_Systemrun.md
@@ -1,13 +1,13 @@
 The default implementation of `System::run` will now always immediately run `System::apply_deferred`. If you were manually calling `System::apply_deferred` in this situation, you may remove it. Please note that `System::run_unsafe` still _does not_ call `apply_deferred` because it cannot guarantee it will be safe.
 
 ```rust
-// Before
+// 0.13
 system.run(world);
 
 // Sometime later:
 system.apply_deferred(world);
 
-// After
+// 0.14
 system.run(world);
 
 // `apply_deferred` no longer needs to be called!

--- a/release-content/0.14/migration-guides/11823_Immediately_apply_deferred_system_params_in_Systemrun.md
+++ b/release-content/0.14/migration-guides/11823_Immediately_apply_deferred_system_params_in_Systemrun.md
@@ -1,11 +1,14 @@
-`System::run` will now always run `System::apply_deferred` immediately after running the system now. If you were running systems and then applying their deferred buffers at a later point in time, you can eliminate the latter.
+The default implementation of `System::run` will now always immediately run `System::apply_deferred`. If you were manually calling `System::apply_deferred` in this situation, you may remove it. Please note that `System::run_unsafe` still _does not_ call `apply_deferred` because it cannot guarantee it will be safe.
 
 ```rust
-// in 0.13
+// Before
 system.run(world);
-// .. sometime later ...
+
+// Sometime later:
 system.apply_deferred(world);
 
-// in 0.14
+// After
 system.run(world);
+
+// `apply_deferred` no longer needs to be called!
 ```

--- a/release-content/0.14/migration-guides/11986_Remove_the_UpdateAssets_and_AssetEvents_schedules.md
+++ b/release-content/0.14/migration-guides/11986_Remove_the_UpdateAssets_and_AssetEvents_schedules.md
@@ -1,13 +1,13 @@
 The `UpdateAssets` schedule has been removed. If you add systems to this schedule, move them to run on `PreUpdate`. (You may need to configure the ordering with `system.before(...)` and `system.after(...)`.)
 
 ```rust
-// Before
+// 0.13
 App::new()
     .add_plugins(DefaultPlugins)
     .add_systems(UpdateAssets, my_system)
     .run();
 
-// After
+// 0.14
 App::new()
     .add_plugins(DefaultPlugins)
     .add_systems(PreUpdate, my_system)
@@ -17,13 +17,13 @@ App::new()
 Furthermore, `AssetEvents` has been changed from a `ScheduleLabel` to a `SystemSet` within the `First` schedule.
 
 ```rust
-// Before
+// 0.13
 App::new()
     .add_plugins(DefaultPlugins)
     .add_systems(AssetEvents, my_system)
     .run();
 
-// After
+// 0.14
 App::new()
     .add_plugins(DefaultPlugins)
     .add_systems(First, my_system.in_set(AssetEvents))

--- a/release-content/0.14/migration-guides/12038_fix_some_typos.md
+++ b/release-content/0.14/migration-guides/12038_fix_some_typos.md
@@ -1,9 +1,9 @@
 `Node2d::ConstrastAdaptiveSharpening` from `bevy::core_pipeline::core_2d::graph` has been renamed to fix a typo. It was originally `Constrast`, but is now `Contrast`.
 
 ```rust
-// Before
+// 0.13
 Node2D::ConstrastAdaptiveSharpening
 
-// After
+// 0.14
 Node2D::ContrastAdaptiveSharpening
 ```

--- a/release-content/0.14/migration-guides/12105_Made_bevy_color_a_dependency_of_bevy_render.md
+++ b/release-content/0.14/migration-guides/12105_Made_bevy_color_a_dependency_of_bevy_render.md
@@ -18,11 +18,11 @@ Note that this conversion can be costly, especially if called during the `Update
 `HslRepresentation` and `LchRepresentation` can be replaced with the `From` implementations between `Srgba`, `Hsla`, and `Lcha`.
 
 ```rust
-// Before
+// 0.13
 let srgb = HslRepresentation::hsl_to_nonlinear_srgb(330.0, 0.7, 0.8);
 let lch = LchRepresentation::nonlinear_srgb_to_lch([0.94, 0.66, 0.8]);
 
-// After
+// 0.14
 let srgba: Srgba = Hsla::new(330.0, 0.7, 0.8, 1.0).into();
 let lcha: Lcha = Srgba::new(0.94, 0.66, 0.8, 1.0).into();
 ```

--- a/release-content/0.14/migration-guides/12163_Migrate_from_LegacyColor_to_bevy_colorColor.md
+++ b/release-content/0.14/migration-guides/12163_Migrate_from_LegacyColor_to_bevy_colorColor.md
@@ -49,7 +49,7 @@ enum Color {
 This makes it easier to organize and manage different color spaces, and many more color spaces have been added too! To handle this change, you may need to update your match statements:
 
 ```rust
-// Before
+// 0.13
 match color {
     Color::Rgba { red, green, blue, alpha } => {
         // Something cool here!
@@ -57,7 +57,7 @@ match color {
     _ => {},
 }
 
-// After
+// 0.14
 match color {
     Color::Srgba(Srgba { red, green, blue, alpha }) => {
         // Something cool here!
@@ -73,10 +73,10 @@ match color {
 Additionally, you must now use the `From` and `Into` implementations when converting between color spaces, as compared to the old helper methods such as `as_rgba` and `as_hsla`.
 
 ```rust
-// Before
+// 0.13
 let color = Color::rgb(1.0, 0.0, 1.0).as_hsla();
 
-// After
+// 0.14
 let color: Hsla = Srgba::rgb(1.0, 0.0, 1.0).into();
 ```
 
@@ -89,11 +89,11 @@ Any mention of RGB has been renamed to [sRGB]. This includes the variant `Color:
 Methods to access specific channels of `Color` have been removed due to causing silent, relatively expensive conversions. This includes `Color::r`, `Color::set_r`, `Color::with_r`, and all of the equivalents for `g`, `b` `h`, `s` and `l`. Convert your `Color` into the desired color space, perform your operation there, and then convert it back.
 
 ```rust
-// Before
+// 0.13
 let mut color = Color::rgb(0.0, 0.0, 0.0);
 color.set_b(1.0);
 
-// After
+// 0.14
 let color = Color::srgb(0.0, 0.0, 0.0);
 let srgba = Srgba {
     blue: 1.0,
@@ -124,10 +124,10 @@ Alpha, also known as transparency, used to be referred to by the letter `a`. It 
 The various CSS color constants are no longer stored directly on `Color`. Instead, they’re defined in the `Srgba` color space, and accessed via `bevy::color::palettes`. Call `.into()` on them to convert them into a `Color` for quick debugging use.
 
 ```rust
-// Before
+// 0.13
 let color = Color::BLUE;
 
-// After
+// 0.14
 use bevy::color::palettes::css::BLUE;
 
 let color = BLUE;

--- a/release-content/0.14/migration-guides/12164_Make_sysinfo_diagnostic_plugin_optional.md
+++ b/release-content/0.14/migration-guides/12164_Make_sysinfo_diagnostic_plugin_optional.md
@@ -1,4 +1,4 @@
-`bevy::diagnostic` depends on the `sysinfo` to track CPU and memory usage, but compiling and polling system information can be very slow. `sysinfo` is now behind the `sysinfo_plugin` feature flag, which is enabled by default for `bevy` for _not_ for `bevy_diagnostic`.
+`bevy::diagnostic` depends on the `sysinfo` to track CPU and memory usage using `SystemInformationDiagnosticsPlugin`, but compiling and polling system information can be very slow. `sysinfo` is now behind the `sysinfo_plugin` feature flag, which is enabled by default for `bevy` for _not_ for `bevy_diagnostic`.
 
 If you depend on `bevy_diagnostic` directly, toggle the flag in `Cargo.toml`:
 

--- a/release-content/0.14/migration-guides/12164_Make_sysinfo_diagnostic_plugin_optional.md
+++ b/release-content/0.14/migration-guides/12164_Make_sysinfo_diagnostic_plugin_optional.md
@@ -1,1 +1,15 @@
-For users who disable default features of bevy and wish to enable the diagnostic plugin, add `sysinfo_plugin` to your bevy features list.
+`bevy::diagnostic` depends on the `sysinfo` to track CPU and memory usage, but compiling and polling system information can be very slow. `sysinfo` is now behind the `sysinfo_plugin` feature flag, which is enabled by default for `bevy` for _not_ for `bevy_diagnostic`.
+
+If you depend on `bevy_diagnostic` directly, toggle the flag in `Cargo.toml`:
+
+```toml
+[dependencies]
+bevy_diagnostic = { version = "0.14", features = ["sysinfo_plugin"] }
+```
+
+If you set `default-features = false` for `bevy`, do the same in `Cargo.toml`:
+
+```toml
+[dependencies]
+bevy = { version = "0.14", default-features = false, features = ["sysinfo_plugin"] }
+```

--- a/release-content/0.14/migration-guides/12234_Move_commands_module_into_bevyecsworld.md
+++ b/release-content/0.14/migration-guides/12234_Move_commands_module_into_bevyecsworld.md
@@ -1,9 +1,9 @@
 `Command` and `CommandQueue` have been moved from `bevy::ecs::system` to `bevy::ecs::world`. If you import them directly, you will need to update your import statements. (This does not affect you if you just import the prelude.)
 
 ```rust
-// Before
+// 0.13
 use bevy::ecs::system::{Command, CommandQueue};
 
-// After
+// 0.14
 use bevy::ecs::world::{Command, CommandQueue};
 ```

--- a/release-content/0.14/migration-guides/12234_Move_commands_module_into_bevyecsworld.md
+++ b/release-content/0.14/migration-guides/12234_Move_commands_module_into_bevyecsworld.md
@@ -1,4 +1,4 @@
-`Command` and `CommandQueue` have been moved from `bevy::ecs::system` to `bevy::ecs::world`. If you import them directly, you will need to update your import statements. (This does not affect you if you just import the prelude.)
+`Command` and `CommandQueue` have been moved from `bevy::ecs::system` to `bevy::ecs::world`. If you import them directly, you will need to update your import statements.
 
 ```rust
 // 0.13

--- a/release-content/0.14/migration-guides/12234_Move_commands_module_into_bevyecsworld.md
+++ b/release-content/0.14/migration-guides/12234_Move_commands_module_into_bevyecsworld.md
@@ -1,8 +1,9 @@
-`Command` and `CommandQueue` have been moved from `bevy::ecs::system` to `bevy::ecs::world`.
+`Command` and `CommandQueue` have been moved from `bevy::ecs::system` to `bevy::ecs::world`. If you import them directly, you will need to update your import statements. (This does not affect you if you just import the prelude.)
 
 ```rust
-// 0.13
+// Before
 use bevy::ecs::system::{Command, CommandQueue};
-// 0.14
+
+// After
 use bevy::ecs::world::{Command, CommandQueue};
 ```

--- a/release-content/0.14/migration-guides/12302_Allow_setting_RenderAssetUsages_for_gLTF_meshes__materials.md
+++ b/release-content/0.14/migration-guides/12302_Allow_setting_RenderAssetUsages_for_gLTF_meshes__materials.md
@@ -5,22 +5,22 @@ You may need to update any gLTF `.meta` files:
 <!-- This is technically RON, but it follows a syntax similar to Rust so we use that instead for syntax highlighting. -->
 
 ```rust
-// Before
+// 0.13
 load_meshes: true
 
-// After
+// 0.14
 load_meshes: ("MAIN_WORLD | RENDER_WORLD")
 ```
 
 If you use `AssetServer::load_with_settings` instead when loading gLTF files, you will also have to update:
 
 ```rust
-// Before
+// 0.13
 asset_server.load_with_settings("model.gltf", |s: &mut GltfLoaderSettings| {
     s.load_meshes = true;
 });
 
-// After
+// 0.14
 asset_server.load_with_settings("model.gltf", |s: &mut GltfLoaderSettings| {
     s.load_meshes = RenderAssetUsages::MAIN_WORLD | RenderAssetUsages::RENDER_WORLD;
 });

--- a/release-content/0.14/migration-guides/12311_Remove_ComponentStorage_and_associated_types.md
+++ b/release-content/0.14/migration-guides/12311_Remove_ComponentStorage_and_associated_types.md
@@ -1,14 +1,22 @@
-If you were manually implementing `Component` instead of using the derive macro, replace the associated `Storage` associated type with the `STORAGE_TYPE` const:
+The `Component::Storage` associated type has been replaced with the associated constant `STORAGE_TYPE`, making the `ComponentStorage` trait unnecessary. If you were manually implementing `Component` instead of using the derive macro, update your definitions:
 
 ```rust
-// in Bevy 0.13
+// Before
 impl Component for MyComponent {
     type Storage = TableStorage;
 }
-// in Bevy 0.14
+
+// After
 impl Component for MyComponent {
     const STORAGE_TYPE: StorageType = StorageType::Table;
+
+    // ...
 }
 ```
 
-Component is no longer object safe. If you were relying on `&dyn Component`, `Box<dyn Component>`, etc. please [file an issue ](https://github.com/bevyengine/bevy/issues) to get [this change](https://github.com/bevyengine/bevy/pull/12311) reverted.
+|Before|After|
+|-|-|
+|`TableStorage`|`StorageType::Table`|
+|`SparseStorage`|`StorageType::SparseSet`|
+
+`Component` is also now no longer object safe. If you were using `dyn Component`, please consider [filing an issue](https://github.com/bevyengine/bevy/issues) describing your use-case.

--- a/release-content/0.14/migration-guides/12311_Remove_ComponentStorage_and_associated_types.md
+++ b/release-content/0.14/migration-guides/12311_Remove_ComponentStorage_and_associated_types.md
@@ -1,12 +1,12 @@
 The `Component::Storage` associated type has been replaced with the associated constant `STORAGE_TYPE`, making the `ComponentStorage` trait unnecessary. If you were manually implementing `Component` instead of using the derive macro, update your definitions:
 
 ```rust
-// Before
+// 0.13
 impl Component for MyComponent {
     type Storage = TableStorage;
 }
 
-// After
+// 0.14
 impl Component for MyComponent {
     const STORAGE_TYPE: StorageType = StorageType::Table;
 

--- a/release-content/0.14/migration-guides/12314_Clean_up_type_registrations.md
+++ b/release-content/0.14/migration-guides/12314_Clean_up_type_registrations.md
@@ -1,3 +1,5 @@
-External types are no longer registered automatically unless they are used by
-other Bevy types. If you were depending on `std`, `glam` or similar types being
-in the type registry you need to manually register them with `.register_type()`.
+External types are no longer registered into the type registry automatically unless they are used by other Bevy types (due to the new recursive registration). If you were depending on types from `std`, `glam`, or similar types being in the type registry you may need to manually register them.
+
+```rust
+App::new().register_type::<DMat3>();
+```

--- a/release-content/0.14/migration-guides/12314_Clean_up_type_registrations.md
+++ b/release-content/0.14/migration-guides/12314_Clean_up_type_registrations.md
@@ -1,3 +1,0 @@
-External types are no longer registered automatically unless they are used by
-other Bevy types. If you were depending on `std`, `glam` or similar types being
-in the type registry you need to manually register them with `.register_type()`.

--- a/release-content/0.14/migration-guides/12314_Clean_up_type_registrations.md
+++ b/release-content/0.14/migration-guides/12314_Clean_up_type_registrations.md
@@ -1,0 +1,3 @@
+External types are no longer registered automatically unless they are used by
+other Bevy types. If you were depending on `std`, `glam` or similar types being
+in the type registry you need to manually register them with `.register_type()`.

--- a/release-content/0.14/migration-guides/12512_Update_to_fixedbitset_05.md
+++ b/release-content/0.14/migration-guides/12512_Update_to_fixedbitset_05.md
@@ -1,12 +1,12 @@
 `Access::grow` from `bevy::ecs::query` has been removed. Many operations now automatically grow the capacity.
 
 ```rust
-// Before
+// 0.13
 let mut access = Access::new();
 access.grow(1);
 // Other operations...
 
-// After
+// 0.14
 let mut access = Access::new();
 // Other operations...
 ```

--- a/release-content/0.14/migration-guides/12526_Solve_some_oklaba_inconsistencies.md
+++ b/release-content/0.14/migration-guides/12526_Solve_some_oklaba_inconsistencies.md
@@ -1,10 +1,10 @@
 If you were creating a Oklaba instance directly, instead of using L, you should use lightness
 
 ```rust
-// Before
+// 0.13
 let oklaba = Oklaba { l: 1., ..Default::default() };
 
-// Now
+// 0.14
 let oklaba = Oklaba { lightness: 1., ..Default::default() };
 ```
 

--- a/release-content/0.14/migration-guides/12550_Use_asyncfn_in_traits_rather_than_BoxedFuture.md
+++ b/release-content/0.14/migration-guides/12550_Use_asyncfn_in_traits_rather_than_BoxedFuture.md
@@ -9,7 +9,7 @@ In Rust 1.75, [`async fn` was stabilized for traits](https://blog.rust-lang.org/
 Please update your trait implementations:
 
 ```rust
-// Before
+// 0.13
 impl AssetLoader for MyAssetLoader {
     // ...
 
@@ -28,7 +28,7 @@ impl AssetLoader for MyAssetLoader {
     }
 }
 
-// After
+// 0.14
 impl AssetLoader for MyAssetLoader {
     // ...
 
@@ -49,9 +49,9 @@ impl AssetLoader for MyAssetLoader {
 Because these traits now use `async`, they are no longer object safe. If you need to receive or store `&dyn Trait`, use the `&dyn ErasedTrait` variant instead. For instance:
 
 ```rust
-// Before
+// 0.13
 struct MyReader(Box<dyn AssetReader>);
 
-// After
+// 0.14
 struct MyReader(Box<dyn ErasedAssetReader>);
 ```

--- a/release-content/0.14/migration-guides/12575_Color_maths_4.md
+++ b/release-content/0.14/migration-guides/12575_Color_maths_4.md
@@ -1,7 +1,7 @@
 It was previously possible to multiply and divide a `Color` by an `f32`, which is now removed. You must now operate on a specific color space, such as `LinearRgba`. Furthermore, these operations used to skip the alpha channel, but that is no longer the case.
 
 ```rust
-// Before
+// 0.13
 let color = Color::RgbaLinear {
     red: 1.0,
     green: 1.0,
@@ -12,7 +12,7 @@ let color = Color::RgbaLinear {
 // Alpha is preserved, ignoring the multiplier.
 assert_eq!(color.a(), 1.0);
 
-// After
+// 0.14
 let color = LinearRgba {
     red: 1.0,
     green: 1.0,

--- a/release-content/0.14/migration-guides/12655_Removed_IntoAssedIdT_for_HandleT_as_mentioned_in_12600.md
+++ b/release-content/0.14/migration-guides/12655_Removed_IntoAssedIdT_for_HandleT_as_mentioned_in_12600.md
@@ -1,9 +1,9 @@
 Converting from a `Handle` to an `AssetId` using `Into` was removed because it was a footgun that could potentially drop the asset if the `Handle` was a strong reference. If you need the `AssetId`, please use `Handle::id()` instead.
 
 ```rust
-// Before
+// 0.13
 let id: AssetId<T> = handle.into();
 
-// After
+// 0.14
 let id = handle.id();
 ```

--- a/release-content/0.14/migration-guides/12709_Error_info_has_been_added_to_LoadStateFailed.md
+++ b/release-content/0.14/migration-guides/12709_Error_info_has_been_added_to_LoadStateFailed.md
@@ -3,13 +3,13 @@ Rust prides itself on its error handling, and Bevy has been steadily catching up
 Now, a full `AssetLoadError` is included inside `Failed` to tell you exactly what went wrong. You may need to update your `match` and `if let` statements to handle this new value:
 
 ```rust
-// Before
+// 0.13
 match asset_server.load_state(asset_id) {
     // ...
     LoadState::Failed => eprintln!("Could not load asset!"),
 }
 
-// After
+// 0.14
 match asset_server.load_state(asset_id) {
     // ...
     LoadState::Failed(error) => eprintln!("Could not load asset! Error: {}", error),

--- a/release-content/0.14/migration-guides/12827_Consolidate_RenderUiMaterials2d_into_RenderAssets.md
+++ b/release-content/0.14/migration-guides/12827_Consolidate_RenderUiMaterials2d_into_RenderAssets.md
@@ -3,14 +3,14 @@
 Furthermore, the `RenderAsset` trait should now be implemented for destination types rather than source types. If you need to access the source type, use the `RenderAsset::SourceAsset` associated type.
 
 ```rust
-// Before
+// 0.13
 impl RenderAsset for Image {
     type PreparedAsset = GpuImage;
 
     // ...
 }
 
-// After
+// 0.14
 impl RenderAsset for GpuImage {
     type SourceAsset = Image;
 

--- a/release-content/0.14/migration-guides/13022_Make_AppExit_more_specific_about_exit_reason.md
+++ b/release-content/0.14/migration-guides/13022_Make_AppExit_more_specific_about_exit_reason.md
@@ -1,12 +1,12 @@
 The `AppExit` event is now an enum that represents whether the code exited successfully or not. If you construct it, you must now specify `Success` or `Error`:
 
 ```rust
-// Before
+// 0.13
 fn send_exit(mut writer: EventWriter<AppExit>) {
     writer.send(AppExit);
 }
 
-// After
+// 0.14
 fn send_exit(mut writer: EventWriter<AppExit>) {
     writer.send(AppExit::Success);
     // Or...
@@ -17,14 +17,14 @@ fn send_exit(mut writer: EventWriter<AppExit>) {
 If you subscribed to this event in a system, consider `match`ing whether it was a success or an error:
 
 ```rust
-// Before
+// 0.13
 fn handle_exit(mut reader: EventReader<AppExit>) {
     for app_exit in reader.read() {
         // Something interesting here...
     }
 }
 
-// After
+// 0.14
 fn handle_exit(mut reader: EventReader<AppExit>) {
     for app_exit in reader.read() {
         match *app_exit {
@@ -40,17 +40,17 @@ fn handle_exit(mut reader: EventReader<AppExit>) {
 Furthermore, `App::run` now returns `AppExit` instead of the unit type `()`. Since `AppExit` implements [`Termination`](https://doc.rust-lang.org/stable/std/process/trait.Termination.html), you can now return it from the main function.
 
 ```rust
-// Before
+// 0.13
 fn main() {
     App::new().run()
 }
 
-// After
+// 0.14
 fn main() -> AppExit {
     App::new().run()
 }
 
-// After (alternative)
+// 0.14 (alternative)
 fn main() {
     // If you want to ignore `AppExit`, you can add a semicolon instead. :)
     App::new().run();

--- a/release-content/0.14/migration-guides/13080_Deprecate_dynamic_plugins.md
+++ b/release-content/0.14/migration-guides/13080_Deprecate_dynamic_plugins.md
@@ -1,7 +1,7 @@
 Dynamic plugins are now deprecated. If possible, remove all usage them from your code:
 
 ```rust
-// Before
+// 0.13
 // This would be compiled into a separate dynamic library.
 #[derive(DynamicPlugin)]
 pub struct MyPlugin;
@@ -15,7 +15,7 @@ App::new()
     .load_plugin("path/to/plugin")
     .run();
 
-// After
+// 0.14
 // This would now be compiled into the main binary as well.
 pub struct MyPlugin;
 

--- a/release-content/0.14/migration-guides/13159_Improve_tracing_layer_customization.md
+++ b/release-content/0.14/migration-guides/13159_Improve_tracing_layer_customization.md
@@ -1,7 +1,7 @@
 Bevy uses `tracing` to handle logging and spans through `LogPlugin`. This could be customized with the `update_subscriber` field, but it was highly restrictive. This has since been amended, replacing the `update_subscriber` field with the more flexible `custom_layer`. which returns a `Layer`.
 
 ```rust
-// Before
+// 0.13
 fn update_subscriber(_app: &mut App, subscriber: BoxedSubscriber) -> BoxedSubscriber {
     Box::new(subscriber.with(CustomLayer))
 }
@@ -13,7 +13,7 @@ App::new()
     })
     .run();
 
-// After
+// 0.14
 use bevy::log::tracing_subscriber;
 
 fn custom_layer(_app: &mut App) -> Option<BoxedLayer> {

--- a/release-content/0.14/migration-guides/13159_Improve_tracing_layer_customization.md
+++ b/release-content/0.14/migration-guides/13159_Improve_tracing_layer_customization.md
@@ -1,28 +1,40 @@
-The `LogPlugin`’s `update_subscriber` field has been replaced with the more flexible `custom_layer`.
+Bevy uses `tracing` to handle logging and spans through `LogPlugin`. This could be customized with the `update_subscriber` field, but it was highly restrictive. This has since been amended, replacing the `update_subscriber` field with the more flexible `custom_layer`. which returns a `Layer`.
 
 ```rust
-// in 0.13
-fn update_subscriber(_: &mut App, subscriber: BoxedSubscriber) -> BoxedSubscriber {
+// Before
+fn update_subscriber(_app: &mut App, subscriber: BoxedSubscriber) -> BoxedSubscriber {
     Box::new(subscriber.with(CustomLayer))
 }
 
-LogPlugin {
-    update_subscriber: Some(update_subscriber),
-    ..default()
-}
+App::new()
+    .add_plugins(LogPlugin {
+        update_subscriber: Some(update_subscriber),
+        ..default()
+    })
+    .run();
 
-// in 0.14
+// After
+use bevy::log::tracing_subscriber;
+
 fn custom_layer(_app: &mut App) -> Option<BoxedLayer> {
-    // You can provide multiple layers like this, since Vec<Layer> is also a layer:
+    // You can provide a single layer:
+    return Some(CustomLayer.boxed());
+
+    // Or you can provide multiple layers, since `Vec<Layer>` also implements `Layer`:
     Some(Box::new(vec![
-        bevy::log::tracing_subscriber::fmt::layer()
+        tracing_subscriber::fmt::layer()
             .with_file(true)
             .boxed(),
         CustomLayer.boxed(),
     ]))
 }
-LogPlugin {
-    custom_layer,
-    ..default()
-}
+
+App::new()
+    .add_plugins(LogPlugin {
+        custom_layer,
+        ..default()
+    })
+    .run();
 ```
+
+The `BoxedSubscriber` type alias has also been removed, it was replaced by the `BoxedLayer` type alias.

--- a/release-content/0.14/migration-guides/13177_Make_AssetMetaCheck_a_field_on_the_asset_plugin.md
+++ b/release-content/0.14/migration-guides/13177_Make_AssetMetaCheck_a_field_on_the_asset_plugin.md
@@ -1,13 +1,13 @@
 `AssetMetaCheck` is used to configure how the `AssetPlugin` reads `.meta` files. It was previously a resource, but now has been changed to a field in `AssetPlugin`. If you use `DefaultPlugins`, you can use `.set` to configure this field.
 
 ```rust
-// Before
+// 0.13
 App::new()
     .add_plugins(DefaultPlugins)
     .insert_resource(AssetMetaCheck::Never)
     .run();
 
-// After
+// 0.14
 App::new()
     .add_plugins(DefaultPlugins.set(AssetPlugin {
         meta_check: AssetMetaCheck::Never,

--- a/release-content/0.14/migration-guides/13209_move_wgsl_color_operations_from_bevy_pbr_to_bevy_render.md
+++ b/release-content/0.14/migration-guides/13209_move_wgsl_color_operations_from_bevy_pbr_to_bevy_render.md
@@ -1,9 +1,9 @@
 Mathematical constants and color conversion functions for shaders have been moved from `bevy_pbr::utils` to `bevy_render::maths` and `bevy_render::color_operations`. If you depended on these in your own shaders, please update your import statements:
 
 ```wgsl
-// Before
+// 0.13
 #import bevy_pbr::utils::{PI, rgb_to_hsv}
 
-// After
+// 0.14
 #import bevy_render::{maths::PI, color_operations::rgb_to_hsv}
 ```

--- a/release-content/0.14/migration-guides/13465_Make_LoadContext_use_the_builder_pattern_for_loading_depen.md
+++ b/release-content/0.14/migration-guides/13465_Make_LoadContext_use_the_builder_pattern_for_loading_depen.md
@@ -3,23 +3,23 @@
 `LoadContext`, used by `AssetLoader`, has been updated so all of its `load_*` methods have been merged into a builder struct.
 
 ```rust
-// Before
+// 0.13
 load_context.load_direct(path);
-// After
+// 0.14
 load_context.loader().direct().untyped().load(path);
 
-// Before
+// 0.13
 load_context.load_direct_with_reader(reader, path);
-// After
+// 0.14
 load_context.loader().direct().with_reader(reader).untyped().load(path);
 
-// Before
+// 0.13
 load_context.load_untyped(path);
-// After
+// 0.14
 load_context.loader().untyped().load(path);
 
-// Before
+// 0.13
 load_context.load_with_settings(path, settings);
-// After
+// 0.14
 load_context.loader().with_settings(settings).load(path);
 ```

--- a/release-content/0.14/migration-guides/13637_Move_state_installation_methods_from_bevy_app_to_bevy_stat.md
+++ b/release-content/0.14/migration-guides/13637_Move_state_installation_methods_from_bevy_app_to_bevy_stat.md
@@ -1,12 +1,12 @@
 `State` has been moved to `bevy::state`. With it, `App::init_state` has been moved from a normal method to an extension trait. You may now need to import `AppExtStates` in order to use this method. (This trait is behind the `bevy_app` feature flag, which you may need to enable.)
 
 ```rust
-// Before
+// 0.13
 App::new()
     .init_state::<MyState>()
     .run();
 
-// After
+// 0.14
 use bevy::state::app::AppExtStates as _;
 
 App::new()

--- a/release-content/0.14/migration-guides/9202_Refactor_App_and_SubApp_internals_for_better_separation.md
+++ b/release-content/0.14/migration-guides/9202_Refactor_App_and_SubApp_internals_for_better_separation.md
@@ -5,7 +5,7 @@
 `SubApp` no longer contains an `App`, so you no longer are able to convert an `App` into a `SubApp`. Furthermore, the extraction function must now be set outside of the constructor.
 
 ```rust
-// Before
+// 0.13
 #[derive(AppLabel, Clone, Copy, Hash, PartialEq, Eq, Debug)]
 struct MySubApp;
 
@@ -19,7 +19,7 @@ app.insert_sub_app(MySubApp, SubApp::new(sub_app, |main_world, sub_app| {
     // Extraction function.
 }));
 
-// After
+// 0.14
 #[derive(AppLabel, Clone, Copy, Hash, PartialEq, Eq, Debug)]
 struct MySubApp;
 
@@ -52,12 +52,12 @@ First, `App::world` as a property is no longer directly accessible. Instead use 
 #[derive(Component)]
 struct MyComponent;
 
-// Before
+// 0.13
 let mut app = App::new();
 println!("{:?}", app.world.id());
 app.world.spawn(MyComponent);
 
-// After
+// 0.14
 let mut app = App::new();
 println!("{:?}", app.world().id()); // Notice the added paranthesese.
 app.world_mut().spawn(MyComponent);

--- a/release-content/0.14/migration-guides/_guides.toml
+++ b/release-content/0.14/migration-guides/_guides.toml
@@ -179,12 +179,6 @@ areas = ["ECS"]
 file_name = "12311_Remove_ComponentStorage_and_associated_types.md"
 
 [[guides]]
-title = "Clean up type registrations"
-url = "https://github.com/bevyengine/bevy/pull/12314"
-areas = ["ECS", "Reflection"]
-file_name = "12314_Clean_up_type_registrations.md"
-
-[[guides]]
 title = "Remove archetype_component_access from QueryState"
 url = "https://github.com/bevyengine/bevy/pull/12474"
 areas = ["ECS"]

--- a/release-content/0.14/migration-guides/_guides.toml
+++ b/release-content/0.14/migration-guides/_guides.toml
@@ -149,7 +149,7 @@ areas = ["Dev-Tools"]
 file_name = "12859_remove_close_on_esc.md"
 
 [[guides]]
-title = "Make sysinfo diagnostic plugin optional"
+title = "Make `sysinfo` diagnostic plugin optional"
 url = "https://github.com/bevyengine/bevy/pull/12164"
 areas = ["Diagnostics"]
 file_name = "12164_Make_sysinfo_diagnostic_plugin_optional.md"

--- a/release-content/0.14/migration-guides/_guides.toml
+++ b/release-content/0.14/migration-guides/_guides.toml
@@ -173,7 +173,7 @@ areas = ["ECS"]
 file_name = "12234_Move_commands_module_into_bevyecsworld.md"
 
 [[guides]]
-title = "Remove ComponentStorage and associated types"
+title = "Make `Component::Storage` a constant"
 url = "https://github.com/bevyengine/bevy/pull/12311"
 areas = ["ECS"]
 file_name = "12311_Remove_ComponentStorage_and_associated_types.md"

--- a/release-content/0.14/migration-guides/_guides.toml
+++ b/release-content/0.14/migration-guides/_guides.toml
@@ -155,7 +155,7 @@ areas = ["Diagnostics"]
 file_name = "12164_Make_sysinfo_diagnostic_plugin_optional.md"
 
 [[guides]]
-title = "Improve tracing layer customization"
+title = "Improve `tracing` layer customization"
 url = "https://github.com/bevyengine/bevy/pull/13159"
 areas = ["Diagnostics"]
 file_name = "13159_Improve_tracing_layer_customization.md"

--- a/release-content/0.14/migration-guides/_guides.toml
+++ b/release-content/0.14/migration-guides/_guides.toml
@@ -161,7 +161,7 @@ areas = ["Diagnostics"]
 file_name = "13159_Improve_tracing_layer_customization.md"
 
 [[guides]]
-title = "Immediately apply deferred system params in System::run"
+title = "Immediately apply deferred system params in `System::run`"
 url = "https://github.com/bevyengine/bevy/pull/11823"
 areas = ["ECS"]
 file_name = "11823_Immediately_apply_deferred_system_params_in_Systemrun.md"

--- a/release-content/0.14/migration-guides/_guides.toml
+++ b/release-content/0.14/migration-guides/_guides.toml
@@ -179,6 +179,12 @@ areas = ["ECS"]
 file_name = "12311_Remove_ComponentStorage_and_associated_types.md"
 
 [[guides]]
+title = "Clean up type registrations"
+url = "https://github.com/bevyengine/bevy/pull/12314"
+areas = ["ECS", "Reflection"]
+file_name = "12314_Clean_up_type_registrations.md"
+
+[[guides]]
 title = "Remove archetype_component_access from QueryState"
 url = "https://github.com/bevyengine/bevy/pull/12474"
 areas = ["ECS"]

--- a/release-content/0.14/migration-guides/_guides.toml
+++ b/release-content/0.14/migration-guides/_guides.toml
@@ -167,7 +167,7 @@ areas = ["ECS"]
 file_name = "11823_Immediately_apply_deferred_system_params_in_Systemrun.md"
 
 [[guides]]
-title = "Move commands module into bevy::ecs::world"
+title = "Move `Command` and `CommandQueue` into `bevy::ecs::world`"
 url = "https://github.com/bevyengine/bevy/pull/12234"
 areas = ["ECS"]
 file_name = "12234_Move_commands_module_into_bevyecsworld.md"


### PR DESCRIPTION
Another round of migration guides! (Part of #1396.)

~~@james7132, would you mind confirming that I was correct in removing https://github.com/bevyengine/bevy/pull/12314 from the migration guide? It would only be a breaking change if it no longer registered a type that was registered previously. (Non-blocking, though, if you don't find the time for this!)~~