### PR TITLE
Fix README to specify Zola 0.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The Bevy website is built using the Zola static site engine. In our experience, 
 
 To check out any local changes you've made:
 
-1. [Install Zola](https://www.getzola.org/documentation/getting-started/installation/) version `0.17.2`.
+1. [Install Zola](https://www.getzola.org/documentation/getting-started/installation/) version `0.18.0`.
 2. Clone the Bevy Website git repo and enter that directory:
    1. `git clone https://github.com/bevyengine/bevy-website.git`
    2. `cd bevy-website`


### PR DESCRIPTION
Unfortunately I didn't have time to catch #1600 before it was merged. The website actually uses Zola 0.18, not 0.17.2! It was updated last February in #1018. 

Note how we pull in `shalzz/zola-deploy-action@v0.18.0`:

https://github.com/bevyengine/bevy-website/blob/e285dfdc5149b13129b81472c5ad201abdf61d08/.github/workflows/ci.yml#L247-L253

https://github.com/bevyengine/bevy-website/blob/e285dfdc5149b13129b81472c5ad201abdf61d08/.github/workflows/deploy.yml#L47-L53