### PR TITLE
Change generate-release to use a better path to release-content

### DIFF
--- a/generate-release/src/main.rs
+++ b/generate-release/src/main.rs
@@ -5,7 +5,7 @@ use contributors::generate_contributors;
 use github_client::BevyRepo;
 use migration_guides::generate_migration_guides;
 use release_notes::generate_release_notes;
-use std::path::PathBuf;
+use std::env::current_exe;
 
 mod changelog;
 mod contributors;
@@ -87,8 +87,15 @@ fn main() -> anyhow::Result<()> {
         BevyRepo::Bevy,
     );
 
-    // WARN this assumes it gets ran from ./generate-release
-    let release_path = PathBuf::from("..")
+    let mut release_path = current_exe()?;
+    // We pop thrice because the executable is
+    // in the workspaces (roots) `target/debug` directory,
+    // so we're effectively finding the directory containing
+    // `target/debug/executable`, which is what we want.
+    for _ in 0..3 {
+        release_path.pop();
+    }
+    let release_path = release_path
         .join("release-content")
         .join(args.release_version);
 


### PR DESCRIPTION
# Objective
Fixes #1465 

Currently `generate-release` uses the relative path of `../release-content`, but this is dependent on where you're calling from and as such is undesirable.

## Solution
This PR instead uses the `current_exe()` function to get the absolute path to the executable, which in our use cases will always be `{workspace}/target/{debug|release}/{executable}`. So if we get the workspace directory (equivalent to the root of the project, which is what we want), then we always have the correct directory regardless of if we call it in `generate-release` or `{workspace}`.

## Testing
It has not been tested fully; when I try to run it, it seems to require a `GITHUB_TOKEN` to make issues and PRs which is undesirable in testing imo.