### PR TITLE
Automatically run `oxipng` on example screenshots

### DIFF
--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Install oxipng
         run: |
-          which oxipng || cargo install oxipng
+          cargo install oxipng
 
       - name: Take Screenshots
         run: |
@@ -66,7 +66,7 @@ jobs:
 
       - name: Optimize PNGs
         run: |
-          oxipng -o 4 -s -r screenshots
+          oxipng -o 6 -s -r screenshots
 
       - name: Upload Generated Files
         uses: actions/upload-artifact@v4

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Optimize PNGs
         run: |
-          oxipng -o 4 -s screenshots/*
+          oxipng -o 4 -s -r screenshots
 
       - name: Upload Generated Files
         uses: actions/upload-artifact@v4

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Optimize PNGs
         run: |
-          oxipng -o 4 -s screenshots
+          oxipng -o 4 -s screenshots/*.png
 
       - name: Upload Generated Files
         uses: actions/upload-artifact@v4

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Optimize PNGs
         run: |
-          oxipng -o 4 -s screenshots/
+          oxipng -o 4 -s screenshots/*
 
       - name: Upload Generated Files
         uses: actions/upload-artifact@v4

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Install oxipng
         run: |
-          cargo install oxipng
+          cargo install oxipng --version ^9.1.1
 
       - name: Take Screenshots
         run: |
@@ -66,7 +66,7 @@ jobs:
 
       - name: Optimize PNGs
         run: |
-          oxipng -o 6 -s -r screenshots
+          oxipng --opt max --strip safe --recursive screenshots
 
       - name: Upload Generated Files
         uses: actions/upload-artifact@v4

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -56,9 +56,12 @@ jobs:
           sudo apt-get update
           sudo apt install -y xvfb libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
 
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@main
+
       - name: Install oxipng
         run: |
-          cargo install oxipng
+          cargo binstall oxipng
 
       - name: Take Screenshots
         run: |

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -57,11 +57,11 @@ jobs:
           sudo apt install -y xvfb libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
 
       - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@main
+        uses: cargo-bins/cargo-binstall@v1.7.4
 
       - name: Install oxipng
         run: |
-          cargo binstall oxipng --no-confirm
+          cargo binstall oxipng@9.1.1 --no-confirm
 
       - name: Take Screenshots
         run: |

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Install oxipng
         run: |
-          cargo binstall oxipng
+          cargo binstall oxipng --no-confirm
 
       - name: Take Screenshots
         run: |

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Optimize PNGs
         run: |
-          oxipng -o 4 -s screenshots/*.png
+          oxipng -o 4 -s screenshots/
 
       - name: Upload Generated Files
         uses: actions/upload-artifact@v4

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -49,16 +49,30 @@ jobs:
           DEBIAN_FRONTEND=noninteractive sudo apt-get install --no-install-recommends -yq \
             libasound2-dev libudev-dev libxkbcommon-x11-0;
 
-      - name: install xvfb, llvmpipe and lavapipe
+      - name: Install xvfb, llvmpipe and lavapipe
         run: |
           sudo apt-get update -y -qq
           sudo add-apt-repository ppa:kisak/turtle -y
           sudo apt-get update
           sudo apt install -y xvfb libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
 
+      - name: Cache oxipng
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/
+          key: ${{ runner.os }}-cargo
+
+      - name: Install oxipng
+        run: |
+          which oxipng || cargo install oxipng
+
       - name: Take Screenshots
         run: |
           xvfb-run cargo run -p example-showcase -- --page ${{ matrix.page }} --per-page ${{ env.PER_PAGE }} run --screenshot --in-ci
+
+      - name: Optimize PNGs
+        run: |
+          oxipng -o 4 -s *.png
 
       - name: Upload Generated Files
         uses: actions/upload-artifact@v4

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -56,12 +56,6 @@ jobs:
           sudo apt-get update
           sudo apt install -y xvfb libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
 
-      - name: Cache oxipng
-        uses: actions/cache@v3
-        with:
-          path: ~/.cargo/
-          key: ${{ runner.os }}-cargo
-
       - name: Install oxipng
         run: |
           which oxipng || cargo install oxipng
@@ -72,7 +66,7 @@ jobs:
 
       - name: Optimize PNGs
         run: |
-          oxipng -o 4 -s *.png
+          oxipng -o 4 -s screenshots
 
       - name: Upload Generated Files
         uses: actions/upload-artifact@v4

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -56,12 +56,9 @@ jobs:
           sudo apt-get update
           sudo apt install -y xvfb libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
 
-      - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@v1.7.4
-
       - name: Install oxipng
         run: |
-          cargo binstall oxipng@9.1.1 --no-confirm
+          cargo install oxipng
 
       - name: Take Screenshots
         run: |


### PR DESCRIPTION
- Fixes #1534.
- This PR adds an image compression step to the [`Update Screenshots`](https://github.com/bevyengine/bevy-website/actions/workflows/update-screenshots.yml) GitHub Action.
- The whole compression overhead (installing `oxipng` and running it with the maximum compression level) adds about a minute to the workflow runtime, which is minuscule when compared to the avg. ~3h completion time.
