### PR TITLE
Add specific zola version currently being used

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The Bevy website is built using the Zola static site engine. In our experience, 
 
 To check out any local changes you've made:
 
-1. [Download Zola](https://www.getzola.org/).
+1. [Install Zola](https://www.getzola.org/documentation/getting-started/installation/) version `0.17.2`.
 2. Clone the Bevy Website git repo and enter that directory:
    1. `git clone https://github.com/bevyengine/bevy-website.git`
    2. `cd bevy-website`


### PR DESCRIPTION
Currently, the build process uses Zola `0.17.2` (ref https://discord.com/channels/691052431525675048/695741366520512563/1272241115558314037) so added that to the README so people don't try to use the latest Zola version (which is currently incompatible)

Also changed the link to go directly to the installation page, and changed the wording from `Download Zola` to `Install Zola`, small copyedits :)