### PR TITLE
Fix typo in `ECS Hooks and Observers` section

### DIFF
--- a/release-content/0.14/release-notes/10756_hooks_and_observers.md
+++ b/release-content/0.14/release-notes/10756_hooks_and_observers.md
@@ -71,7 +71,7 @@ impl Component for Targetable {
             let targetable = world.get::<Targetable>(targeted_entity).unwrap();
             for targeting_entity in targetable.targeted_by {
                 // Track down the entity that's targeting us
-                let mut targeting = world.get::<Targeting>(targeting_entity).unwrap();
+                let mut targeting = world.get::<Target>(targeting_entity).unwrap();
                 // And clear its target, cleaning up any dangling references
                 targeting.0 = None;
             }


### PR DESCRIPTION
Replaced `Targeting` with `Target`.