### PR TITLE
0.14 release: Minor cleanup in upstreaming bevy color section

### DIFF
--- a/release-content/0.14/release-notes/12013_Upstreaming_bevy_color.md
+++ b/release-content/0.14/release-notes/12013_Upstreaming_bevy_color.md
@@ -1,4 +1,5 @@
-Colors are a huge part of building a good game: UI, effects, shaders and more all need fully-featured, correct and convenient color tools.  
+Colors are a huge part of building a good game: UI, effects, shaders and more all need fully-featured, correct and convenient color tools.
+
 Bevy now supports a broad selection of color spaces, each with their own type (e.g. `LinearRgba`, `Hsla`, `Oklaba`),
 and offers a wide range of fully documented operations on and conversions between them.
 
@@ -13,20 +14,20 @@ use bevy_color::prelude::*;
 // Each color space now corresponds to a specific type
 let red = Srgba::rgb(1., 0., 0.);
 
-// All non-standard color space conversions are done through the shortest path between  
-// the source and target color spaces to avoid a quadratic explosion of generated code.  
-// This conversion...  
-let red = Oklcha::from(red);  
-// ...is implemented using  
-let red = Oklcha::from(Oklaba::from(LinearRgba::from(red)));  
+// All non-standard color space conversions are done through the shortest path between
+// the source and target color spaces to avoid a quadratic explosion of generated code.
+// This conversion...
+let red = Oklcha::from(red);
+// ...is implemented using
+let red = Oklcha::from(Oklaba::from(LinearRgba::from(red)));
 
 // We've added the `tailwind` palette colors: perfect for quick-but-pretty prototyping!
 // And the existing CSS palette is now actually consistent with the industry standard :p
-let blue = Oklcha = tailwind::BLUE_500;
+let blue = tailwind::BLUE_500;
 
 // The color space that you're mixing your colors in has a huge impact!
 // Consider using the scientifically-motivated `Oklcha` or `Oklaba` for a perceptually uniform effect.
-let purple =  red.mix(blue, 0.5);
+let purple = red.mix(blue, 0.5);
 ```
 
 Most of the user-facing APIs still accept a colorspace-agnostic `Color` (which now wraps our color-space types),


### PR DESCRIPTION
Mainly fixing this: 

```
let blue = Oklcha = tailwind::BLUE_500;
```

But cleaned up some whitespace as well.