### PR TITLE
Deduplicate and rewrite Fast Compiles section

### DIFF
--- a/content/learn/book/development-practices/fast-compiles.md
+++ b/content/learn/book/development-practices/fast-compiles.md
@@ -7,48 +7,6 @@ status = 'hidden'
 +++
 
 {% todo() %}
-
-* Explain why you might want faster compiles
+Move from [Setup#Enable Fast Compiles (Optional)](/learn/quick-start/getting-started/setup#enable-fast-compiles-optional) when the book is released.
+**Delete the original.**
 {% end %}
-
-* **Enable Bevy's Dynamic Linking Feature**: This is the most impactful compilation time decrease! If `bevy` is a dependency you can compile the binary with the "dynamic_linking" feature flag (enables dynamic linking):
-
-    ```sh
-    cargo run --features bevy/dynamic_linking
-    ```
-
-    If you don't want to add the `--features bevy/dynamic_linking` to each run, this flag can permanently be set via `Cargo.toml`:
-
-    ```toml
-    [dependencies]
-    bevy = { version = "0.5.0", features = ["dynamic_linking"] }
-    ```
-
-    NOTE: Remember to revert this before releasing your game! Otherwise you will need to include `libbevy_dylib` alongside your game if you want it to run. If you remove the "dynamic_linking" feature, your game executable can run standalone.
-
-* **LLD linker**: The Rust compiler spends a lot of time in the "link" step. LLD is _much faster_ at linking than the default Rust linker. To install LLD, find your OS below and run the given command:
-  * **Ubuntu**: `sudo apt-get install lld`
-  * **Arch**: `sudo pacman -S lld`
-  * **Windows**: Ensure you have the latest [cargo-binutils](https://github.com/rust-embedded/cargo-binutils)
-
- ```sh
- cargo install -f cargo-binutils
- rustup component add llvm-tools-preview
- ```
-
-* **MacOS**: Modern LLD does not yet support MacOS, but we can use zld instead: `brew install michaeleisel/zld/zld`
-* **Nightly Rust Compiler**: This gives access to the latest performance improvements and "unstable" optimizations
-
- ```sh
-    # Install the nightly toolchain
-    rustup toolchain install nightly
-    # Configure your current project to use nightly (run this command within the project)
-    rustup override set nightly
-    # OR configure cargo to use nightly for all projects -- switch back with `rustup default stable`
-    rustup default nightly
-    ```
-
-  * You can use `cargo +nightly ...` if you don't want to change the default to nightly.
-* **Generic Sharing**: Allows crates to share monomorphized generic code instead of duplicating it. In some cases this allows us to "precompile" generic code so it doesn't affect iterative compiles. This is only available on nightly Rust.
-
-To enable fast compiles, install the nightly rust compiler and LLD. Then copy [this file](https://github.com/bevyengine/bevy/blob/main/.cargo/config_fast_builds.toml) to `YOUR_WORKSPACE/.cargo/config.toml`. For the project in this guide, that would be `my_bevy_game/.cargo/config.toml`.

--- a/content/learn/quick-start/getting-started/setup.md
+++ b/content/learn/quick-start/getting-started/setup.md
@@ -145,7 +145,7 @@ You might think to simply develop in release mode instead, but we recommend agai
 
 Bevy can be built just fine using default configuration on stable Rust.
 Unfortunately, the compile times are rather long.
-This section explains how to improve iterative compile times.
+This section explains how to speed up iterative compiles: the amount of time it takes to rebuild your project after changing a single file.
 
 #### Dynamic Linking
 

--- a/content/learn/quick-start/getting-started/setup.md
+++ b/content/learn/quick-start/getting-started/setup.md
@@ -164,6 +164,10 @@ bevy = { version = "0.13.0", features = ["dynamic_linking"] }
 ```
 
 {% callout(type="note") %}
+On Windows you must also enable the [performance optimizations](#compile-with-performance-optimizations) or you will get a ["too many exported symbols"](https://github.com/bevyengine/bevy/issues/1110#issuecomment-1312926923) error.
+{% end %}
+
+{% callout(type="note") %}
 Shipping your game with dynamic linking enabled is not recommended because it requires you to include `libbevy_dylib` alongside your game, it prevents certain optimizations, and can increase the size of your game.
 If you remove the `dynamic_linking` feature, your game executable can run standalone.
 {% end %}
@@ -249,12 +253,25 @@ Allows crates to share monomorphized generic code instead of duplicating it.
 In some cases this allows us to "precompile" generic code so it doesn't affect iterative compiles.
 This is currently only available on nightly Rust ([see above](#nightly-rust-compiler)).
 
+<details>
+  <summary>Setup</summary>
+
+See [this file](https://github.com/bevyengine/bevy/blob/latest/.cargo/config_fast_builds.toml) for a more comprehensive, cross-platform example.
+
+```toml
+[target.x86_64-unknown-linux-gnu]
+linker = "clang"
+rustflags = [
+  "-Zshare-generics=y",      # (Nightly) Make the current crate share its generic instantiations
+]
+```
+
+</details>
+
+
 ### Build Bevy
 
 Now run `cargo run` again. The Bevy dependencies should start building. This will take some time as you are essentially building an engine from scratch. You will only need to do a full rebuild once. Every build after this one will be fast!
-
-To enable fast compiles, install the nightly rust compiler and LLD.
-Then copy the contents of [this file](https://github.com/bevyengine/bevy/blob/latest/.cargo/config_fast_builds.toml) to `/path/to/project/.cargo/config.toml`.
 
 Now that we have our Bevy project set up, we're ready to start making our first Bevy app!
 

--- a/content/learn/quick-start/getting-started/setup.md
+++ b/content/learn/quick-start/getting-started/setup.md
@@ -170,7 +170,9 @@ If you remove the `dynamic_linking` feature, your game executable can run standa
 
 #### Alternative Linkers
 
-The Rust compiler spends a lot of time in the final "link" step, especially with a massive library like Bevy. `lld` is _much faster_ at linking than the default Rust linker. To install LLD, find your OS below and run the given command.
+The Rust compiler spends a lot of time in the final "link" step, especially with a massive library like Bevy.
+`lld` is _much faster_ at linking than the default Rust linker.
+To install LLD, find your OS below and run the given command.
 
 <details>
   <summary>LLD Installation</summary>
@@ -247,13 +249,13 @@ Allows crates to share monomorphized generic code instead of duplicating it.
 In some cases this allows us to "precompile" generic code so it doesn't affect iterative compiles.
 This is currently only available on nightly Rust.
 
-To enable fast compiles, install the nightly rust compiler and LLD.
-Then copy the contents of [this file](https://github.com/bevyengine/bevy/blob/latest/.cargo/config_fast_builds.toml) to `/path/to/project/.cargo/config.toml`.
-
-If something went wrong, check out our [troubleshooting section](/learn/quick-start/troubleshooting/) or [ask for help on our Discord](https://discord.gg/bevy).
-
 ### Build Bevy
 
 Now run `cargo run` again. The Bevy dependencies should start building. This will take some time as you are essentially building an engine from scratch. You will only need to do a full rebuild once. Every build after this one will be fast!
 
+
 Now that we have our Bevy project set up, we're ready to start making our first Bevy app!
+
+{% callout(type="note") %}
+If something went wrong, check out our [troubleshooting section](/learn/quick-start/troubleshooting/) or [ask for help on our Discord](https://discord.gg/bevy).
+{% end %}

--- a/content/learn/quick-start/getting-started/setup.md
+++ b/content/learn/quick-start/getting-started/setup.md
@@ -232,7 +232,7 @@ Disabling `bevy/dynamic_linking` may improve Mold's performance.
 
 #### Nightly Rust Compiler
 
-This gives access to the latest performance improvements and "unstable" optimizations
+This gives access to the latest performance improvements and "unstable" optimizations, including [generic sharing](#generic-sharing) below
 
 Create a ```rust-toolchain.toml``` file in the root of your project, next to ```Cargo.toml```.
 
@@ -247,12 +247,14 @@ For more information, see [The rustup book: Overrides](https://rust-lang.github.
 
 Allows crates to share monomorphized generic code instead of duplicating it.
 In some cases this allows us to "precompile" generic code so it doesn't affect iterative compiles.
-This is currently only available on nightly Rust.
+This is currently only available on nightly Rust ([see above](#nightly-rust-compiler)).
 
 ### Build Bevy
 
 Now run `cargo run` again. The Bevy dependencies should start building. This will take some time as you are essentially building an engine from scratch. You will only need to do a full rebuild once. Every build after this one will be fast!
 
+To enable fast compiles, install the nightly rust compiler and LLD.
+Then copy the contents of [this file](https://github.com/bevyengine/bevy/blob/latest/.cargo/config_fast_builds.toml) to `/path/to/project/.cargo/config.toml`.
 
 Now that we have our Bevy project set up, we're ready to start making our first Bevy app!
 

--- a/content/learn/quick-start/getting-started/setup.md
+++ b/content/learn/quick-start/getting-started/setup.md
@@ -232,7 +232,7 @@ Disabling `bevy/dynamic_linking` may improve Mold's performance.
 
 #### Nightly Rust Compiler
 
-This gives access to the latest performance improvements and "unstable" optimizations, including [generic sharing](#generic-sharing) below
+This gives access to the latest performance improvements and "unstable" optimizations, including [generic sharing](#generic-sharing) below.
 
 Create a ```rust-toolchain.toml``` file in the root of your project, next to ```Cargo.toml```.
 

--- a/content/learn/quick-start/getting-started/setup.md
+++ b/content/learn/quick-start/getting-started/setup.md
@@ -253,20 +253,20 @@ In some cases this allows us to "precompile" generic code so it doesn't affect i
 This is currently only available on nightly Rust ([see above](#nightly-rust-compiler)).
 
 <details>
-  <summary>Setup</summary>
+  <summary>Generic sharing setup</summary>
 
 See [this file](https://github.com/bevyengine/bevy/blob/latest/.cargo/config_fast_builds.toml) for a more comprehensive, cross-platform example.
 
 ```toml
+# /path/to/project/.cargo/config.toml
 [target.x86_64-unknown-linux-gnu]
-linker = "clang"
 rustflags = [
-  "-Zshare-generics=y",      # (Nightly) Make the current crate share its generic instantiations
+  # (Nightly) Make the current crate share its generic instantiations
+  "-Zshare-generics=y",
 ]
 ```
 
 </details>
-
 
 ### Build Bevy
 

--- a/content/learn/quick-start/getting-started/setup.md
+++ b/content/learn/quick-start/getting-started/setup.md
@@ -150,7 +150,7 @@ This section explains how to speed up iterative compiles: the amount of time it 
 #### Dynamic Linking
 
 This is the most impactful compilation time decrease!
-If `bevy` is a dependency, you can compile the binary with the `dynamic_linking` feature flag.
+You can compile `bevy` as dynamic library, preventing it from having to be statically linked each time you rebuild your project. You can enable this with the `dynamic_linking` feature flag.
 
 ```sh
 cargo run --features bevy/dynamic_linking

--- a/content/learn/quick-start/getting-started/setup.md
+++ b/content/learn/quick-start/getting-started/setup.md
@@ -162,7 +162,7 @@ If you don't want to add the `--features bevy/dynamic_linking` to each run, this
 cargo add bevy -F dynamic_linking
 ```
 
-{% callout(type="note") %}
+{% callout(type="warning") %}
 On Windows you must also enable the [performance optimizations](#compile-with-performance-optimizations) or you will get a ["too many exported symbols"](https://github.com/bevyengine/bevy/issues/1110#issuecomment-1312926923) error.
 {% end %}
 

--- a/content/learn/quick-start/getting-started/setup.md
+++ b/content/learn/quick-start/getting-started/setup.md
@@ -156,11 +156,10 @@ You can compile `bevy` as dynamic library, preventing it from having to be stati
 cargo run --features bevy/dynamic_linking
 ```
 
-If you don't want to add the `--features bevy/dynamic_linking` to each run, this flag can permanently be set via `Cargo.toml`:
+If you don't want to add the `--features bevy/dynamic_linking` to each run, this flag can permanently be set with this command (edits `Cargo.toml` for you):
 
-```toml
-[dependencies]
-bevy = { version = "0.13.0", features = ["dynamic_linking"] }
+```sh
+cargo add bevy -F dynamic_linking
 ```
 
 {% callout(type="note") %}

--- a/content/learn/quick-start/getting-started/setup.md
+++ b/content/learn/quick-start/getting-started/setup.md
@@ -254,6 +254,6 @@ If something went wrong, check out our [troubleshooting section](/learn/quick-st
 
 ### Build Bevy
 
-Now run ```cargo run``` again. The Bevy dependencies should start building. This will take some time as you are essentially building an engine from scratch. You will only need to do a full rebuild once. Every build after this one will be fast!
+Now run `cargo run` again. The Bevy dependencies should start building. This will take some time as you are essentially building an engine from scratch. You will only need to do a full rebuild once. Every build after this one will be fast!
 
 Now that we have our Bevy project set up, we're ready to start making our first Bevy app!

--- a/content/learn/quick-start/getting-started/setup.md
+++ b/content/learn/quick-start/getting-started/setup.md
@@ -214,7 +214,7 @@ Mold is _up to 5× (five times!) faster_ than LLD, but with a few caveats like l
 * **Windows**: support not planned; [See this tracking issue](https://github.com/rui314/mold/issues/1069#issuecomment-1653436823) for more information.
 * **MacOS**: available as [sold](https://github.com/bluewhalesystems/sold), but this is unnecessary since the default linker is just as fast.
 
-You will also need to add the following to your Cargo config at `/path/to/project/.cargo/config.toml`:
+You will also need to add the following to your Cargo config at `/path/to/project/.cargo/config.toml` (where `/path/to/project` is the directory which contains `Cargo.toml`):
 
 ```toml
 [target.x86_64-unknown-linux-gnu]

--- a/content/learn/quick-start/getting-started/setup.md
+++ b/content/learn/quick-start/getting-started/setup.md
@@ -212,8 +212,8 @@ Mold is _up to 5× (five times!) faster_ than LLD, but with a few caveats like l
 * **Ubuntu**: `sudo apt-get install mold clang`
 * **Fedora**: `sudo dnf install mold clang`
 * **Arch**: `sudo pacman -S mold clang`
-* **Windows**: support not planned; [See this tracking issue](https://github.com/rui314/mold/issues/1069#issuecomment-1653436823) for more information.
-* **MacOS**: available as [sold](https://github.com/bluewhalesystems/sold), but this is unnecessary since the default linker is just as fast.
+* **Windows**: Support not planned; [See this tracking issue](https://github.com/rui314/mold/issues/1069#issuecomment-1653436823) for more information.
+* **MacOS**: Available as [sold](https://github.com/bluewhalesystems/sold), but this is unnecessary since the default linker is just as fast.
 
 You will also need to add the following to your Cargo config at `/path/to/project/.cargo/config.toml`:
 

--- a/content/learn/quick-start/getting-started/setup.md
+++ b/content/learn/quick-start/getting-started/setup.md
@@ -223,7 +223,8 @@ rustflags = ["-C", "link-arg=-fuse-ld=/usr/bin/mold"]
 ```
 
 {% callout(type="note") %}
-Disabling `bevy/dynamic_linking` may improve Mold's performance. <sup>[citation needed]</sup>
+Disabling `bevy/dynamic_linking` may improve Mold's performance.
+<sup>[citation needed]</sup>
 {% end %}
 
 </details>

--- a/content/learn/quick-start/getting-started/setup.md
+++ b/content/learn/quick-start/getting-started/setup.md
@@ -164,8 +164,7 @@ bevy = { version = "0.13.0", features = ["dynamic_linking"] }
 ```
 
 {% callout(type="note") %}
-Shipping your game with dynamic linking enabled is not recommended.
-Otherwise you will need to include `libbevy_dylib` alongside your game if you want it to run.
+Shipping your game with dynamic linking enabled is not recommended because it requires you to include `libbevy_dylib` alongside your game, it prevents certain optimizations, and can increase the size of your game.
 If you remove the `dynamic_linking` feature, your game executable can run standalone.
 {% end %}
 

--- a/content/learn/quick-start/getting-started/setup.md
+++ b/content/learn/quick-start/getting-started/setup.md
@@ -189,7 +189,7 @@ The Rust compiler spends a lot of time in the final "link" step, especially with
 
 </details>
 
-Then, add one of the following to your Cargo config at `/path/to/project/.cargo/config.toml` depending on your OS:
+Then, add one of the following to your Cargo config at `/path/to/project/.cargo/config.toml` (where `/path/to/project` is the directory which contains `Cargo.toml`) depending on your OS:
 
 ```toml
 # for Linux
@@ -213,7 +213,7 @@ Mold is _up to 5× (five times!) faster_ than LLD, but with a few caveats like l
 * **Windows**: support not planned; [See this tracking issue](https://github.com/rui314/mold/issues/1069#issuecomment-1653436823) for more information.
 * **MacOS**: available as [sold](https://github.com/bluewhalesystems/sold), but this is unnecessary since the default linker is just as fast.
 
-You will also need to add the following to your Cargo config at `/path/to/project/.cargo/config.toml` (where `/path/to/project` is the directory which contains `Cargo.toml`):
+You will also need to add the following to your Cargo config at `/path/to/project/.cargo/config.toml`:
 
 ```toml
 [target.x86_64-unknown-linux-gnu]


### PR DESCRIPTION
Fixes #45. Fixes #1085.

Completely removed the "Fast Compiles" page in the book and replaced it with strongly-worded instructions for when the book ships. Then rewrote the fast compiles section in quick-start while i was at it.