### PR TITLE
Added target folder size warning with Cranelift on Windows

### DIFF
--- a/content/learn/quick-start/getting-started/setup.md
+++ b/content/learn/quick-start/getting-started/setup.md
@@ -322,6 +322,11 @@ Notably, Wasm builds do not work yet.
 
 When shipping your game, you should still compile it with LLVM.
 
+{% callout(type="warning") %}
+With Cranelift on Windows, you can end up with very large `target/` folders if you have debug symbols turned on.
+Disable debug symbols by adding `debug = false` under the `[profile.dev.package."*"]` section in your `Cargo.toml`.
+{% end %}
+
 #### Generic Sharing
 
 Allows crates to share monomorphized generic code instead of duplicating it.


### PR DESCRIPTION
When using Cranelift on Windows with debug symbols turned on for all dev packages, you can end up with a target folder up to 20 GBs for the hello world project and initial compile time can go up to 30 minutes.

![image](https://github.com/user-attachments/assets/85caf967-9dde-4066-b40c-0487e90cdfbf)

This PR adds a warning to prevent users from bumping into this issue if they don't have much storage or time to spare.

Feel free to edit the message itself! I have done my best to write down the problem in as little characters as possible in order to not make a large warning note.
