### PR TITLE
Update .gitignore and templates to resize donor and news images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ content/community/people/
 content/community/donate/
 static/assets/examples/
 static/processed_images/
+static/assets/donor_logos/
 
 # Tools
 target/

--- a/templates/news.html
+++ b/templates/news.html
@@ -9,7 +9,7 @@
             {% if page.extra.image %}
               {% set image_parent = page.path | replace(from="_index.md", to="") %}
               <img class="link-card__img"
-                    src="{{ image_macros::resize_image(path=image_parent ~ page.extra.image, width=580, height=326) }}"
+                    src="{{ image_macros::resize_image(path=image_parent ~ page.extra.image, width=277, height=156) }}"
                     loading="lazy"
                     alt="An image representing the article" />
             {% else %}

--- a/templates/sponsors.html
+++ b/templates/sponsors.html
@@ -56,13 +56,14 @@
     <div class="sponsors__content">
         {% for donor in donors_in_tier %}
         {% if tier.reward_logo and donor.logo %}
-            {% set_global logo_height = tier.logo_height %}
+            {% set_global logo_height = tier.logo_height | int %}
             {% if donor.square_logo %}
-                {% set_global logo_height = logo_height * 2.0 %}
+                {% set_global logo_height = (logo_height * 2.0) | int %}
             {% endif %}
             {% if donor.logo_scale %}
-                {% set_global logo_height = logo_height * donor.logo_scale %}
+                {% set_global logo_height = (logo_height * donor.logo_scale) | int %}
             {% endif %}
+            {% set logo_path = "/assets/donor_logos/" ~ donor.logo %}
         <a class="sponsors__link" {% if donor.link %}href="{{ donor.link }}"{% endif %}>
             <img
                 class="sponsors__logo"
@@ -70,7 +71,12 @@
                 {% if donor.style %}
                 style="{{ donor.style }}"
                 {% endif %}
-                src="/assets/donor_logos/{{ donor.logo }}"
+                {% if donor.logo is matching("\.svg$") %}
+                src="{{ logo_path }}"
+                {% else %}
+                {% set image = resize_image(path=logo_path, op="fit_height", height=logo_height) %}
+                src="{{ image.url }}"
+                {% endif %}
                 {% if donor.name %}
                 alt="{{ donor.name }} logo"
                 {% endif %}


### PR DESCRIPTION
Optimize the size of the donor logos as they are too large. (See first screenshot)

The total file size of all images is 2.3 MB - in the new version the resizing only occurs in the rendered view to the same maximum height.
The result: 704kB (see #2 screenshot).

![Bildschirmfoto vom 2024-10-08 18-33-54](https://github.com/user-attachments/assets/4a59b1c7-af67-4bbc-8f15-4277bff48125)
![Bildschirmfoto vom 2024-10-08 18-34-25](https://github.com/user-attachments/assets/7128d005-0326-4e8f-960d-0b4987f9b576)

I also adjusted the height and width of the news images to the maximum rendering size.

I also wrote the donor_logos in the gitignore so that you can't upload them accidentally.


