### PR TITLE
Add spaces to match formatting by taplo in guide and notes generators

### DIFF
--- a/generate-release/src/migration_guides.rs
+++ b/generate-release/src/migration_guides.rs
@@ -130,7 +130,7 @@ file_name = "{file_name}.md"
             .iter()
             .map(|area| format!("\"{area}\""))
             .collect::<Vec<_>>()
-            .join(","),
+            .join(", "),
         title = title.trim().replace('"', "\\\"")
     )
 }

--- a/generate-release/src/release_notes.rs
+++ b/generate-release/src/release_notes.rs
@@ -123,7 +123,7 @@ file_name = "{file_name}.md"
             .iter()
             .map(|author| format!("\"{author}\""))
             .collect::<Vec<_>>()
-            .join(","),
+            .join(", "),
         title = title.trim().replace('"', "\\\"")
     )
 }


### PR DESCRIPTION
This will make generated toml by these tools more closely match the formatting that is produced by `taplo` (as recommended in `CONTRIBUTING.md`). This should result in less of a mess when someone's editor auto-formats them.

There are some places where this still won't match because there are many entries in the array and they won't fit on one line. We should probably be using the `toml` crate to generate this instead of building it manually.

```diff
[[guides]]
title = "Decouple `BackgroundColor` from `UiImage`"
url = "https://github.com/bevyengine/bevy/pull/11165"
- areas = ["Rendering","UI"]
+ areas = ["Rendering", "UI"]
file_name = "11165_Decouple_BackgroundColor_from_UiImage.md"
```

```diff
[[release_notes]]
title = "Upstreaming bevy_color."
- authors = ["@viridia","@mockersf"]
+ authors = ["@viridia", "@mockersf"]
url = "https://github.com/bevyengine/bevy/pull/12013"
file_name = "12013_Upstreaming_bevy_color.md"
```