### PR TITLE
0.14 migration: Fix an error in colors table and add more colors

### DIFF
--- a/release-content/0.14/migration-guides/12163_Migrate_from_LegacyColor_to_bevy_colorColor.md
+++ b/release-content/0.14/migration-guides/12163_Migrate_from_LegacyColor_to_bevy_colorColor.md
@@ -137,9 +137,12 @@ Please note that `palettes::css` is not necessarily 1:1 with the constants defin
 
 |0.13|0.14|
 |-|-|
-|`GREEN`|`LIMEGREEN`|
-|`PINK`|`DEEP_PINK`|
+|`CYAN`|`AQUA`|
 |`DARK_GRAY`|`Srgba::gray(0.25)`|
+|`DARK_GREEN`|`Srgba::rgb(0.0, 0.5, 0.0)`|
+|`GREEN`|`LIME`|
+|`LIME_GREEN`|`LIMEGREEN`|
+|`PINK`|`DEEP_PINK`|
 
 #### Switch to `LinearRgba`
 


### PR DESCRIPTION
I included a mistake in this table when I added it -- `GREEN`'s new equivalent is `LIME`, not `LIME_GREEN`. `LIME_GREEN` isn't even a thing anymore, it's `LIMEGREEN`. 😅

Also alphabetized the list and added a few more examples. This may still not be totally comprehensive, but I did a quick side-by-side scan of the color constants before/after.