### PR TITLE
Fix warning on `actions-without-meeting` minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,8 +108,9 @@ jobs:
           key: assets-${{ steps.date.outputs.date }}-${{ hashFiles('generate-assets/**/*.rs', 'generate-assets/Cargo.toml', 'generate-assets/generate_assets.sh') }}
 
       - name: "Build Bevy Assets"
-        # Only run if in merge queue or if no cache was found
-        if: ${{ github.event_name == 'merge_group' || !steps.restore-cached-assets.outputs.cache-hit }}
+        # Only run if in merge queue or if no cache was found. `cache-hit` is a string, so we
+        # cannot use normal boolean operators on it, as `!'false' == true`.
+        if: ${{ github.event_name == 'merge_group' || steps.restore-cached-assets.outputs.cache-hit != 'true' }}
         working-directory: generate-assets
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/content/foundation/meeting-minutes/actions-without-meeting/index.md
+++ b/content/foundation/meeting-minutes/actions-without-meeting/index.md
@@ -1,5 +1,9 @@
 +++
 title = "Actions by the Board without a Meeting"
+date = 2024-09-16
+authors = ["Alice I. Cecile"]
+[extra]
+github = "alice-i-cecile"
 +++
 
 <!-- more -->


### PR DESCRIPTION
This page was [missing the `date` field](https://github.com/bevyengine/bevy-website/actions/runs/11250795257/job/31280424360), as helpfully pointed out by @TrialDragon. I filled it out based off the merge date of #1628.

While I was there, I also added the author field, since it was missing.

This will not fix the website not deploying, since there's an issue with the donation page, but it will silence the only other warning.