### PR TITLE
Fix typo

### DIFF
--- a/content/learn/quick-start/getting-started/setup.md
+++ b/content/learn/quick-start/getting-started/setup.md
@@ -293,7 +293,7 @@ For more information, see [The rustup book: Overrides](https://rust-lang.github.
 
 #### Cranelift
 
-This uses a new nightly-only codegen that is about 30% faster at compiling than LLM. 
+This uses a new nightly-only codegen that is about 30% faster at compiling than LLVM. 
 It currently works best on Linux.
 
 To install cranelift, run the following.


### PR DESCRIPTION
LLM -> LLVM

Giving this the `S-Ready-For-Final-Review` label instantly because of extreme triviality