### PR TITLE
Remove hard-coded width and height from news page image

### DIFF
--- a/templates/news-page.html
+++ b/templates/news-page.html
@@ -50,15 +50,9 @@
   {% if page.extra.image and page.extra.show_image %}
     <div class="media-content news-content">
       {% if page.extra.image_subtitle %}
-        <img src="{{ page.extra.image }}"
-              alt="{{ page.extra.image_subtitle }}"
-              width="926"
-              height="521" />
+        <img src="{{ page.extra.image }}" alt="{{ page.extra.image_subtitle }}" />
       {% else %}
-        <img src="{{ page.extra.image }}"
-              alt="An image representing the article"
-              width="926"
-              height="521" />
+        <img src="{{ page.extra.image }}" alt="An image representing the article" />
       {% endif %}
       {% if page.extra.image_subtitle %}
         {% if page.extra.image_subtitle_link %}


### PR DESCRIPTION
The hard coded image size (specifically the height) prevents it from following the aspect ratio of the image, resulting in it stretching when there isn't enough space. These were added in #1026 ... I don't think this is a good rule to enforce.