### PR TITLE
Remove Jondolf as author from some release notes

### DIFF
--- a/release-content/0.14/release-notes/_release-notes.toml
+++ b/release-content/0.14/release-notes/_release-notes.toml
@@ -253,7 +253,6 @@ authors = [
 	"@bushrat011899",
 	"@JohnTheCoolingFan",
 	"@NthTensor",
-	"@Jondolf",
 	"@IQuick143",
 	"@alice-i-cecile",
 ]
@@ -412,6 +411,6 @@ file_name = "13653_Added_CompassQuadrant_and_CompassOctant_as_per_13647.md"
 
 [[release_notes]]
 title = "Bevy Working Groups"
-authors = ["@alice-i-cecile", "@Jondolf"]
+authors = ["@alice-i-cecile"]
 url = "https://github.com/bevyengine/bevy/pull/13162"
 file_name = "13162_Add_a_process_for_working_groups.md"


### PR DESCRIPTION
I am listed in some release notes as an author even though I don't consider myself to be one, so I thought I'd remove myself from there. For the `VectorSpace` PR, I didn't even comment or participate in any other way, so I'm not sure how I ended up there :P