### PR TITLE
Write in a alternative logo-title if name is not given

### DIFF
--- a/templates/sponsors.html
+++ b/templates/sponsors.html
@@ -73,6 +73,8 @@
                 src="/assets/donor_logos/{{ donor.logo }}"
                 {% if donor.name %}
                 alt="{{ donor.name }} logo"
+                {% else %}
+                alt="{{ donor.logo | split(pat=".") | first }} logo"
                 {% endif %}
             />
         </a>


### PR DESCRIPTION
The change ensures that if a donor's name is not provided, the `alt` attribute for the donor's logo will use the filename (without the extension) as the alternative text.

* [`templates/sponsors.html`](diffhunk://#diff-d8ee107f524a55dc818ad29b30faf95d6f235424d7b12a83a874d24971fd1777R76-R77): Added a fallback for the `alt` attribute to use the donor's logo filename if the donor's name is not available.