### PR TITLE
Fix Discord link in callout

### DIFF
--- a/content/contributing/helping-out/how-you-can-help.md
+++ b/content/contributing/helping-out/how-you-can-help.md
@@ -59,6 +59,8 @@ If you already know what you want to work on, all you have to do is make your ch
 
 {% callout() %}
 When working on the engine's code, it's a good idea to introduce yourself in the `#engine-dev` channel on [Discord] and tell people about your plans. Communicating your progress early and often can help you avoid avoid headaches and disagreements during code review.
+
+[Discord]: https://discord.gg/bevy
 {% end %}
 
 ## Writing docs and examples


### PR DESCRIPTION
Zola renders shortcode content within a different context, so you need to specify links within them.

This is the callout block before this PR (note "[Discord]"):

![image](https://github.com/user-attachments/assets/ae0a4060-296c-4f77-b8ab-a71588cbd81e)