### PR TITLE
Bring Contributing Guide Working Groups Documentation Up to Date

### DIFF
--- a/content/learn/contribute/helping-out/how-you-can-help.md
+++ b/content/learn/contribute/helping-out/how-you-can-help.md
@@ -41,7 +41,7 @@ Interested in reviewing, but don't know where to start? Check out [Reviewing Pul
 
 ## Joining a Working Group
 
-Bevy's active initiatives are organized into *temporary working groups*: public, open-membership teams where people work together to tackle a sizeable, well-scoped goal. Each working group coordinates through a dedicated forum-channel on [Discord], but they may also create issues or use project boards to organize and track their progress.
+Bevy's active initiatives are organized into *temporary working groups*: public, open-membership teams where people work together to tackle a sizeable, well-scoped goal. Each working group coordinates through a [dedicated forum-channel](https://discord.com/channels/691052431525675048/1235758970703188008) on [Discord], but they may also create issues or use project boards to organize and track their progress.
 
 You should consider joining a working group if you're interested in contributing, but don't know where to start or what to work on. Choosing one and asking how to help can be a fantastic way to get up to speed and be immediately useful.
 

--- a/content/learn/contribute/project-information/working-groups.md
+++ b/content/learn/contribute/project-information/working-groups.md
@@ -64,8 +64,8 @@ This is the primary review step: Maintainers and SMEs should be broadly patient 
 ## Implement The Design Doc
 
 With a sign-off in hand, post the design doc to [GitHub Discussions](https://github.com/Bevyengine/Bevy/discussions) with the [`C-Design-Doc` label](https://github.com/Bevyengine/Bevy/discussions?discussions_q=is%3Aopen+label%3A%22C-Design+Doc%22) for archival purposes and begin work on implementation.
-Post PRs that you need review on in your group's forum thread, ask for advice, and share the load.
-Controversial PRs are still `X-Controversial`, but with a sign-off-in-priniciple, things should go more smoothly.
+Post PRs that you need reviews on in your group's forum thread, ask for advice, and share the load.
+Controversial PRs are still `X-Controversial`, but with a sign-off-in-principle, things should go more smoothly.
 
 If work peters out and the initiative dies, Maintainers can wind down working groups (in consultation with SMEs and the working group itself).
 This is normal and expected— projects fail for all sorts of reasons!


### PR DESCRIPTION
# Objective
Bring the Contributing Guide's Working Group page up to date with the `bevy` repository's `CONTRIBUTING.md`.

## Solution
Port over the last two commits relevant to working groups (https://github.com/bevyengine/bevy/commit/68db79862227885bb5d4794c2636e1749e36e574 https://github.com/bevyengine/bevy/commit/4a312a12e79ccf32b54ba2d3e99053685028c055).

## Testing
Run `zola serve --open` in `trialdragon/bring_working_groups_up_to_date`, and check that the changes didn't break render, or that Zola runs.