### PR TITLE
Allow `clippy::doc_markdown` in `code-validation` and fix `lint-tools` job

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2287,6 +2287,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "thiserror",
  "ureq",
 ]
 
@@ -4433,18 +4434,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.57"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.57"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/code-validation/src/lib.rs
+++ b/code-validation/src/lib.rs
@@ -3,6 +3,11 @@
 //! It is currently used to validate the rust code of the official `bevy` book.
 //! The modules represents the folder structure of the website.
 
+// This prevents Clippy from linting the Markdown of our documentation, we just want it to lint
+// code blocks. Without this, Clippy would require front-matter and Tera templates to be surrounded
+// by backticks.
+#![allow(clippy::doc_markdown)]
+
 mod learn {
     #[doc = include_str!("../../content/learn/quick-start/_index.md")]
     mod quick_start {

--- a/generate-release/Cargo.toml
+++ b/generate-release/Cargo.toml
@@ -16,6 +16,7 @@ regex = "1.7.0"
 dotenvy = "0.15.6"
 serde_json = "1.0.91"
 rayon = "1.10.0"
+thiserror = "1.0.61"
 
 [lints]
 workspace = true

--- a/generate-release/src/github_client.rs
+++ b/generate-release/src/github_client.rs
@@ -31,25 +31,13 @@ impl Display for BevyRepo {
 }
 
 #[derive(Deserialize, Clone, Debug)]
-pub struct GithubBranchesResponse {
-    pub name: String,
-    pub commit: GithubBranchesCommitResponse,
-}
-#[derive(Deserialize, Clone, Debug)]
-pub struct GithubBranchesCommitResponse {
-    pub sha: String,
-}
-
-#[derive(Deserialize, Clone, Debug)]
 pub struct GithubCommitResponse {
     pub sha: String,
     pub commit: GithubCommitContent,
-    pub author: Option<GithubUser>,
 }
 
 #[derive(Deserialize, Clone, Debug)]
 pub struct Committer {
-    pub name: String,
     pub date: String,
 }
 
@@ -73,40 +61,13 @@ pub struct GithubUser {
 }
 
 #[derive(Deserialize, Clone, Debug)]
-pub struct GithubCommitBranchResponse {
-    pub name: String,
-    pub commit: GithubCommitBranchCommitResponse,
-}
-
-#[derive(Deserialize, Clone, Debug)]
-pub struct GithubCommitBranchCommitResponse {
-    pub sha: String,
-}
-
-#[derive(Deserialize, Clone, Debug)]
-pub struct GithubPullRequestResponse {
-    pub title: String,
-    pub number: i32,
-    pub body: Option<String>,
-    pub labels: Vec<GithubLabel>,
-    pub user: GithubUser,
-    pub closed_at: DateTime<Utc>,
-}
-
-#[derive(Deserialize, Clone, Debug)]
 pub struct GithubCompareResponse {
-    pub base_commit: GithubCommitResponse,
     pub commits: Vec<GithubCommitResponse>,
 }
 
 #[derive(Deserialize, Clone, Debug)]
 pub struct GithubLabel {
     pub name: String,
-}
-
-#[derive(Deserialize, Clone, Debug)]
-pub struct GithubUserSearchResponse {
-    pub items: Vec<GithubUser>,
 }
 
 #[derive(Deserialize, Clone, Debug)]

--- a/generate-release/src/github_client.rs
+++ b/generate-release/src/github_client.rs
@@ -6,6 +6,7 @@ use std::{
 use anyhow::bail;
 use chrono::{DateTime, NaiveDate, TimeZone, Utc};
 use serde::Deserialize;
+use thiserror::Error;
 use ureq::Response;
 
 /// A GitHub repository in the `bevyengine` organization.
@@ -405,23 +406,14 @@ query {{
 }
 
 /// An issue that occurred while opening an issue on Github.
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum IssueError {
-    Ureq(ureq::Error),
+    #[error("error making request")]
+    Ureq(#[from] ureq::Error),
+    #[error("failed to create issue")]
     FailedToCreateIssue(Response),
-    FailedToParseResponse(std::io::Error),
-}
-
-impl From<ureq::Error> for IssueError {
-    fn from(err: ureq::Error) -> Self {
-        IssueError::Ureq(err)
-    }
-}
-
-impl From<std::io::Error> for IssueError {
-    fn from(err: std::io::Error) -> Self {
-        IssueError::FailedToParseResponse(err)
-    }
+    #[error("failed to parse response")]
+    FailedToParseResponse(#[from] std::io::Error),
 }
 
 /// The status of an issue or PR on Github.


### PR DESCRIPTION
## Allow `clippy::doc_markdown` in `code-validation`

Fixes #1399!

This change disables the [`clippy::doc_markdown`] lint for our `code-validation` tool. This lint requires code-like text to be surrounded by backticks. The problem with it is that it thinks Tera templates `{{ ... }}` and front-matter are code-like, and wants backticks around them. Doing so would break the website, though.

[`clippy::doc_markdown`]: https://rust-lang.github.io/rust-clippy/stable/index.html#/doc_markdown

While it is nice to catch missing backticks, it's not `code-validation`'s first responsibility. It's first responsibility is to test all of our code blocks to ensure they are valid.

One final note: I originally tried using the `[lint]` table in `Cargo.toml` to disable this lint, but `workspace = true` is incompatible with this: I would have had to duplicate all of `[workspace.lints]` . Instead, I opted to just use a crate attribute.

## Fix `lint-tools` job

There were several structs and fields that were never used, so I deleted them. Furthermore, `IssueError` was raising a warning because the fields of its variants were never read. I fixed this by implementing `std::error::Error` for it, which exposes the `source` error when the question mark `?` operator is used. `thiserror` was already in our dependency tree, so it should not hurt compile times too much.