### PR TITLE
Set `publish = false` for all tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1508,7 +1508,7 @@ checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "code-validation"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "bevy",
 ]
@@ -2240,7 +2240,7 @@ dependencies = [
 
 [[package]]
 name = "generate-assets"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -2257,7 +2257,7 @@ dependencies = [
 
 [[package]]
 name = "generate-community"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "rand",
  "serde",
@@ -2267,7 +2267,7 @@ dependencies = [
 
 [[package]]
 name = "generate-errors"
-version = "0.2.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2276,7 +2276,7 @@ dependencies = [
 
 [[package]]
 name = "generate-release"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5430,7 +5430,7 @@ dependencies = [
 
 [[package]]
 name = "write-rustdoc-hide-lines"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "indoc",

--- a/code-validation/Cargo.toml
+++ b/code-validation/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "code-validation"
-version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 # This should point to `main` when we are preparing for the next release,

--- a/generate-assets/Cargo.toml
+++ b/generate-assets/Cargo.toml
@@ -1,14 +1,12 @@
 [package]
 name = "generate-assets"
-version = "0.1.0"
 authors = [
   "Bevy Contributors <bevyengine@gmail.com>",
   "Carter Anderson <mcanders1@gmail.com>",
 ]
 license = "MIT"
 edition = "2018"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
 
 [dependencies]
 toml = "0.7"

--- a/generate-community/Cargo.toml
+++ b/generate-community/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "generate-community"
-version = "0.1.0"
 authors = [
   "Bevy Contributors <bevyengine@gmail.com>",
 ]
 license = "MIT"
 edition = "2021"
+publish = false
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/generate-errors/Cargo.toml
+++ b/generate-errors/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "generate-errors"
-version = "0.2.0"
 authors = [
   "Bevy Contributors <bevyengine@gmail.com>",
   "Carter Anderson <mcanders1@gmail.com>",
 ]
 license = "MIT"
 edition = "2021"
+publish = false
 
 [lints]
 workspace = true

--- a/generate-release/Cargo.toml
+++ b/generate-release/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "generate-release"
-version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
 
 [dependencies]
 ureq = { version = "2.5.0", features = ["json"] }

--- a/write-rustdoc-hide-lines/Cargo.toml
+++ b/write-rustdoc-hide-lines/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "write-rustdoc-hide-lines"
-version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
All of the Cargo projects in this repository are internal and should never be published on <https://crates.io>. This PR sets the [`publish`](https://doc.rust-lang.org/cargo/reference/manifest.html#the-publish-field) field to false to prevent `cargo publish` from accidentally succeeding.

Furthermore, this also removes the `version` field. These tools do not need a version field because nothing outside of the repository should be depending on them.