### PR TITLE
Remove remaining reference to legacy sponsors page

### DIFF
--- a/content/donate/faq/index.md
+++ b/content/donate/faq/index.md
@@ -29,7 +29,3 @@ The monthly dollar amount is the "raw pledged amount for active monthly donation
 
 1. This number is "pre Stripe fees". This includes credit card fees and Stripes "processing fees", which vary per payment type.
 2. This is the amount we _expect_ to get each month. In practice the payouts will be less, once chargebacks and cancellations are processed.
-
-## Why doesn't the Individual Sponsors section / the "old way to sponsor" contribute to the metrics on the donate page?
-
-Primarily this is because we don't want to conflate Bevy Foundation funds with other funds. The Bevy Foundation does not have direct access to these funds, and for "reporting / transparency" reasons, conflating the two contexts would be confusing for the public (and likely government agencies as well). We plan on deprecating the Individual Sponsors section in the future. It exists today as a courtesy to ensure we aren't quickly changing the rules on our current sponsors.


### PR DESCRIPTION
#1564 Removed the legacy sponsors section, but a reference remained within the donation FAQ.