### PR TITLE
few improvements in process to help close PRs

### DIFF
--- a/content/learn/contribute/helping-out/opening-pull-requests.md
+++ b/content/learn/contribute/helping-out/opening-pull-requests.md
@@ -153,5 +153,5 @@ Then, notify org members to close the original.
 ## Helping a PR get ready
 
 Without going to the complete adoption of a PR, sometimes the author needs help to get it approved or passing CI.
-Those PRs can be labeled as *[S-Needs-Help](https://github.com/bevyengine/bevy/labels/S-Needs-Help)*, and opening PRs on them is welcomed to fix the last few points, resolve conflicts ro pass CI.
+Those PRs can be labeled as *[S-Needs-Help](https://github.com/bevyengine/bevy/labels/S-Needs-Help)*, and opening PRs on them is welcomed to fix the last few points, resolve conflicts to pass CI.
 You will need to work closely with the original author or one of the maintainer to add your commits to the original PR.

--- a/content/learn/contribute/helping-out/opening-pull-requests.md
+++ b/content/learn/contribute/helping-out/opening-pull-requests.md
@@ -136,8 +136,10 @@ This is a natural part of any open source project.
 To avoid blocking these efforts, these pull requests may be *adopted*, where another contributor creates a new pull request with the same content.
 If there is an old pull request that is without updates, comment to the organization whether it is appropriate to add the
 *[S-Adopt-Me](https://github.com/bevyengine/bevy/labels/S-Adopt-Me)* label, to indicate that it can be *adopted*.
+*S-Adopt-Me* PRs should be closed, and a tracking issue opened with the same labels to track their adoptions.
 
-If you plan on adopting a PR yourself, you can also leave a comment on the PR asking the author if they plan on returning.
+If you plan on adopting a PR yourself, mention so in the tracking issue.
+For a PR that hasn't been yet marked as open for adoption, you can also leave a comment on the PR asking the author if they plan on returning.
 If the author gives permission or simply doesn't respond after a few days, then it can be adopted.
 This may sometimes even skip the labeling process since at that point the PR has been adopted by you.
 

--- a/content/learn/contribute/helping-out/opening-pull-requests.md
+++ b/content/learn/contribute/helping-out/opening-pull-requests.md
@@ -149,3 +149,9 @@ When the new pull request is ready, it should reference the original PR in the d
 Then, notify org members to close the original.
 
 * For example, you can reference the original PR by adding the following to your PR description: `Adopted #number-original-pull-request`
+
+## Helping a PR get ready
+
+Without going to the complete adoption of a PR, sometimes the author needs help to get it approved or passing CI.
+Those PRs can be labeled as *[S-Needs-Help](https://github.com/bevyengine/bevy/labels/S-Needs-Help)*, and opening PRs on them is welcomed to fix the last few points, resolve conflicts ro pass CI.
+You will need to work closely with the original author or one of the maintainer to add your commits to the original PR.

--- a/content/learn/contribute/reference/triage.md
+++ b/content/learn/contribute/reference/triage.md
@@ -33,7 +33,7 @@ Labels are our primary tool for organizing work. You can find a complete list wi
   - Most work is not explicitly categorized by priority; volunteer work mostly occurs on an ad hoc basis depending on contributor interests.
 - **S**: Status. The most common include:
   - `S-Needs-Triage`: this issue needs to be labeled.
-  - `S-Adopt-Me`: the original PR author has no intent to complete the PR, and it should be adopted by another contributor.
+  - `S-Adopt-Me`: the original PR author has no intent to complete the PR, and it should be adopted by another contributor. This PR should be closed, and have an issue linked to track its adoption.
   - `S-Blocked`: cannot move forward until something else changes.
   - `S-Needs-Review`: this PR needs reviewer attention to move forward.
   - `S-Waiting-On-Author`: the author needs to make changes to this PR before it can be approved.
@@ -98,10 +98,8 @@ This might happen if:
 3. The PR was successfully adopted.
 4. The work is particularly low quality, and the author is resistant to coaching.
 5. The work adds features or abstraction of limited value, especially in a way that could easily be recreated outside of the engine.
-6. The work has been sitting in review for so long and accumulated so many conflicts that it would be simpler to redo it from scratch.
+6. The work has been sitting in review for so long and accumulated so many conflicts that it needs substantial work to get it in a correct state.
 7. The PR is pointlessly large, and should be broken into multiple smaller PRs for easier review.
-
-PRs that are `S-Adopt-Me` should be left open, but only if they're genuinely more useful to rebase rather than simply use as a reference.
 
 There are several paths for PRs to be closed:
 
@@ -111,6 +109,7 @@ There are several paths for PRs to be closed:
 4. Anyone may nominate a PR for closure, by bringing it to the attention of the author and / or one of the SMEs / Maintainers. Let them press the button, but this is generally well-received and helpful.
 5. SMEs or Maintainers may, and are encouraged, to unilaterally close PRs that fall into one or more of the remaining categories.
 6. In the case of PRs where some members of the community, other than the author, are in favor, and some are opposed, any two relevant SMEs or Maintainers may act in concert to close the PR.
+7. For a PR that has been sitting for a while and became bitrotten, check with the original author if they intend to continue working on it. if not, or without a response, the PR can be labeled with `S-Adopt-Me`, and closed. Tracking adoption progress will happen in a linked issue.
 
 When closing a PR, check if it has an issue linked. If it does not, you should strongly consider creating an issue and linking the now-closed PR to help make sure the previous work can be discovered and credited.
 

--- a/content/learn/contribute/reference/triage.md
+++ b/content/learn/contribute/reference/triage.md
@@ -38,7 +38,7 @@ Labels are our primary tool for organizing work. You can find a complete list wi
   - `S-Needs-Review`: this PR needs reviewer attention to move forward.
   - `S-Waiting-On-Author`: the author needs to make changes to this PR before it can be approved.
   - `S-Ready-For-Final-Review`: this PR has been approved by the community and is ready for a Maintainer to consider merging it.
-  - `S-Needs-Help`: this PRs is almost ready to be merged but blocked on a technical issue. Helping to fix it is welcomed.
+  - `S-Needs-Help`: this PR is almost ready to be merged but blocked on a technical issue. Helping to fix it is welcomed.
 - **X**: Controversiality. In order, these are:
   - `X-Uncontroversial`: everyone should agree that this is a good idea.
   - `X-Contentious`: there's real design thought needed to ensure that this is the right path forward.
@@ -111,8 +111,8 @@ There are several paths for PRs to be closed:
 4. Anyone may nominate a PR for closure, by bringing it to the attention of the author and / or one of the SMEs / Maintainers. Let them press the button, but this is generally well-received and helpful.
 5. SMEs or Maintainers may, and are encouraged, to unilaterally close PRs that fall into one or more of the remaining categories.
 6. In the case of PRs where some members of the community, other than the author, are in favor, and some are opposed, any two relevant SMEs or Maintainers may act in concert to close the PR.
-7. For a PR that has been sitting for a while and became bitrotten, check with the original author if they intend to continue working on it. if not, or without a response, the PR can be labeled with `S-Adopt-Me`, and closed. Tracking adoption progress will happen in a linked issue.
-8. Inactive `X-Controversial` can be closed if relevant SMEs or Maintainers have decided there's no more interest for it. If it's still interesting and controversial, a decision must be taken.
+7. For a PR that has been sitting for a while and became bitrotten, check with the original author if they intend to continue working on it. If not, or without a response, the PR can be labeled with `S-Adopt-Me`, and closed. Tracking adoption progress will happen in a linked issue.
+8. Inactive `X-Controversial` can be closed if relevant SMEs or Maintainers have decided there's no more interest for it. If it's still interesting and controversial, a decision must be made.
 
 When closing a PR, check if it has an issue linked. If it does not, you should strongly consider creating an issue and linking the now-closed PR to help make sure the previous work can be discovered and credited.
 

--- a/content/learn/contribute/reference/triage.md
+++ b/content/learn/contribute/reference/triage.md
@@ -100,6 +100,7 @@ This might happen if:
 5. The work adds features or abstraction of limited value, especially in a way that could easily be recreated outside of the engine.
 6. The work has been sitting in review for so long and accumulated so many conflicts that it needs substantial work to get it in a correct state.
 7. The PR is pointlessly large, and should be broken into multiple smaller PRs for easier review.
+8. The PR is controversial and hasn't seen activity in the last 6 months.
 
 There are several paths for PRs to be closed:
 
@@ -110,6 +111,7 @@ There are several paths for PRs to be closed:
 5. SMEs or Maintainers may, and are encouraged, to unilaterally close PRs that fall into one or more of the remaining categories.
 6. In the case of PRs where some members of the community, other than the author, are in favor, and some are opposed, any two relevant SMEs or Maintainers may act in concert to close the PR.
 7. For a PR that has been sitting for a while and became bitrotten, check with the original author if they intend to continue working on it. if not, or without a response, the PR can be labeled with `S-Adopt-Me`, and closed. Tracking adoption progress will happen in a linked issue.
+8. Inactive `X-Controversial` can be closed if relevant SMEs or Maintainers have decided there's no more interest for it. If it's still interesting and controversial, a decision must be taken.
 
 When closing a PR, check if it has an issue linked. If it does not, you should strongly consider creating an issue and linking the now-closed PR to help make sure the previous work can be discovered and credited.
 

--- a/content/learn/contribute/reference/triage.md
+++ b/content/learn/contribute/reference/triage.md
@@ -38,6 +38,7 @@ Labels are our primary tool for organizing work. You can find a complete list wi
   - `S-Needs-Review`: this PR needs reviewer attention to move forward.
   - `S-Waiting-On-Author`: the author needs to make changes to this PR before it can be approved.
   - `S-Ready-For-Final-Review`: this PR has been approved by the community and is ready for a Maintainer to consider merging it.
+  - `S-Needs-Help`: this PRs is almost ready to be merged but blocked on a technical issue. Helping to fix it is welcomed.
 - **X**: Controversiality. In order, these are:
   - `X-Uncontroversial`: everyone should agree that this is a good idea.
   - `X-Contentious`: there's real design thought needed to ensure that this is the right path forward.


### PR DESCRIPTION
## PR Adoption

Currently it's not clear if PRs up for adoption should be closed or left opened until they are adopted. Both cases have happened.
I propose to change it to close by default, open a tracking issue, and claim the issue when you are working on it.

## Closing Controversies

I propose to review X-Controversials after 6 months of inactivity: after such a delay, we should be able either to tell if nobody cares about it anymore (then close it), or take a final decision instead of leaving it hanging.

## Helping Finishing PRs

I propose a new status `S-Needs-Help` to mark PRs that could use help to resolve conflicts, pass CI and so on. Working on this PRs either with the original author or one of the maintainers to add commits and get it merged.