### PR TITLE
Fix Contributor's Guide layout

### DIFF
--- a/content/contributing/_index.md
+++ b/content/contributing/_index.md
@@ -2,8 +2,10 @@
 title = "Contributing"
 template = "docs.html"
 page_template = "docs.html"
-insert_anchor_links = "right"
+# TODO: Create introduction page.
+# redirect_to = "/contributing/introduction"
 [extra]
+# TODO: Remove this to publish the Contributing book.
 status = 'hidden'
 public_draft = 1146
 +++

--- a/content/contributing/_index.md
+++ b/content/contributing/_index.md
@@ -5,7 +5,7 @@ page_template = "docs.html"
 # TODO: Create introduction page.
 # redirect_to = "/contributing/introduction"
 [extra]
-# TODO: Remove this to publish the Contributing book.
+# TODO: Remove both of these lines below, `status` and `public_draft`, to publish the Contributing book.
 status = 'hidden'
 public_draft = 1146
 +++

--- a/content/contributing/helping-out/_index.md
+++ b/content/contributing/helping-out/_index.md
@@ -1,6 +1,6 @@
 +++
-title = "Reference"
+title = "Helping out"
 template = "docs.html"
 [extra]
-weight = 3
+weight = 2
 +++

--- a/content/contributing/helping-out/reporting-issues.md
+++ b/content/contributing/helping-out/reporting-issues.md
@@ -1,5 +1,5 @@
 +++
-title = "Using Github Issues"
+title = "Reporting Issues"
 insert_anchor_links = "right"
 [extra]
 weight = 1


### PR DESCRIPTION
This updates the layout of the Contributor's Guide to mirror the layout in [HackMD](https://hackmd.io/qWCaVBIuR6aF692yZNPvTA). It also fixes some issues where sections where missing, and removes redundant configuration.

Instead of trying to comprehend the changes, I recommend running `zola serve` and seeing the changes for yourself. You can find the guide at <http://127.0.0.1:1111/contributing/>.