### PR TITLE
Remove HTML-Comments in loop

### DIFF
--- a/templates/sponsors.html
+++ b/templates/sponsors.html
@@ -35,8 +35,8 @@
             {% if donor.past %}
                 {% continue %}
             {% endif %}
-            <!-- Note: this "donor filtering logic" _must_ be kept in sync with the logic in donate.html -->
-            <!-- If we can find a way to reuse this logic in Zola, we absolutely should! -->
+            {# Note: this "donor filtering logic" _must_ be kept in sync with the logic in donate.html #}
+            {# If we can find a way to reuse this logic in Zola, we absolutely should! #}
             {% if donor.amount >= tier.amount %}
                 {% if next_tier and donor.amount >= next_tier.amount %}
                     {% continue %}


### PR DESCRIPTION
This comment overloads the size of the website.
This happens per donor.

See Screenshot:

![image](https://github.com/user-attachments/assets/ac243a75-bc7b-4afe-91ec-9a394dd20850)
