### PR TITLE
Change Github to GitHub across the website's content

### DIFF
--- a/content/foundation/meeting-minutes/2024-02-03/index.md
+++ b/content/foundation/meeting-minutes/2024-02-03/index.md
@@ -81,7 +81,7 @@ Unanimously approved.
 
 Discussed how to validate meeting minutes.
 
-Agreed on storing meeting minutes on Github on `bevy-website repo`, and approved by board members via PR approval.
+Agreed on storing meeting minutes on GitHub on `bevy-website repo`, and approved by board members via PR approval.
 
 ## Transferring the ownership of the bevyengine.org domain to the Foundation
 

--- a/content/learn/migration-guides/0.6-to-0.7.md
+++ b/content/learn/migration-guides/0.6-to-0.7.md
@@ -7,7 +7,7 @@ long_title = "Migration Guide: 0.6 to 0.7"
 weight = 2
 +++
 
-<!-- Github filter used to find the relevant PRs "is:pr label:C-Breaking-Change closed:>2022-02-01 [Merged by Bors]" -->
+<!-- GitHub filter used to find the relevant PRs "is:pr label:C-Breaking-Change closed:>2022-02-01 [Merged by Bors]" -->
 
 ### [ParamSet for conflicting SystemParam](https://github.com/bevyengine/bevy/pull/2765)
 

--- a/content/learn/migration-guides/0.7-to-0.8.md
+++ b/content/learn/migration-guides/0.7-to-0.8.md
@@ -12,7 +12,7 @@ Before migrating make sure to run `rustup update`
 Bevy relies heavily on improvements in the Rust language and compiler.
 As a result, the Minimum Supported Rust Version (MSRV) is "the latest stable release" of Rust.
 
-<!-- Github filter used to find the relevant PRs "is:pr label:C-Breaking-Change closed:>2022-04-15 [Merged by Bors]" -->
+<!-- GitHub filter used to find the relevant PRs "is:pr label:C-Breaking-Change closed:>2022-04-15 [Merged by Bors]" -->
 
 ### [Camera Driven Rendering](https://github.com/bevyengine/bevy/pull/4745)
 

--- a/content/news/2020-08-19-scaling-bevy/index.md
+++ b/content/news/2020-08-19-scaling-bevy/index.md
@@ -23,7 +23,7 @@ First, I want to take a moment to highlight just how wild the last week has been
         <img src="2nd_on_hacker_news.png" style="display: block; height: 10rem"/>
     </div>
     <div style="max-width: 20rem; max-height: 15rem; margin-right: 3rem; margin-bottom: 3rem">
-        <h4>2,200 Github Stars</h4>
+        <h4>2,200 GitHub Stars</h4>
         <img src="2_2k_stars.png" style="display: block; height: 3rem"/>
     </div>
     <div style="max-width: 20rem; max-height: 15rem; margin-right: 3rem; margin-bottom: 3rem">

--- a/content/news/2021-08-10-bevys-first-birthday/index.md
+++ b/content/news/2021-08-10-bevys-first-birthday/index.md
@@ -25,7 +25,7 @@ For those who don't know, Bevy is a refreshingly simple data-driven game engine 
 * **August 10**: [Bevy 0.1](/news/introducing-bevy/)
   * Bevy's first public release! After months of working incognito, I released Bevy to the world. It was by no means complete, but it had most of the pillars in place to show the world what Bevy is (and could be): a modern and flexible renderer built on top of a modular Render Graph, a custom ECS with unrivaled ergonomics and competitive performance, 2D and 3D rendering features, asset handling, a modular app model that blurs the lines between engine developers and app developers, a custom UI system that integrates deeply with the engine, scenes, hot reloading, and blissfully productive iterative compile times.
 * **August 19**: [Absolutely Wild Public Reception](/news/scaling-bevy/)
