### PR TITLE
Remove corporate stripe note

### DIFF
--- a/templates/donate.html
+++ b/templates/donate.html
@@ -128,7 +128,7 @@
 <div id="corporate-sponsorship" style="display: none">
 <h2 class="donate-header-padding">Corporate Sponsorship</h2>
 <div class="donate-membership-description">
-These tiers exist for individuals or organizations that want to support Bevy in a big way. We <i>highly</i> recommend using bank transfers for payments at these levels to avoid exorbitant credit card processor fees. We provide Stripe links as a convenience, but note that Stripe charges us a 0.5% fee for subscriptions (ex: if you pay $500 / month, they take $2.50 a month). Please <a href="mailto:support@bevyengine.org">contact us</a> if you have any questions, or if you would like to discuss other payment options!
+These tiers exist for individuals or organizations that want to support Bevy in a big way. We <i>highly</i> recommend using bank transfers for payments at these levels to avoid exorbitant credit card processor fees. Please <a href="mailto:support@bevyengine.org">contact us</a> if you have any questions, or if you would like to discuss other payment options!
 </div>
 <div class="donate-levels-container">
 <div class="donate-membership-levels">


### PR DESCRIPTION
This is no longer relevant on this page, as we default to every.org.