### PR TITLE
Changed public to private comment and minifyed HTML

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,6 +7,9 @@ title = "Bevy Engine"
 # Whether to automatically compile all Sass files in the sass directory
 compile_sass = true
 
+# When set to "true", the generated HTML files are minified.
+minify_html = true
+
 # Whether to build a search index to be used later on by a JavaScript library
 build_search_index = true
 

--- a/templates/sponsors.html
+++ b/templates/sponsors.html
@@ -35,8 +35,8 @@
             {% if donor.past %}
                 {% continue %}
             {% endif %}
-            <!-- Note: this "donor filtering logic" _must_ be kept in sync with the logic in donate.html -->
-            <!-- If we can find a way to reuse this logic in Zola, we absolutely should! -->
+            {# Note: this "donor filtering logic" _must_ be kept in sync with the logic in donate.html #}
+            {# If we can find a way to reuse this logic in Zola, we absolutely should! #}
             {% if donor.amount >= tier.amount %}
                 {% if next_tier and donor.amount >= next_tier.amount %}
                     {% continue %}


### PR DESCRIPTION
Public HTML comments have been converted to private so that they are not displayed over and over again in the loop and thus fill up the entire HTML.

Also written into the config that the HTML is minified by default.

![Bildschirmfoto vom 2024-10-07 20-06-19](https://github.com/user-attachments/assets/0110d6c8-3a3e-448f-87d3-f559a36918f8)

![Bildschirmfoto vom 2024-10-07 20-08-59](https://github.com/user-attachments/assets/a0a937f1-1235-4c5a-8153-18ad2260f53d)