-  * Just a week after release we became the 3rd most popular /r/rust post of all time, hit #2 on Hacker News, received 2,200 Github stars, merged pull requests from 26 new contributors, gained 644 Discord members, and received [sponsorships](https://github.com/sponsors/cart) that brought us 37% of the way to our first funding goal.
+  * Just a week after release we became the 3rd most popular /r/rust post of all time, hit #2 on Hacker News, received 2,200 GitHub stars, merged pull requests from 26 new contributors, gained 644 Discord members, and received [sponsorships](https://github.com/sponsors/cart) that brought us 37% of the way to our first funding goal.
 * **August 20**: [Reached our first funding goal ($1500 / month)](https://github.com/sponsors/cart)
   * [Embark became our first platinum sponsor](https://twitter.com/BevyEngine/status/1296525644004593664), which brought us past our first funding goal, allowing me to work on Bevy full time without eating into my savings. This honestly set the course for the rest of the year of Bevy development.
 * **August 20**: [The Amethyst forum post: "Bevy Engine - Addressing the elephant in the room"](https://community.amethyst.rs/t/bevy-engine-addressing-the-elephant-in-the-room/)
@@ -46,7 +46,7 @@ For those who don't know, Bevy is a refreshingly simple data-driven game engine 
   * [Bevy Assets](https://bevyengine.org/assets/) is a public library of community developed Bevy plugins, crates, assets, games, and learning materials. The website is fed by structured toml files in the [bevy-assets repo](https://github.com/bevyengine/bevy-assets). It has its roots in the awesome-bevy repo, our old unstructured markdown document with a list of community projects. It is still hot off the presses, but we have big plans for it!  
 * **June 24**: [Reached our third funding goal ($4000 / month)](https://github.com/sponsors/cart)
   * Reaching this goal marked the point where I started thinking about Bevy as a career. I'm not making "market rate" for my skills and I'm still making less than 1/4th what I made as a Senior Software Engineer at Microsoft, but I'm no longer "just breaking even" and I'm starting to save some money.
-* **August 2**: [Bevy hits 10,000 stars on Github](https://twitter.com/cart_cart/status/1422393321394085888)
+* **August 2**: [Bevy hits 10,000 stars on GitHub](https://twitter.com/cart_cart/status/1422393321394085888)
   * I honestly can't believe we hit this so quickly.
 * **August 10**: Bevy is now one year old!
 
@@ -54,13 +54,13 @@ For those who don't know, Bevy is a refreshingly simple data-driven game engine 
 
 ![numbers](numbers.svg)
 
-* **255** unique Bevy contributors on [Github](https://github.com/bevyengine)
-* **10,030** [Github](https://github.com/bevyengine) stars
-* **837** forks on [Github](https://github.com/bevyengine)
-* **1,501** pull requests (1060 merged) on [Github](https://github.com/bevyengine)
-* **1,112** issues (609 closed) on [Github](https://github.com/bevyengine)
-* **1,895** commits on [Github](https://github.com/bevyengine)
-* **153**  [Github Discussions](https://github.com/bevyengine/bevy/discussions)
+* **255** unique Bevy contributors on [GitHub](https://github.com/bevyengine)
+* **10,030** [GitHub](https://github.com/bevyengine) stars
+* **837** forks on [GitHub](https://github.com/bevyengine)
+* **1,501** pull requests (1060 merged) on [GitHub](https://github.com/bevyengine)
+* **1,112** issues (609 closed) on [GitHub](https://github.com/bevyengine)
+* **1,895** commits on [GitHub](https://github.com/bevyengine)
+* **153**  [GitHub Discussions](https://github.com/bevyengine/bevy/discussions)
 * **110** [Bevy Assets](https://bevyengine.org/assets/) (plugins, crates, games, apps, and learning materials)
 * **57,349** downloads on [crates.io](https://crates.io/crates/bevy)
 * **93** [@BevyEngine](https://twitter.com/BevyEngine) retweets of Bevy community content on Twitter
@@ -76,7 +76,7 @@ For those who don't know, Bevy is a refreshingly simple data-driven game engine 
 
 I'm _so_ happy that Bevy quickly went from being "my engine" to being "our engine". It was beautiful to see so many people find passion projects in Bevy. Take a look at the feature author lists in the release blog posts (after Bevy 0.1). This community is _huge_, _wildly_ productive, and _intensely_ collaborative!
 
-Our community is also extremely welcoming: we have an active [Github Q&A platform](https://github.com/bevyengine/bevy/discussions/categories/q-a) and [#help channel](https://discord.com/invite/bevy) on Discord (with over 82,000 messages). If you haven't already, [hop in to our Discord](https://discord.com/invite/bevy) and say hi!
+Our community is also extremely welcoming: we have an active [GitHub Q&A platform](https://github.com/bevyengine/bevy/discussions/categories/q-a) and [#help channel](https://discord.com/invite/bevy) on Discord (with over 82,000 messages). If you haven't already, [hop in to our Discord](https://discord.com/invite/bevy) and say hi!
 
 ### Development Pace
 
@@ -146,9 +146,9 @@ Bevy ECS is the interface we use to build both engine features and apps, so it w
 
 For those who think ECS is over-hyped ... I totally get it. ECS is _not_ the only way to build a good engine. Anyone who tells you otherwise either has an agenda or hasn't thought enough about the problem yet. ECS is, however, one of the best ways to standardize data representation and flow in a modular context. This is a problem that _every_ engine needs to solve and the results almost always end up looking _something_ like ECS, even if they don't use that label. ECS is also an extremely broad category, to the point of being almost meaningless. If thinking about Bevy ECS as "Bevy Data Layer" makes you happier, that is a completely valid mindset! Our APIs extend beyond traditional ECS definitions (and [we have plans to go further](https://github.com/bevyengine/bevy/pull/1627)). If you want to use an ECS-based engine because you've bought into the hype, I promise Bevy ECS can deliver :)
 
-### Github Popularity
+### GitHub Popularity
 
-With over 10,000 stars, we are now the most popular Rust game engine on Github by a pretty wide margin. We are the [8th most popular game engine on Github](https://github.com/topics/game-engine). And Godot (currently holding the #1 spot with 40,900 stars) is starting to feel within our grasp, especially given their six year head start on us. If we make the same amount of progress next year, we'll be in the #2 spot! I'll be the first to say that popularity isn't everything. It isn't a measure of project maturity or feature set, but it _is_ a measure of how many people we reach and resonate with. Winning hearts and minds is an important part of scaling an open source project. I'm proud of this progress and I hope the rest of the community is too.
+With over 10,000 stars, we are now the most popular Rust game engine on GitHub by a pretty wide margin. We are the [8th most popular game engine on GitHub](https://github.com/topics/game-engine). And Godot (currently holding the #1 spot with 40,900 stars) is starting to feel within our grasp, especially given their six year head start on us. If we make the same amount of progress next year, we'll be in the #2 spot! I'll be the first to say that popularity isn't everything. It isn't a measure of project maturity or feature set, but it _is_ a measure of how many people we reach and resonate with. Winning hearts and minds is an important part of scaling an open source project. I'm proud of this progress and I hope the rest of the community is too.
 
 ### Bevy Jobs
 
@@ -254,7 +254,7 @@ Here are some predictions about Bevy's trajectory over the next year:
 * If the "Next Generation Bevy UI" effort is successful, people wanting to build "Rust GUI apps" will start reaching for Bevy.
 * We will break out of the "Rust gamedev enthusiast" circles. By the end of the year, Bevy will be brought up more regularly in the wider gamedev community alongside conversations about Unity, Unreal, and Godot. Not necessarily as a _direct_ competitor yet, but as a viable alternative for people that (1) want something new / innovative / different and (2) are willing to work around a smaller feature set and slightly less stable APIs.
 
-If any of this excites you, we would love your help! Check out our code on [Github](https://github.com/bevyengine/bevy), start participating in the [Bevy Community](https://bevyengine.org/community/), and consider [sponsoring my work](https://github.com/sponsors/cart) to ensure I can continue building and leading this wildly ambitious project.
+If any of this excites you, we would love your help! Check out our code on [GitHub](https://github.com/bevyengine/bevy), start participating in the [Bevy Community](https://bevyengine.org/community/), and consider [sponsoring my work](https://github.com/sponsors/cart) to ensure I can continue building and leading this wildly ambitious project.
 
 I'm looking forward to spending the next year with you all!
 

--- a/content/news/2023-08-10-bevys-third-birthday/index.md
+++ b/content/news/2023-08-10-bevys-third-birthday/index.md
@@ -155,7 +155,7 @@ This will change. The Editor _is actually my top priority now_ and I aim to make
 
 ### Funding Bevy is Confusing
 
-In the early days, I was the only person meaningfully working on Bevy. It made sense to have the Donate button link directly to my [Github Sponsors page](https://github.com/sponsors/cart). But things have changed! The [Bevy Org](/community/people/#the-bevy-organization) is now huge and there are plenty of people spending significant amounts of time making Bevy awesome. This year to help account for that, we made a new [Donate Page](/community/donate/) that describes the structure of the Bevy Org and provides a list of people accepting sponsorships. The Donate button now links to this page instead of directly to me.
+In the early days, I was the only person meaningfully working on Bevy. It made sense to have the Donate button link directly to my [GitHub Sponsors page](https://github.com/sponsors/cart). But things have changed! The [Bevy Org](/community/people/#the-bevy-organization) is now huge and there are plenty of people spending significant amounts of time making Bevy awesome. This year to help account for that, we made a new [Donate Page](/community/donate/) that describes the structure of the Bevy Org and provides a list of people accepting sponsorships. The Donate button now links to this page instead of directly to me.
 
 However this is still suboptimal. How does a company or individual pick who to sponsor? It takes insider knowledge to know where the money would be "best spent". In the end I'm certain most people will opt for name recognition. And when I am often the public face of the project, that likely often means me. Bevy's funding should not be a popularity contest.
 

--- a/content/news/2024-02-17-bevy-0.13/index.md
+++ b/content/news/2024-02-17-bevy-0.13/index.md
@@ -2387,7 +2387,7 @@ For a complete list of changes, check out the PRs listed below.
 * [fix patches for example showcase after winit update][11058]
 * [finish cleaning up dependency bans job][11059]
 * [Bump actions/upload-artifact from 2 to 4][11014]
-* [Publish dev-docs with Github Pages artifacts (2nd attempt)][10892]
+* [Publish dev-docs with GitHub Pages artifacts (2nd attempt)][10892]
 * [example showcase patches: use default instead of game mode for desktop][11250]
 * [Bump toml_edit in build-template-pages tool][11342]
 * [Miri is failing on latest nightly: pin nightly to last known working version][11421]


### PR DESCRIPTION
# Objective
Fixes #1607 

## Solution
Run the command `find . -type f - exec sed -i 's/Github/GitHub/g' {} +` in `/content` to search and replace all references of `Github` to `GitHub` in the website's content.

## Testing
1. Clone or get my `bevy-website` fork as a remote
2. Fetch the remote.
3. `git switch trialdragon/1607_fix_github_capitalization` to get my working branch.
4. Run `zola serve` to see a local version of the website and check if the changes are made user-side.