### PR TITLE
Fixed casing for a migration guide title

### DIFF
--- a/content/learn/migration-guides/0.12-to-0.13.md
+++ b/content/learn/migration-guides/0.12-to-0.13.md
@@ -10,7 +10,7 @@ Bevy relies heavily on improvements in the Rust language and compiler.
 As a result, the Minimum Supported Rust Version (MSRV) is "the latest stable release" of Rust.
 <div class="migration-guide">
 
-### [support all types of animation interpolation from gltf](https://github.com/bevyengine/bevy/pull/10755)
+### [Support all types of animation interpolation from gltf](https://github.com/bevyengine/bevy/pull/10755)
 
 <div class="migration-guide-area-tags">
     <div class="migration-guide-area-tag">Animation</div>


### PR DESCRIPTION
Just to align it with others.