### PR TITLE
0.13 migration: Fix canvas size css

### DIFF
--- a/content/learn/migration-guides/0.12-to-0.13.md
+++ b/content/learn/migration-guides/0.12-to-0.13.md
@@ -1473,8 +1473,8 @@ Remove uses of `Window::fit_canvas_to_parent` in favor of CSS properties, for ex
 
 ```css
 canvas {
-  width: 100%;
-  height: 100%;
+  width: 100% !important;
+  height: 100% !important;
 }
 ```
 


### PR DESCRIPTION
This seems to be necessary.

It's possible that it's not necessary when specifying a canvas by id, but I didn't test that. Either way, with Bevy's defaults, I believe this is needed.

note: `fit_canvas_to_parent` was re-added in Bevy 0.14, but seemingly only as a convenience for users without the ability to use css. So I am pretty sure this is still relevant.