### PR TITLE
Tidy up release notes for PR 12747 and cubic splines

### DIFF
--- a/release-content/0.14/release-notes/12747_Move_Point_out_of_cubic_splines_module_and_expand_it.md
+++ b/release-content/0.14/release-notes/12747_Move_Point_out_of_cubic_splines_module_and_expand_it.md
@@ -4,4 +4,4 @@ These traits underpin the new curve and shape sampling apis. `VectorSpace` is im
 
 The splines module in bevy has been lacking some features for a long time. Splines are extremely useful in game development, so improving them would improve everything that uses them.
 
-The biggest addition is NURBS support! It is a variant of a B-Spline with much more parameters that can be tweaked to create specific curve shapes. We also added a `LinearSpline`, which can be used to put straight line segments in a `CubicCurve`, which now acts as a sequence of curve segments, so you can mix various spline types together to form a single path.
+The biggest addition is NURBS support! It is a variant of a B-Spline with much more parameters that can be tweaked to create specific curve shapes. We also added a `LinearSpline`, which can be used to put straight line segments in a curve. `CubicCurve` now acts as a sequence of curve segments to which you can add new pieces, so you can mix various spline types together to form a single path.

--- a/release-content/0.14/release-notes/12747_Move_Point_out_of_cubic_splines_module_and_expand_it.md
+++ b/release-content/0.14/release-notes/12747_Move_Point_out_of_cubic_splines_module_and_expand_it.md
@@ -4,6 +4,4 @@ These traits underpin the new curve and shape sampling apis. `VectorSpace` is im
 
 The splines module in bevy has been lacking some features for a long time. Splines are extremely useful in game development, so improving them would improve everything that uses them.
 
-The biggest addition is NURBS support! It is a variant of a B-Spline with much more parameters that can be tweaked to create specific curve shapes.
-
-We also added a LinearSpline, which can be used to put straight line segments in a CubicCurve, which now acts as a sequence of cure segments, so you can mix various spline types together to form a single path.
+The biggest addition is NURBS support! It is a variant of a B-Spline with much more parameters that can be tweaked to create specific curve shapes. We also added a `LinearSpline`, which can be used to put straight line segments in a `CubicCurve`, which now acts as a sequence of cure segments, so you can mix various spline types together to form a single path.

--- a/release-content/0.14/release-notes/12747_Move_Point_out_of_cubic_splines_module_and_expand_it.md
+++ b/release-content/0.14/release-notes/12747_Move_Point_out_of_cubic_splines_module_and_expand_it.md
@@ -7,5 +7,3 @@ The splines module in bevy has been lacking some features for a long time. Splin
 The biggest addition is NURBS support! It is a variant of a B-Spline with much more parameters that can be tweaked to create specific curve shapes.
 
 We also added a LinearSpline, which can be used to put straight line segments in a CubicCurve, which now acts as a sequence of cure segments, so you can mix various spline types together to form a single path.
-
-And as a small improvement, the VectorSpace trait has been implemented and 4-dimensional Vectors. This trait is implemented for types that can be used in cubic curves, so now you have more types that can be used. For example, you can use the 4th element of a Vec4 to store tilt along the path on the curve.

--- a/release-content/0.14/release-notes/12747_Move_Point_out_of_cubic_splines_module_and_expand_it.md
+++ b/release-content/0.14/release-notes/12747_Move_Point_out_of_cubic_splines_module_and_expand_it.md
@@ -4,4 +4,4 @@ These traits underpin the new curve and shape sampling apis. `VectorSpace` is im
 
 The splines module in bevy has been lacking some features for a long time. Splines are extremely useful in game development, so improving them would improve everything that uses them.
 
-The biggest addition is NURBS support! It is a variant of a B-Spline with much more parameters that can be tweaked to create specific curve shapes. We also added a `LinearSpline`, which can be used to put straight line segments in a `CubicCurve`, which now acts as a sequence of cure segments, so you can mix various spline types together to form a single path.
+The biggest addition is NURBS support! It is a variant of a B-Spline with much more parameters that can be tweaked to create specific curve shapes. We also added a `LinearSpline`, which can be used to put straight line segments in a `CubicCurve`, which now acts as a sequence of curve segments, so you can mix various spline types together to form a single path.


### PR DESCRIPTION
Removed last paragraph that talked about a small change to `VectorSpace`, all of it is included in the top paragraph.
Merged the remaining last two paragraphs, improved wording, fixed typos and broke up a long chained sentence.