### PR TITLE
Fix date formatting for days with one digit

### DIFF
--- a/templates/news-page.html
+++ b/templates/news-page.html
@@ -7,7 +7,7 @@
 {% block page_content %}
   <h1 class="news-title">{{ page.title }}</h1>
   <h2 class="news-subtitle">
-    Posted on {{ page.date | date(format="%B %d, %Y") }} by {% if page.authors %}{% for author in page.authors %}{{ author }}{% endfor %}{% else %}Bevy Contributors{% endif %}
+    Posted on {{ page.date | date(format="%B %-d, %Y") }} by {% if page.authors %}{% for author in page.authors %}{{ author }}{% endfor %}{% else %}Bevy Contributors{% endif %}
     {% if page.extra.twitter or page.extra.github %}
       <span class="news-social-links">
         (


### PR DESCRIPTION
Before:
<img width="417" alt="Screenshot 2024-08-21 at 4 25 25 PM" src="https://github.com/user-attachments/assets/6470ecb0-79d6-4712-b705-e0cb38298c60">


After:
<img width="417" alt="Screenshot 2024-08-21 at 4 21 07 PM" src="https://github.com/user-attachments/assets/267de0c0-0a50-42be-a856-e8bd40d34c20">

