### PR TITLE
add styles for details > .callout

### DIFF
--- a/sass/elements/_details.scss
+++ b/sass/elements/_details.scss
@@ -17,20 +17,25 @@ details {
     }
   }
 
-  >pre {
-    // push code blocks to the edge and remove their corners
+  // these styles are noncritical so the 2.4% without `:is` will be fine
+  // https://caniuse.com/css-matches-pseudo
+  // also, to avoid these styles, put the block in a <div>
+  $big-blocks: ":is(pre.z-code, .callout)";
+
+  >#{$big-blocks} {
+    // push big blocks to the edge and remove their corners
     margin-inline: -$h-padding;
     padding-inline: $h-padding !important;
     border-radius: 0 !important;
   }
 
-  >summary~pre.z-code {
+  >summary~#{$big-blocks} {
     // remove margin on leading...
     margin-top: 0;
   }
 
-  >pre.z-code:last-child {
-    // ...and trailing code blocks
+  >#{$big-blocks}:last-child {
+    // ...and trailing big blocks
     margin-bottom: 0;
   }
 

--- a/sass/elements/_details.scss
+++ b/sass/elements/_details.scss
@@ -29,7 +29,7 @@ details {
     border-radius: 0 !important;
   }
 
-  >summary~#{$big-blocks} {
+  >summary+#{$big-blocks} {
     // remove margin on leading...
     margin-top: 0;
   }


### PR DESCRIPTION
Went on a tangent to give `details > .callout` the same styles as `details > pre.z-code`.

before:

![image](https://github.com/bevyengine/bevy-website/assets/14184826/f4d4b7b1-1a54-42ca-a2de-b38292359f4c)



after:

![image](https://github.com/bevyengine/bevy-website/assets/14184826/82815f5d-108a-4a7c-8599-2652f6e63bc6)

also turns out that I used the wrong sibling selector in #1155 DX