### PR TITLE
Fix top of table borders

### DIFF
--- a/sass/elements/_table.scss
+++ b/sass/elements/_table.scss
@@ -16,3 +16,11 @@ tr td {
 tr td:not(:first-child) {
   border-left: 2px solid $subtitle-color;
 }
+
+table tr:first-child th:first-child {
+  border-radius: $border-radius;
+}
+
+table tr:first-child th:last-child {
+  border-radius: $border-radius;
+}

--- a/sass/elements/_table.scss
+++ b/sass/elements/_table.scss
@@ -17,10 +17,15 @@ tr td:not(:first-child) {
   border-left: 2px solid $subtitle-color;
 }
 
-table tr:first-child th:first-child {
-  border-radius: $border-radius;
-}
-
-table tr:first-child th:last-child {
-  border-radius: $border-radius;
+table tr:first-child {
+  border-top-left-radius: $border-radius;
+  border-top-right-radius: $border-radius;
+  
+  th:first-child {
+    border-top-left-radius: $border-radius;
+  }
+  
+  th:last-child {
+    border-top-right-radius: $border-radius;
+  }
 }


### PR DESCRIPTION
## Objective

Fixes #1271

## Solution

Also apply border radius to first/last `th` elements.

## Testing

Tested in chrome and firefox on macos.

### Before

<img width="638" alt="Screenshot 2024-06-13 at 11 52 10 AM" src="https://github.com/bevyengine/bevy-website/assets/200550/9ea4519f-1b48-4ccb-a093-336513847216">

### After

<img width="638" alt="Screenshot 2024-06-13 at 11 51 57 AM" src="https://github.com/bevyengine/bevy-website/assets/200550/1077252f-d668-48fc-b490-06a43b68e44b">
