### PR TITLE
Sort assets that use the latest Bevy version first

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2283,6 +2283,7 @@ dependencies = [
  "dotenv",
  "rand",
  "regex",
+ "semver",
  "serde",
  "toml 0.7.8",
  "ureq",
@@ -4409,6 +4410,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "send_wrapper"

--- a/generate-assets/Cargo.toml
+++ b/generate-assets/Cargo.toml
@@ -20,6 +20,7 @@ base64 = "0.13.0"
 cratesio-dbdump-csvtab = "0.2.2"
 ureq = { version = "2.5.0", features = ["json"] }
 dotenv = "0.15.0"
+semver = "1.0.23"
 
 [lints]
 workspace = true

--- a/generate-assets/src/bin/generate.rs
+++ b/generate-assets/src/bin/generate.rs
@@ -74,21 +74,22 @@ fn sort_section(nodes: &mut [AssetNode], latest_bevy_version: &semver::Version) 
         let is_semver_compat = node_semver_compat_with(node, latest_bevy_version);
         let random: u32 = rand::random();
 
-        to_sort.push((node, is_semver_compat, random));
+        let existing_order = match node {
+            AssetNode::Asset(asset) => asset.order.unwrap_or(usize::MAX),
+            _ => continue,
+        };
+
+        to_sort.push((node, existing_order, !is_semver_compat, random));
     }
 
-    to_sort.sort_by_key(|sorts| (!sorts.1, sorts.2));
+    to_sort.sort_by_key(|sorts| (sorts.1, sorts.2, sorts.3));
 
-    for (i, (node, _, _)) in to_sort.into_iter().enumerate() {
+    for (i, (node, _, _, _)) in to_sort.into_iter().enumerate() {
         let AssetNode::Asset(asset) = node else {
             continue;
         };
 
-        if asset.order.is_none() {
-            // Reserve some space in the front for official assets that have been
-            // manually ordered.
-            asset.order = Some(100 + i);
-        }
+        asset.order = Some(i);
     }
 }
 

--- a/generate-assets/src/bin/generate.rs
+++ b/generate-assets/src/bin/generate.rs
@@ -72,13 +72,13 @@ fn sort_section(nodes: &mut [AssetNode], latest_bevy_version: &semver::Version) 
     let mut to_sort = vec![];
     for node in nodes {
         let is_semver_compat = node_semver_compat_with(node, latest_bevy_version);
-        let random: u32 = rand::random();
 
         let existing_order = match node {
             AssetNode::Asset(asset) => asset.order.unwrap_or(usize::MAX),
             _ => continue,
         };
 
+        let random: u32 = rand::random();
         to_sort.push((node, existing_order, !is_semver_compat, random));
     }
 

--- a/generate-assets/src/bin/generate.rs
+++ b/generate-assets/src/bin/generate.rs
@@ -38,7 +38,7 @@ fn main() -> anyhow::Result<()> {
     };
 
     let _ = fs::create_dir(content_dir.clone());
