### PR TITLE
fix compilation error

### DIFF
--- a/content/learn/quick-start/getting-started/apps.md
+++ b/content/learn/quick-start/getting-started/apps.md
@@ -12,7 +12,7 @@ Every Bevy program can be referred to as an [`App`]. The simplest Bevy app looks
 use bevy::prelude::*;
 
 fn main() {
-    App::new().run();
+    App::new().run((), ());
 }
 ```
 


### PR DESCRIPTION
I compile [The simplest Bevy app](https://bevyengine.org/learn/quick-start/getting-started/apps/) shown as bellow.

```rust
use bevy::prelude::*;

fn main() {
    App::new.run();
}
```

that raises compilation error.

```console
error[E0061]: this method takes 2 arguments but 0 arguments were supplied
   --> src/main.rs:4:14
    |
4   |     App::new.run();
    |              ^^^-- two arguments of type `()` and `()` are missing
    |
note: method defined here
   --> /home/kazuk/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bevy_ecs-0.14.0/src/system/function_system.rs:685:8
    |
685 |     fn run(&mut self, input: Self::In, param_value: SystemParamIte...
    |        ^^^
help: provide the arguments
    |
4   |     App::new.run((), ());
    |                 ~~~~~~~~

For more information about this error, try `rustc --explain E0061`.
```

run needs 2 of units as args.