### PR TITLE
Fix migration guide related to `App`

### DIFF
--- a/release-content/0.14/migration-guides/13022_Make_AppExit_more_specific_about_exit_reason.md
+++ b/release-content/0.14/migration-guides/13022_Make_AppExit_more_specific_about_exit_reason.md
@@ -37,7 +37,7 @@ fn handle_exit(mut reader: EventReader<AppExit>) {
 }
 ```
 
-Furthermore, `App::run()` and `App::runner` now return `AppExit` instead of the unit type `()`. Since `AppExit` implements [`Termination`](https://doc.rust-lang.org/stable/std/process/trait.Termination.html), you can now return it from the main function.
+Furthermore, `App::run()` now returns `AppExit` instead of the unit type `()`. Since `AppExit` implements [`Termination`](https://doc.rust-lang.org/stable/std/process/trait.Termination.html), you can now return it from the main function.
 
 ```rust
 // 0.13
@@ -55,4 +55,17 @@ fn main() {
     // If you want to ignore `AppExit`, you can add a semicolon instead. :)
     App::new().run();
 }
+```
+
+Finally, if you configured a custom `App` runner function, it will now have to return an `AppExit`.
+
+```rust
+let mut app = App::new();
+
+app.set_runner(|_app| {
+    // ...
+
+    // Return success by default, though you may also return an error code.
+    AppExit::Success
+});
 ```

--- a/release-content/0.14/migration-guides/13022_Make_AppExit_more_specific_about_exit_reason.md
+++ b/release-content/0.14/migration-guides/13022_Make_AppExit_more_specific_about_exit_reason.md
@@ -37,7 +37,7 @@ fn handle_exit(mut reader: EventReader<AppExit>) {
 }
 ```
 
-Furthermore, `App::run` now returns `AppExit` instead of the unit type `()`. Since `AppExit` implements [`Termination`](https://doc.rust-lang.org/stable/std/process/trait.Termination.html), you can now return it from the main function.
+Furthermore, `App::run()` and `App::runner` now return `AppExit` instead of the unit type `()`. Since `AppExit` implements [`Termination`](https://doc.rust-lang.org/stable/std/process/trait.Termination.html), you can now return it from the main function.
 
 ```rust
 // 0.13

--- a/release-content/0.14/migration-guides/9202_Refactor_App_and_SubApp_internals_for_better_separation.md
+++ b/release-content/0.14/migration-guides/9202_Refactor_App_and_SubApp_internals_for_better_separation.md
@@ -75,7 +75,7 @@ app.insert_sub_app(MySubApp, SubApp::new());
 assert_eq!(app.sub_app(MySubApp).type_id(), TypeId::of::<SubApp>());
 ```
 
-Finally, `App::runner` and `App::main_schedule_label` are now private. It is no longer possible to access the runner function, but you can access the main schedule label using `SubApp::update_schedule`.
+Finally, `App::runner` and `App::main_schedule_label` are now private. It is no longer possible to get the runner closure, but you can get the main schedule label using `SubApp::update_schedule`.
 
 ```rust
 let app = App::new();

--- a/release-content/0.14/migration-guides/9202_Refactor_App_and_SubApp_internals_for_better_separation.md
+++ b/release-content/0.14/migration-guides/9202_Refactor_App_and_SubApp_internals_for_better_separation.md
@@ -75,6 +75,13 @@ app.insert_sub_app(MySubApp, SubApp::new());
 assert_eq!(app.sub_app(MySubApp).type_id(), TypeId::of::<SubApp>());
 ```
 
+Finally, `App::runner` and `App::main_schedule_label` are now private. It is no longer possible to access the runner function, but you can access the main schedule label using `SubApp::update_schedule`.
+
+```rust
+let app = App::new();
+let label = app.main().update_schedule;
+```
+
 #### 3rd-party traits on `App`
 
 If you implemented an extension trait on `App`, consider also implementing it on `SubApp`:


### PR DESCRIPTION
Fixes #1540. This now mentions how `App::set_runner()` requires the function to return `AppExit`, and how `App`'s properties are now private.