-    let asset_root_section = parse_assets(
+    let mut asset_root_section = parse_assets(
         &asset_dir,
         MetadataSource {
             crates_io_db: Some(&db),
@@ -48,10 +48,64 @@ fn main() -> anyhow::Result<()> {
         },
     )?;
 
+    let latest_bevy_version = get_latest_bevy_version(&db)?;
+
+    sort_section(&mut asset_root_section.content, &latest_bevy_version);
+
     asset_root_section
         .write(Path::new(&content_dir), Path::new(""), 0)
         .expect("Failed to write assets section");
     Ok(())
+}
+
+/// Sort the assets in the section so that:
+/// - Assets that have been manually assigned an order in `bevy-assets` are first
+/// - Assets that are semver compatible with Bevy are next
+/// - If all else is equal, sort randomly
+fn sort_section(nodes: &mut [AssetNode], latest_bevy_version: &semver::Version) {
+    for node in nodes.iter_mut() {
+        if let AssetNode::Section(ref mut section) = node {
+            sort_section(&mut section.content, latest_bevy_version);
+        }
+    }
+
+    let mut to_sort = vec![];
+    for node in nodes.iter_mut() {
+        let is_semver_compat = node_semver_compat_with(node, latest_bevy_version);
+        let random: u32 = rand::random();
+
+        to_sort.push((node, is_semver_compat, random));
+    }
+
+    to_sort.sort_by_key(|sorts| (!sorts.1, sorts.2));
+
+    for (i, (node, _, _)) in to_sort.into_iter().enumerate() {
+        let AssetNode::Asset(asset) = node else {
+            continue;
+        };
+
+        if asset.order.is_none() {
+            // Reserve some space in the front for official assets that have been
+            // manually ordered.
+            asset.order = Some(100 + i);
+        }
+    }
+}
+
+fn node_semver_compat_with(node: &AssetNode, version: &semver::Version) -> bool {
+    let AssetNode::Asset(asset) = node else {
+        return false;
+    };
+
+    let Some(ver) = asset.bevy_versions.as_ref().and_then(|v| v.first()) else {
+        return false;
+    };
+
+    let Ok(semver) = semver::VersionReq::parse(ver) else {
+        return false;
+    };
+
+    semver.matches(version)
 }
 
 trait FrontMatterWriter {

--- a/generate-assets/src/bin/generate.rs
+++ b/generate-assets/src/bin/generate.rs
@@ -64,7 +64,7 @@ fn main() -> anyhow::Result<()> {
 /// - If all else is equal, sort randomly
 fn sort_section(nodes: &mut [AssetNode], latest_bevy_version: &semver::Version) {
     for node in nodes.iter_mut() {
-        if let AssetNode::Section(ref mut section) = node {
+        if let AssetNode::Section(section) = node {
             sort_section(&mut section.content, latest_bevy_version);
         }
     }

--- a/generate-assets/src/bin/generate.rs
+++ b/generate-assets/src/bin/generate.rs
@@ -70,7 +70,7 @@ fn sort_section(nodes: &mut [AssetNode], latest_bevy_version: &semver::Version) 
     }
 
     let mut to_sort = vec![];
-    for node in nodes.iter_mut() {
+    for node in nodes {
         let is_semver_compat = node_semver_compat_with(node, latest_bevy_version);
         let random: u32 = rand::random();
 

--- a/generate-assets/src/lib.rs
+++ b/generate-assets/src/lib.rs
@@ -697,7 +697,6 @@ pub fn get_latest_bevy_version(db: &CratesIoDb) -> anyhow::Result<semver::Versio
         .filter_map(|r| semver::Version::parse(&r.ok()?).ok())
         .collect();
 
-    // Reverse sort
     bevy_versions
         .into_iter()
         .max()

--- a/generate-assets/src/lib.rs
+++ b/generate-assets/src/lib.rs
@@ -672,6 +672,38 @@ fn get_bevy_crates(db: &CratesIoDb) -> Result<Vec<(String, String)>, rusqlite::E
     bevy_crates
 }
 
+/// Get the highest (according to semver) version of Bevy listed in the crates.io database
+pub fn get_latest_bevy_version(db: &CratesIoDb) -> anyhow::Result<semver::Version> {
+    let mut bevy_id_statement = db.prepare(
+        "\
+            SELECT id \
+            FROM crates \
+            WHERE name = 'bevy'\
+        ",
+    )?;
+
+    let bevy_id: String = bevy_id_statement.query_row([], |row| row.get(0))?;
+
+    let mut bevy_versions_statement = db.prepare(
+        "\
+            SELECT num \
+            FROM versions \
+            WHERE crate_id = ?\
+        ",
+    )?;
+
+    let bevy_versions: Vec<semver::Version> = bevy_versions_statement
+        .query_map([bevy_id], |r| r.get::<_, String>(0))?
+        .filter_map(|r| semver::Version::parse(&r.ok()?).ok())
+        .collect();
+
+    // Reverse sort
+    bevy_versions
+        .into_iter()
+        .max()
+        .context("Failed to retrieve Bevy versions from crates.io db")
+}
+
 /// Get a prepared statement to get license and version for a crate from the
 /// crates.io database dump.
 ///


### PR DESCRIPTION
# Motivation

Help users find up-to-date assets quicker

Fixes #760
Fixes https://github.com/bevyengine/bevy-assets/issues/297

# Solution

Sorts assets by the following key:
```rust
(
    // Any existing order defined in the bevy-assets metadata.
    // e.g. for "official" templates and learning material
    existing_order,
    // Uses the semver crate to compare the "version requirement" from the asset with
    // the latest Bevy version
    is_semver_compatible_with_latest_bevy,
    // If all else is equal, randomize
    random
)
````