### PR TITLE
Fix clippy lints for Rust 1.80

### DIFF
--- a/code-validation/src/lib.rs
+++ b/code-validation/src/lib.rs
@@ -7,6 +7,7 @@
 // code blocks. Without this, Clippy would require front-matter and Tera templates to be surrounded
 // by backticks.
 #![allow(clippy::doc_markdown)]
+#![allow(clippy::doc_lazy_continuation)]
 
 mod learn {
     #[doc = include_str!("../../content/learn/quick-start/_index.md")]

--- a/generate-assets/src/lib.rs
+++ b/generate-assets/src/lib.rs
@@ -307,16 +307,16 @@ fn merge_version(version1: Option<String>, version2: Option<String>) -> Option<S
 /// - tries to get metadata from the root `Cargo.toml` file,
 /// - if the license is missing, search the license of the project on Github,
 /// - if metadata is missing, search all `Cargo.toml` files, then tries to get metadata
-/// from all of them, until we have the information we need.
+///   from all of them, until we have the information we need.
 ///
 /// Note:
 /// - The search call of the API has a tendency to return 403 errors after a few number
-/// of calls. Assets that are at the "end" might not have correct metadata because of that.
+///   of calls. Assets that are at the "end" might not have correct metadata because of that.
 /// - This algorithm tries to retain the "best" version and merge all licenses found.
 /// - If a licence and version is found, it will stop searching, but the information
-/// about the version and license could have gotten "better" by searching deper.
+///   about the version and license could have gotten "better" by searching deper.
 /// - Likewise, the project license is never checked if a license is provided in the root
-/// `Cargo.toml` file.
+///   `Cargo.toml` file.
 fn get_metadata_from_github(
     client: &GithubClient,
     username: &str,
@@ -465,7 +465,7 @@ fn get_license(cargo_manifest: &cargo_toml::Manifest) -> Option<String> {
 /// - in the (regular) dependencies,
 /// - in the dev dependencies (used for examples, tests and benchmarks),
 /// - in the workspace dependencies.
-/// It doesn't go deeper if a version is already found.
+///   It doesn't go deeper if a version is already found.
 fn get_bevy_version_from_manifest(
     cargo_manifest: &cargo_toml::Manifest,
     bevy_crates: &Option<Vec<String>>,


### PR DESCRIPTION
It's new Rust day!

Similar to #1403, a new clippy lint was complaining about markdown in the book.

And also some trivial indentation in `generate-assets` doc comments.