### PR TITLE
Donation FAQ: Correct expected update time for donation page

### DIFF
--- a/content/donate/faq/index.md
+++ b/content/donate/faq/index.md
@@ -21,7 +21,7 @@ Please only use names, logos, and links that you have the right and permission t
 
 ## I sponsored but the metrics / names / logos on the donate page haven't updated!
 
-Please wait a little. It might take up to an hour for the automatic update to add you to the credits.
+Please wait a little. It might take up to eight hours for the automatic update to add you to the credits.
 
 ## How are the metrics on the donation page calculated?
 


### PR DESCRIPTION
The info on donation page updates only every  8  hours.

Fix statement in FAQ claiming that the update happens within one hour.