### PR TITLE
Add aspect ratio to news images

### DIFF
--- a/templates/news-page.html
+++ b/templates/news-page.html
@@ -50,9 +50,9 @@
   {% if page.extra.image and page.extra.show_image %}
     <div class="media-content news-content">
       {% if page.extra.image_subtitle %}
-        <img src="{{ page.extra.image }}" alt="{{ page.extra.image_subtitle }}" style="aspect-ratio: auto 19 / 9" />
+        <img src="{{ page.extra.image }}" alt="{{ page.extra.image_subtitle }}" style="aspect-ratio: auto 16 / 9" />
       {% else %}
-        <img src="{{ page.extra.image }}" alt="An image representing the article" style="aspect-ratio: auto 19 / 9" />
+        <img src="{{ page.extra.image }}" alt="An image representing the article" style="aspect-ratio: auto 16 / 9" />
       {% endif %}
       {% if page.extra.image_subtitle %}
         {% if page.extra.image_subtitle_link %}

--- a/templates/news-page.html
+++ b/templates/news-page.html
@@ -50,9 +50,9 @@
   {% if page.extra.image and page.extra.show_image %}
     <div class="media-content news-content">
       {% if page.extra.image_subtitle %}
-        <img src="{{ page.extra.image }}" alt="{{ page.extra.image_subtitle }}" />
+        <img src="{{ page.extra.image }}" alt="{{ page.extra.image_subtitle }}" style="aspect-ratio: auto 19 / 9" />
       {% else %}
-        <img src="{{ page.extra.image }}" alt="An image representing the article" />
+        <img src="{{ page.extra.image }}" alt="An image representing the article" style="aspect-ratio: auto 19 / 9" />
       {% endif %}
       {% if page.extra.image_subtitle %}
         {% if page.extra.image_subtitle_link %}


### PR DESCRIPTION
This PR adds the `aspect-ratio` property to the image header of all news posts (defaults to 16:9). This lets the browser allocate space on the page for it before the image loads, reducing layout shifts after the first paint. [See this link for an example of layout shifts.](https://web.dev/articles/optimize-cls#images-without-dimensions)

The aspect ratio is set using inline CSS so it is loaded with the very first request, in case the normal style sheet is delayed. I use `aspect-ratio: auto 16 / 9` to tell the browser that the image is usually 16:9, but `auto` says to override this ratio once the image loads in case it is different. [See this section on `auto`.](https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio#auto_ratio)

This PR is a follow up to #1519, which removed the hard-coded dimensions of the image because it caused stretching on mobile. Big thanks to @Jondolf for pointing this change out [on Discord](https://discord.com/channels/691052431525675048/1239930965267054623/1258419498713612308).

Here is a video using the `aspect-ratio` property, though it was before 2558368b2fda8d7ee7d89e826874851026b19cc2 so the ratio is wrong.

https://github.com/bevyengine/bevy-website/assets/59022059/aec89772-e5cf-4820-be15-54b292c2ef13