### PR TITLE
Add migration notes for 12889 Implement GPU frustum culling

### DIFF
--- a/release-content/0.14/migration-guides/12889_Implement_GPU_frustum_culling.md
+++ b/release-content/0.14/migration-guides/12889_Implement_GPU_frustum_culling.md
@@ -1,0 +1,3 @@
+For phase items, the `dynamic_offset: Option<NonMaxU32>` field is now `extra_index: PhaseItemExtraIndex`, which wraps a `u32`. Instead of `None`, use `PhaseItemExtraIndex::NONE`.
+
+This change affects `AlphaMask3d`, `AlphaMask3dDeferred`, `AlphaMask3dPrepass`, `Opaque2d`, `Opaque3dDeferred`, `Opaque3dPrepass`, `Shadow`, `Transmissive3d`, `Transparent2d`, `Transparent3d`, and `TransparentUi`.

--- a/release-content/0.14/migration-guides/_guides.toml
+++ b/release-content/0.14/migration-guides/_guides.toml
@@ -545,6 +545,12 @@ areas = ["Rendering"]
 file_name = "12453_Improve_performance_by_binning_together_opaque_items_inste.md"
 
 [[guides]]
+title = "Implement GPU frustum culling"
+url = "https://github.com/bevyengine/bevy/pull/12889"
+areas = ["Rendering"]
+file_name = "12889_Implement_GPU_frustum_culling.md"
+
+[[guides]]
 title = "remove `DeterministicRenderingConfig`"
 url = "https://github.com/bevyengine/bevy/pull/12811"
 areas = ["Rendering"]


### PR DESCRIPTION
Adds migration notes for https://github.com/bevyengine/bevy/pull/12889 . Closes #1454 .