### PR TITLE
Update Zola to v0.19.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,7 +245,7 @@ jobs:
           path: content/community/people
 
       - name: "Build website"
-        uses: shalzz/zola-deploy-action@v0.18.0
+        uses: shalzz/zola-deploy-action@v0.19.2
         env:
           PAGES_BRANCH: gh-pages
           BUILD_DIR: .

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: "Build and deploy website"
         if: github.repository_owner == 'bevyengine'
-        uses: shalzz/zola-deploy-action@v0.18.0
+        uses: shalzz/zola-deploy-action@v0.19.2
         env:
           PAGES_BRANCH: gh-pages
           BUILD_DIR: .

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ The Bevy website is built using the Zola static site engine. In our experience, 
 
 To check out any local changes you've made:
 
-1. [Download Zola v0.18.0](https://www.getzola.org/).
+1. [Download Zola v0.19.2](https://www.getzola.org/).
 2. Clone the Bevy Website git repo and enter that directory:
     1. `git clone https://github.com/bevyengine/bevy-website.git`
     2. `cd bevy-website`

--- a/config.toml
+++ b/config.toml
@@ -10,9 +10,8 @@ compile_sass = true
 # Whether to build a search index to be used later on by a JavaScript library
 build_search_index = true
 
-generate_feed = true
-rss_limit = 1000
-highlight_theme = "charcoal"
+generate_feeds = true
+feed_limit = 1000
 
 taxonomies = [
     {name = "news", feed = true},
@@ -22,7 +21,7 @@ taxonomies = [
 # Whether to do syntax highlighting
 # Theme can be customised by setting the `highlight_theme` variable to a theme supported by Zola
 highlight_code = true
-highlight_theme = "css"
+highlight_theme = "charcoal"
 
 [extra]
 # Put all your custom variables here

--- a/config.toml
+++ b/config.toml
@@ -21,7 +21,7 @@ taxonomies = [
 # Whether to do syntax highlighting
 # Theme can be customised by setting the `highlight_theme` variable to a theme supported by Zola
 highlight_code = true
-highlight_theme = "charcoal"
+highlight_theme = "css"
 
 [extra]
 # Put all your custom variables here

--- a/content/contributing/helping-out/writing-docs.md
+++ b/content/contributing/helping-out/writing-docs.md
@@ -47,7 +47,7 @@ We also consider [bevyengine.org](https://bevyengine.org) to be part of our core
 
 To check out any local changes you've made:
 
-1. [Download Zola v0.18.0](https://www.getzola.org/).
+1. [Download Zola v0.19.2](https://www.getzola.org/).
 2. Clone the Bevy Website GitHub repository and enter that directory:
     1. `git clone https://github.com/bevyengine/bevy-website.git`
     2. `cd bevy-website`


### PR DESCRIPTION
# Objective

Closes #1601 

Update Zola to v0.19.2 so that folks can just use the latest version without worry.

## Solution

Modify the the `config.toml` to account for the support for multiple types of feeds (RSS, and Atom), and remove an erring line on our part (`highlight_themes` seems to be only valid under the `[markdown]` category, and I don't know why this didn't error before).

Change the work flows to use v0.19.2 of Zola.

Also update the CONTRIBUTING.md and Contributing Guide to reflect that we've changed versions