### PR TITLE
Add contextually clearing gizmos Migration Guide for 0.13 to 0.14

### DIFF
--- a/release-content/0.14/migration-guides/10973_Contextually_clearing_gizmos.md
+++ b/release-content/0.14/migration-guides/10973_Contextually_clearing_gizmos.md
@@ -1,0 +1,1 @@
+`App::insert_gizmo_group()` function is now named `App::insert_gizmo_config()`.

--- a/release-content/0.14/migration-guides/_guides.toml
+++ b/release-content/0.14/migration-guides/_guides.toml
@@ -771,3 +771,9 @@ title = "Separating Finite and Infinite 3d Planes"
 url = "https://github.com/bevyengine/bevy/pull/12426"
 areas = ["Math", "Rendering"]
 file_name = "12426_separating_finite_and_infinite_3d_planes.md"
+
+[[guides]]
+title = "Contextually clearing gizmos"
+url = "https://github.com/bevyengine/bevy/pull/10973"
+areas = ["Gizmos"]
+file_name = "10973_Contextually_clearing_gizmos.md"


### PR DESCRIPTION
Fixes #1551 

Mentions that `insert_gizmo_group` is now `insert_gizmo_config`.