### PR TITLE
Fix path of config.toml

### DIFF
--- a/content/learn/quick-start/getting-started/setup.md
+++ b/content/learn/quick-start/getting-started/setup.md
@@ -301,7 +301,7 @@ To install cranelift, run the following.
 rustup component add rustc-codegen-cranelift-preview --toolchain nightly
 ```
 
-To activate it for your project, add the following to your `.config/cargo.toml`.
+To activate it for your project, add the following to your `.cargo/config.toml`.
 ```toml
 [unstable]
 codegen-backend = true


### PR DESCRIPTION
Fix path by switching `.config/cargo.toml` to `.cargo/config.toml`

[source](https://github.com/rust-lang/rustc_codegen_cranelift?tab=readme-ov-file#download-using-rustup) for fix