### PR TITLE
Migrate engine style guide to Contributing Guide

### DIFF
--- a/content/learn/contribute/helping-out/opening-pull-requests.md
+++ b/content/learn/contribute/helping-out/opening-pull-requests.md
@@ -76,7 +76,7 @@ When contributing, please:
 * Prefer small PRs that incrementally improve things.
 * Explain what you're doing and why.
 * Try to loosely follow the workflow in [*Making changes to Bevy*](#making-changes-to-bevy).
-* Consult the [style guide](@/learn/contribute/helping-out/creating-examples.md#style-guide) to help keep our code base tidy.
+* Consult the [style guide](@/learn/contribute/helping-out/opening-pull-requests.md#style-guide) to help keep our code base tidy.
 * Document new code with doc comments.
 * Include clear, simple tests.
 * Add or improve the examples when adding new user-facing functionality.
@@ -86,6 +86,42 @@ When contributing, please:
 Your first PR will be merged in no time!
 
 No matter how you're helping, thanks for contributing to Bevy!
+
+## Style Guide
+
+### General guidelines
+
+1. Prefer granular imports over glob imports like `bevy_ecs::prelude::*`.
+2. Use a consistent comment style:
+   1. `///` doc comments belong above `#[derive(Trait)]` invocations.
+   2. `//` comments should generally go above the line in question, rather than in-line.
+   3. Avoid `/* */` block comments, even when writing long comments.
+   4. Use \`variable_name\` code blocks in comments to signify that you're referring to specific types and variables.
+   5. Start comments with capital letters. End them with a period if they are sentence-like.
+3. Use comments to organize long and complex stretches of code that can't sensibly be refactored into separate functions.
+4. When using [Bevy error codes](https://bevyengine.org/learn/errors/) include a link to the relevant error on the Bevy website in the returned error message `... See: https://bevyengine.org/learn/errors/b0003`.
+
+### Rust API guidelines
+
+As a reference for our API development we are using the [Rust API guidelines][Rust API guidelines]. Generally, these should be followed, except for the following areas of disagreement:
+
+#### Areas of disagreements
+
+Some areas mentioned in the [Rust API guidelines][Rust API guidelines] we do not agree with. These areas will be expanded whenever we find something else we do not agree with, so be sure to check these from time to time.
+
+> All items have a rustdoc example
+
+- This guideline is too strong and not applicable for everything inside of the Bevy game engine. For functionality that requires more context or needs a more interactive demonstration (such as rendering or input features), make use of the `examples` folder instead.
+
+> Examples use ?, not try!, not unwrap
+
+- This guideline is usually reasonable, but not always required.
+
+> Only smart pointers implement Deref and DerefMut
+
+- Generally a good rule of thumb, but we're probably going to deliberately violate this for single-element wrapper types like `Life(u32)`. The behavior is still predictable and it significantly improves ergonomics / new user comprehension.
+
+[Rust API guidelines]: https://rust-lang.github.io/api-guidelines/about.html
 
 ## Receiving and Responding To Reviews
 


### PR DESCRIPTION
# Objective
Migrate the `bevy` repository's `.github/contributing/engine_style_guide.md` to the Opening Pull Requests page, so that the modern guide has parity with the old contributing guide and materials for https://github.com/bevyengine/bevy/issues/14884

## Solution

Create a new second-level header for the style guide and copy the engine style guide to it verbatim.

## Testing
Run `zola serve --open` on the branch `trialdragon/migrate_engine_style_guide`, and explore `/learn/contribute/helping-out/opening-pull-requests#style-guide`.