### PR TITLE
Improve `generate-release` workflow involving editing and merging notes and guides

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2321,6 +2321,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "toml 0.8.19",
  "ureq",
 ]
 
@@ -4732,6 +4733,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.22.20",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4771,6 +4784,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
 dependencies = [
  "indexmap",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow 0.6.18",
 ]

--- a/content/learn/contribute/helping-out/how-you-can-help.md
+++ b/content/learn/contribute/helping-out/how-you-can-help.md
@@ -36,7 +36,7 @@ If you do have specific skills (e.g. advanced familiarity with `unsafe` code, re
 Not even our Project Lead and Maintainers are exempt from reviews! By giving feedback on this work (and related supporting work), you can help us make sure our releases are both high-quality and timely.
 
 {% callout() %}
-Interested in reviewing, but don't know where to start? Check out [Reviewing Pull Requests](TODO)!
+Interested in reviewing, but don't know where to start? Check out [Reviewing Pull Requests](@/learn/contribute/helping-out/reviewing-pull-requests.md)!
 {% end %}
 
 ## Joining a Working Group
@@ -48,14 +48,14 @@ You should consider joining a working group if you're interested in contributing
 There are no special requirements to participate in a working group — no applications, formal membership list, or even leadership. Anyone can help, and you should expect to compromise and work together with others to bring your shared vision to life. Working groups are *spaces*, not clubs.
 
 {% callout() %}
-Anyone can start a working group! Check out [Working Groups](TODO) for more information about the process and requirements.
+Anyone can start a working group! Check out [Working Groups](@/learn/contribute/project-information/working-groups.md) for more information about the process and requirements.
 {% end %}
 
 ## Contributing Code
 
 We love getting code contributions from the community, and there's plenty of work to go around! If you want to code, but don't know what to work on, you should take a look at the open issues. The page on [Triage](@/learn/contribute/reference/triage.md) details several tags that you can use to filter issues by difficulty and area.
 
-If you already know what you want to work on, all you have to do is make your changes and submit a pull request! The page on [Your First Pull Request](TODO) is there to help if you get stuck.
+If you already know what you want to work on, all you have to do is make your changes and submit a pull request! The page on [Opening Pull Requests](@/learn/contribute/helping-out/opening-pull-requests.md) is there to help if you get stuck.
 
 {% callout() %}
 When working on the engine's code, it's a good idea to introduce yourself in the `#engine-dev` channel on [Discord](https://discord.gg/bevy) and tell people about your plans. Communicating your progress early and often can help you avoid avoid headaches and disagreements during code review.
@@ -63,7 +63,7 @@ When working on the engine's code, it's a good idea to introduce yourself in the
 
 ## Writing docs and examples
 
-Bevy relies heavily on Rust's inline documentation and a collection of up-to-date examples, but both are in constant need of revision and improvement. If you'd like to help us improve our learning materials, take a look at the dedicated sections on [Writing Docs](TODO) and [Creating Examples](TODO).
+Bevy relies heavily on Rust's inline documentation and a collection of up-to-date examples, but both are in constant need of revision and improvement. If you'd like to help us improve our learning materials, take a look at the dedicated sections on [Writing Docs](@/learn/contribute/helping-out/writing-docs.md) and [Creating Examples](@/learn/contribute/helping-out/creating-examples.md).
 
 ## Expanding the Ecosystem
 

--- a/content/learn/contribute/project-information/release-process.md
+++ b/content/learn/contribute/project-information/release-process.md
@@ -47,14 +47,14 @@ When making a release, the Maintainers follow these checklists:
 5. Run the [`generate-release`](https://github.com/bevyengine/bevy-website/tree/main/generate-release) tool.
     1. Create migration guide.
     2. Write blog post.
-7. Update book.
-8. Bump version number for all crates, using the "Release" workflow.
+6. Update book.
+7. Bump version number for all crates, using the "Release" workflow.
    1. Change the commit message to be nicer.
-9. Create tag on GitHub.
-10. Edit GitHub Release. Add links to the `Release announcement` and `Migration Guide`.
-11. Bump `latest` tag to most recent release.
-12. Run the [`update-screenshots` workflow] to update screenshots. *This will block blog post releases (and take ~40 minutes) so do it early*.
-13. Run the [`build-wasm-examples` workflow] to update Wasm examples.
+8. Create tag on GitHub.
+9. Edit GitHub Release. Add links to the `Release announcement` and `Migration Guide`.
+10. Bump `latest` tag to most recent release.
+11. Run the [`update-screenshots` workflow] to update screenshots. *This will block blog post releases (and take ~40 minutes) so do it early*.
+12. Run the [`build-wasm-examples` workflow] to update Wasm examples.
 
 #### Minor Release
 

--- a/content/learn/contribute/project-information/release-process.md
+++ b/content/learn/contribute/project-information/release-process.md
@@ -44,8 +44,9 @@ When making a release, the Maintainers follow these checklists:
 2. Check appropriate milestone and close it.
 3. Check GitHub Projects page for staleness.
 4. Update change log.
-5. Create migration guide.
-6. Write blog post.
+5. Run the [`generate-release`](https://github.com/bevyengine/bevy-website/tree/main/generate-release) tool.
+    1. Create migration guide.
+    2. Write blog post.
 7. Update book.
 8. Bump version number for all crates, using the "Release" workflow.
    1. Change the commit message to be nicer.

--- a/content/learn/contribute/project-information/release-process.md
+++ b/content/learn/contribute/project-information/release-process.md
@@ -43,18 +43,19 @@ When making a release, the Maintainers follow these checklists:
 1. Check regressions tag.
 2. Check appropriate milestone and close it.
 3. Check GitHub Projects page for staleness.
-4. Update change log.
-5. Run the [`generate-release`](https://github.com/bevyengine/bevy-website/tree/main/generate-release) tool.
+4. Run the [`generate-release`](https://github.com/bevyengine/bevy-website/tree/main/generate-release) tool.
     1. Create migration guide.
     2. Write blog post.
-6. Update book.
-7. Bump version number for all crates, using the "Release" workflow.
+    3. Generate contributors list
+    4. Generate change log.
+5. Update book.
+6. Bump version number for all crates, using the "Release" workflow.
    1. Change the commit message to be nicer.
-8. Create tag on GitHub.
-9. Edit GitHub Release. Add links to the `Release announcement` and `Migration Guide`.
-10. Bump `latest` tag to most recent release.
-11. Run the [`update-screenshots` workflow] to update screenshots. *This will block blog post releases (and take ~40 minutes) so do it early*.
-12. Run the [`build-wasm-examples` workflow] to update Wasm examples.
+7. Create tag on GitHub.
+8. Edit GitHub Release. Add links to the `Release announcement` and `Migration Guide`.
+9. Bump `latest` tag to most recent release.
+10. Run the [`update-screenshots` workflow] to update screenshots. *This will block blog post releases (and take ~40 minutes) so do it early*.
+11. Run the [`build-wasm-examples` workflow] to update Wasm examples.
 
 #### Minor Release
 

--- a/generate-release/Cargo.toml
+++ b/generate-release/Cargo.toml
@@ -15,6 +15,7 @@ dotenvy = "0.15.6"
 serde_json = "1.0.91"
 rayon = "1.10.0"
 thiserror = "1.0.61"
+toml = "0.8.19"
 
 [lints]
 workspace = true

--- a/generate-release/README.md
+++ b/generate-release/README.md
@@ -81,7 +81,7 @@ Once all those files are generated you'll need to create a new blog post in `/co
 # Let X be the major version, and y the minor version.
 # Change the Bevy release versions below to match this one!
 title = "Bevy X.y"
-# Insert a year in the year, month, day format.
+# Insert a date in the year, month, day format.
 date = YYYY-MM-DD
 [extra]
 # GitHub issue number for tracking this release's

--- a/generate-release/README.md
+++ b/generate-release/README.md
@@ -34,7 +34,7 @@ cargo run -p generate-release -- --from v0.13.0 --to main --release-version 0.14
 
 To generate a release from scratch, run all these commands then add the new migration guide and blog post to their respective `/content` folder. When doing so, it's important to use the `public_draft` feature to hide those pages until the day of the release. For the `public_draft` feature, you'll need to provide it a GitHub issue number, it's recommended to point it to an issue tracker for the current release being worked on. The issue needs to be on the `bevy-website` repo.
 
-When you're merging, or editing, notes and guides, keep in mind that this tool will not regenerate notes or guides that still have a PR number in any note or guide's metadata, contained in the `_<release_notes|migration_guides>.toml`. This means to merge multiple PRs into one note or guide you simply remove one `[[release_notes]]` or `[[guides]]` entry, and move it's PR number to the merged entry that is the sum of all the merged PRs. For editing, this means the other metadata will also not be regenerated if the PR number still exists in the metadata.
+When you're merging, or editing, notes and guides, keep in mind that this tool will not regenerate notes or guides that still have a PR number in any note or guide's metadata, contained in the `_<release_notes|guides>.toml`. This means to merge multiple PRs into one note or guide you simply remove one `[[release_notes]]` or `[[guides]]` entry, and move it's PR number to the merged entry that is the sum of all the merged PRs. For editing, this means the other metadata will also not be regenerated if the PR number still exists in the metadata.
 
 The following sections go in more details on each parts of the process.
 

--- a/generate-release/README.md
+++ b/generate-release/README.md
@@ -49,15 +49,22 @@ Inside that file, you should have something that looks like this:
 
 ```markdown
 +++
-title = "0.13 to 0.14"
+# Let Xa be the old major version, and ya the old minor version,
+# and Xb be the new major version, and yb the new minor version.
+# 
+# Change the Bevy versions below to match these!
+title = "Xa.ya to Xb.yb"
 insert_anchor_links = "right"
 [extra]
-weight = 9
-long_title = "Migration Guide: 0.13 to 0.14"
+# Let N be the weight of the prior / last migration guide, plus one.
+weight = N
+long_title = "Migration Guide: Xa.ya to Xb.yb"
+# GitHub issue number for tracking this release's
+# migration guides or news post.
 public_draft = _release tracking issue number_
 +++
 
-{{ migration_guides(version="0.14") }}
+{{ migration_guides(version="Xb.yb") }}
 ```
 
 The most important part of this is the `migrations_guides` shortcode. It will get the list of guides from the `_guides.toml` file and combine all the separate file and generate appropriate markup for it.
@@ -82,6 +89,7 @@ Once all those files are generated you'll need to create a new blog post in `/co
 # Change the Bevy release versions below to match this one!
 title = "Bevy X.y"
 # Insert a date in the year, month, day format.
+# This should be the date that the post will be posted.
 date = YYYY-MM-DD
 [extra]
 # GitHub issue number for tracking this release's
@@ -93,15 +101,15 @@ public_draft = _release tracking issue number_
 
 <!-- more -->
 
-{{ release_notes(version="0.14") }}
+{{ release_notes(version="X.y") }}
 
 ## What's Next?
 
 <!-- TODO What's next -->
 
 {{ support_bevy() }}
-{{ contributors(version="0.14") }}
-{{ changelog(version="0.14")}}
+{{ contributors(version="X.y") }}
+{{ changelog(version="X.y")}}
 ```
 
 The most important part of this is the `release_notes`, `changelog`, and `contributors` shortcodes. `release_notes` will get the list of release notes from the `_release_notes.toml` file and combine all the separate file and add them to this file. `contributors()` will load the `contributors.toml` file and generate the necessary markup. `changelog()` will load the `changelog.toml` file and generate the necessary markup.

--- a/generate-release/README.md
+++ b/generate-release/README.md
@@ -4,7 +4,7 @@ This CLI tool is used to generate all the skeleton files required to create a ne
 
 For a bit more background see this issue: <https://github.com/bevyengine/bevy-website/issues/1163>
 
-The commands can be run from anywhere inside the workspace folder.
+The commands can be run from anywhere inside the workspace folder. If you have a `.env` file, this will only work if it is located at the root of the workspace.
 
 Each command will generate files in the `/release-content/{release-version}` folder. The `release-version` is an argument to all commands.
 

--- a/generate-release/README.md
+++ b/generate-release/README.md
@@ -34,7 +34,7 @@ cargo run -p generate-release -- --from v0.13.0 --to main --release-version 0.14
 
 To generate a release from scratch, run all these commands then add the new migration guide and blog post to their respective `/content` folder. When doing so, it's important to use the `public_draft` feature to hide those pages until the day of the release. For the `public_draft` feature, you'll need to provide it a GitHub issue number, it's recommended to point it to an issue tracker for the current release being worked on. The issue needs to be on the `bevy-website` repo.
 
-When you're merging, or editing, notes and guides, keep in mind that this tool will not regenerate notes or guides that still have a PR number in any note or guide's metadata, contained in the `_<release_notes|guides>.toml`. This means to merge multiple PRs into one note or guide you simply remove one `[[release_notes]]` or `[[guides]]` entry, and move it's PR number to the merged entry that is the sum of all the merged PRs. For editing, this means the other metadata will also not be regenerated if the PR number still exists in the metadata.
+When you're merging or editing notes and guides, keep in mind that this tool will not regenerate notes or guides that still have a PR number in any note or guide's metadata, contained in the `_<release_notes|guides>.toml`. This means to merge multiple PRs into one note or guide you simply remove one `[[release_notes]]` or `[[guides]]` entry, and move its PR number to the merged entry that is the sum of all the merged PRs. For editing, this means the other metadata will also not be regenerated if the PR number still exists in the metadata.
 
 The following sections go in more details on each parts of the process.
 

--- a/generate-release/README.md
+++ b/generate-release/README.md
@@ -25,8 +25,8 @@ Here's an example for the commands used to generate the `0.14` release:
 
 ```shell
 cargo run -p generate-release -- --from v0.13.0 --to main --release-version 0.14 migration-guides
-cargo run -p genereate-release -- --from v0.13.0 --to main --release-version 0.14 release-notes
-cargo run -p genereate-release -- --from v0.13.0 --to main --release-version 0.14 changelog
+cargo run -p generate-release -- --from v0.13.0 --to main --release-version 0.14 release-notes
+cargo run -p generate-release -- --from v0.13.0 --to main --release-version 0.14 changelog
 cargo run -p generate-release -- --from v0.13.0 --to main --release-version 0.14 contributors
 ```
 

--- a/generate-release/src/migration_guides.rs
+++ b/generate-release/src/migration_guides.rs
@@ -25,7 +25,6 @@ struct MigrationGuides {
 struct MigrationGuide {
     title: String,
     prs: Vec<u64>,
-    urls: Vec<String>,
     areas: Vec<String>,
     file_name: String,
 }
@@ -193,7 +192,6 @@ fn generate_metadata_block(
         r#"[[guides]]
 title = "{title}"
 prs = [{pr_number},]
-urls = ["https://github.com/bevyengine/bevy/pull/{pr_number}",]
 areas = [{areas}]
 file_name = "{file_name}.md"
 "#,

--- a/generate-release/src/migration_guides.rs
+++ b/generate-release/src/migration_guides.rs
@@ -128,12 +128,23 @@ pub fn generate_migration_guides(
         return Ok(());
     }
 
-    // Write the metadata file
-    let mut guides_toml = OpenOptions::new()
-        .append(true)
-        .create(true)
-        .open(path.join("_guides.toml"))
-        .context("Failed to create _guides.toml")?;
+    let mut guides_toml = if overwrite_existing {
+        // Replace and overwrite file.
+        OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .create(true)
+            .open(path.join("_guides.toml"))
+            .context("Failed to create _guides.toml")?
+    } else {
+        // Append to the metadata file,
+        // creating it if necessary.
+        OpenOptions::new()
+            .append(true)
+            .create(true)
+            .open(path.join("_guides.toml"))
+            .context("Failed to create _guides.toml")?
+    };
     for metadata in guides_metadata {
         writeln!(&mut guides_toml, "{metadata}")?;
     }

--- a/generate-release/src/migration_guides.rs
+++ b/generate-release/src/migration_guides.rs
@@ -49,10 +49,14 @@ pub fn generate_migration_guides(
     // and would contain info such as which PR already
     // has an entry, then get it and use it for that.
     let preexisting_metadata_file = fs::read_to_string(path.join("_guides.toml")).ok();
-    let preexisting_metadata: Option<MigrationGuides> = match preexisting_metadata_file {
-        Some(file_data) => Some(toml::from_str(file_data.as_str())?),
-        None => None,
-    };
+    // Deserializes the file inside the option into the `MigrationGuides` struct,
+    // and then transposes / swaps the internal result of that operation to external,
+    // and returns the error of that result if there is one,
+    // else we have our preexisting metadata, ready to use.
+    let preexisting_metadata: Option<MigrationGuides> = preexisting_metadata_file
+        .as_deref()
+        .map(toml::from_str)
+        .transpose()?;
 
     eprintln!("metadata exists? {}", preexisting_metadata.is_some());
 

--- a/generate-release/src/migration_guides.rs
+++ b/generate-release/src/migration_guides.rs
@@ -73,9 +73,9 @@ pub fn generate_migration_guides(
             // If overwrite_existing is true, then ignore
             // if the PRs may have already been generated.
             if preexisting_metadata.is_some() && !overwrite_existing {
-                let preexisting_metadata = preexisting_metadata
-                    .clone()
-                    .expect("that preexisting metadata existed");
+                let preexisting_metadata = preexisting_metadata.clone().expect(
+                    "that preexisting metadata exists at the _guides.toml for this release version",
+                );
                 let mut pr_already_generated = false;
 
                 for migration_guide in preexisting_metadata.guides {

--- a/generate-release/src/migration_guides.rs
+++ b/generate-release/src/migration_guides.rs
@@ -162,7 +162,7 @@ fn get_prs_by_areas(
         let has_breaking_label = pr
             .labels
             .iter()
-            .any(|l| l.name.contains("M-Breaking-Change"));
+            .any(|l| l.name.contains("M-Needs-Migration-Guide"));
 
         // We want to check for PRs with the breaking label but without the guide section
         // to make it easier to track down missing guides

--- a/generate-release/src/migration_guides.rs
+++ b/generate-release/src/migration_guides.rs
@@ -202,7 +202,7 @@ fn generate_metadata_block(
     format!(
         r#"[[guides]]
 title = "{title}"
-prs = [{pr_number},]
+prs = [{pr_number}]
 areas = [{areas}]
 file_name = "{file_name}.md"
 "#,

--- a/generate-release/src/release_notes.rs
+++ b/generate-release/src/release_notes.rs
@@ -173,13 +173,23 @@ pub fn generate_release_notes(
         return Ok(());
     }
 
-    // Append to the metadata file,
-    // creating it if necessary.
-    let mut notes_toml = OpenOptions::new()
-        .append(true)
-        .create(true)
-        .open(path.join("_release-notes.toml"))
-        .context("Failed to create _guides.toml")?;
+    let mut notes_toml = if overwrite_existing {
+        // Replace and overwrite file.
+        OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .create(true)
+            .open(path.join("_release-notes.toml"))
+            .context("Failed to create _release-notes.toml")?
+    } else {
+        // Append to the metadata file,
+        // creating it if necessary.
+        OpenOptions::new()
+            .append(true)
+            .create(true)
+            .open(path.join("_release-notes.toml"))
+            .context("Failed to create _release-notes.toml")?
+    };
     for metadata in notes_metadata {
         writeln!(&mut notes_toml, "{metadata}")?;
     }

--- a/generate-release/src/release_notes.rs
+++ b/generate-release/src/release_notes.rs
@@ -77,7 +77,7 @@ pub fn generate_release_notes(
         if preexisting_metadata.is_some() && !overwrite_existing {
             let preexisting_metadata = preexisting_metadata
                 .clone()
-                .expect("that preexisting metadata existed");
+                .expect("that preexisting metadata existed at the _release_notes.toml for this release version");
             let mut pr_already_generated = false;
 
             for release_note in preexisting_metadata.release_notes {

--- a/generate-release/src/release_notes.rs
+++ b/generate-release/src/release_notes.rs
@@ -210,7 +210,7 @@ fn generate_metadata_block(
 title = "{title}"
 authors = ["{author}",]
 contributors = [{contributors}]
-prs = [{pr_number},]
+prs = [{pr_number}]
 file_name = "{file_name}.md"
 "#,
         contributors = contributors

--- a/generate-release/src/release_notes.rs
+++ b/generate-release/src/release_notes.rs
@@ -59,10 +59,14 @@ pub fn generate_release_notes(
     // and would contain info such as which PR already
     // has an entry, then get it and use it for that.
     let preexisting_metadata_file = fs::read_to_string(path.join("_release-notes.toml")).ok();
-    let preexisting_metadata: Option<ReleaseNotes> = match preexisting_metadata_file {
-        Some(file_data) => Some(toml::from_str(file_data.as_str())?),
-        None => None,
-    };
+    // Deserializes the file inside the option into the `ReleaseNotes` struct,
+    // and then transposes / swaps the internal result of that operation to external,
+    // and returns the error of that result if there is one,
+    // else we have our preexisting metadata, ready to use.
+    let preexisting_metadata: Option<ReleaseNotes> = preexisting_metadata_file
+        .as_deref()
+        .map(toml::from_str)
+        .transpose()?;
 
     eprintln!("metadata exists? {}", preexisting_metadata.is_some());
 

--- a/generate-release/src/release_notes.rs
+++ b/generate-release/src/release_notes.rs
@@ -1,4 +1,5 @@
 use anyhow::Context;
+use serde::Deserialize;
 
 use crate::{
     github_client::{BevyRepo, GithubClient, GithubIssuesResponse, IssueState},
@@ -6,9 +7,26 @@ use crate::{
 };
 use std::{
     collections::HashSet,
+    fs::{self, OpenOptions},
     io::Write,
     path::{Path, PathBuf},
 };
+
+#[derive(Deserialize, Clone)]
+struct ReleaseNotes {
+    release_notes: Vec<ReleaseNote>,
+}
+
+#[expect(dead_code)]
+#[derive(Deserialize, Clone)]
+struct ReleaseNote {
+    title: String,
+    authors: Vec<String>,
+    contributors: Vec<String>,
+    prs: Vec<u64>,
+    urls: Vec<String>,
+    file_name: String,
+}
 
 pub fn generate_release_notes(
     from: &str,
@@ -20,12 +38,12 @@ pub fn generate_release_notes(
     create_issues: bool,
 ) -> anyhow::Result<()> {
     // Get all PRs that need release notes
-    let prs = get_merged_prs(client, from, to, Some("C-Needs-Release-Note"))?;
+    let prs = get_merged_prs(client, from, to, Some("M-Needs-Release-Note"))?;
 
     // Create the directory that will contain all the release notes
     std::fs::create_dir_all(&path).context(format!("Failed to create {path:?}"))?;
 
-    // We'll write the file once at the end when all the metdaata is generated
+    // We'll write the file once at the end when all the metadata is generated
     let mut notes_metadata = Vec::new();
 
     // Generate the list of all issues so we don't spam the repo with duplicates
@@ -38,7 +56,47 @@ pub fn generate_release_notes(
         .collect::<HashSet<_>>();
     println!("Found {} issues", issue_titles.len());
 
+    // If there is metadata that already exists,
+    // and would contain info such as which PR already
+    // has an entry, then get it and use it for that.
+    let preexisting_metadata_file = fs::read_to_string(path.join("_release-notes.toml")).ok();
+    let preexisting_metadata: Option<ReleaseNotes> = match preexisting_metadata_file {
+        Some(file_data) => Some(toml::from_str(file_data.as_str())?),
+        None => None,
+    };
+
+    eprintln!("metadata exists? {}", preexisting_metadata.is_some());
+
+    let mut new_prs = false;
+
     for (pr, commit, title) in prs {
+        // If a PR is already included in the release notes,
+        // then do not generate anything for this PR.
+        //
+        // If overwrite_existing is true, then ignore
+        // if the PRs may have already been generated.
+        if preexisting_metadata.is_some() && !overwrite_existing {
+            let preexisting_metadata = preexisting_metadata
+                .clone()
+                .expect("that preexisting metadata existed");
+            let mut pr_already_generated = false;
+
+            for release_note in preexisting_metadata.release_notes {
+                if release_note.prs.contains(&pr.number) {
+                    pr_already_generated = true;
+                }
+            }
+
+            if pr_already_generated {
+                eprintln!("PR #{} already exists", pr.number);
+                continue;
+            }
+        }
+
+        // If the code has reached this point then that means
+        // there is new PRs to be recorded.
+        new_prs = true;
+
         // Slugify the title
         let title_slug = title
             .replace(' ', "_")
@@ -79,10 +137,6 @@ pub fn generate_release_notes(
         ));
 
         let file_path = path.join(format!("{file_name}.md"));
-        if file_path.exists() && !overwrite_existing {
-            // Skip existing files because we don't want to overwrite changes when regenerating
-            continue;
-        }
 
         let file =
             std::fs::File::create(&file_path).context(format!("Failed to create {file_path:?}"))?;
@@ -106,17 +160,29 @@ pub fn generate_release_notes(
         );
     }
 
-    // Write the metadata file
-    let mut notes_toml = std::fs::File::create(path.join("_release-notes.toml"))
-        .context("Failed to create _guides.toml")?;
-    for metadata in notes_metadata {
-        writeln!(&mut notes_toml, "{metadata}")?;
-    }
-
     if !create_issues {
         println!(
             "No issues were created. If you would like to do so, add the `--create-issues` flag."
         );
+    }
+
+    eprintln!("new prs? {new_prs}");
+
+    // Early return if there is no new PRs
+    // to append to the metadata file.
+    if !new_prs {
+        return Ok(());
+    }
+
+    // Append to the metadata file,
+    // creating it if necessary.
+    let mut notes_toml = OpenOptions::new()
+        .append(true)
+        .create(true)
+        .open(path.join("_release-notes.toml"))
+        .context("Failed to create _guides.toml")?;
+    for metadata in notes_metadata {
+        writeln!(&mut notes_toml, "{metadata}")?;
     }
 
     Ok(())
@@ -135,7 +201,8 @@ fn generate_metadata_block(
 title = "{title}"
 authors = ["{author}",]
 contributors = [{contributors}]
-url = "https://github.com/bevyengine/bevy/pull/{pr_number}"
+prs = [{pr_number},]
+urls = ["https://github.com/bevyengine/bevy/pull/{pr_number}",]
 file_name = "{file_name}.md"
 "#,
         contributors = contributors
@@ -204,7 +271,7 @@ In that PR, please mention this issue with the `Fixes #ISSUE_NUMBER` keyphrase s
         println!("Would open issue on GitHub:");
         println!("Title: {}", issue_title);
         println!("Body: {}", issue_body);
-        println!("Labels: {:?}", labels);
+        println!("Labels: {:?}\n\n", labels);
     } else {
         // Open an issue on the `bevy-website` repo
         let response = client

--- a/generate-release/src/release_notes.rs
+++ b/generate-release/src/release_notes.rs
@@ -24,7 +24,6 @@ struct ReleaseNote {
     authors: Vec<String>,
     contributors: Vec<String>,
     prs: Vec<u64>,
-    urls: Vec<String>,
     file_name: String,
 }
 
@@ -202,7 +201,6 @@ title = "{title}"
 authors = ["{author}",]
 contributors = [{contributors}]
 prs = [{pr_number},]
-urls = ["https://github.com/bevyengine/bevy/pull/{pr_number}",]
 file_name = "{file_name}.md"
 "#,
         contributors = contributors

--- a/release-content/0.14/migration-guides/_guides.toml
+++ b/release-content/0.14/migration-guides/_guides.toml
@@ -1,779 +1,779 @@
 [[guides]]
 title = "Overhaul `Color`"
-url = "https://github.com/bevyengine/bevy/pull/12163"
+prs = ["12163",]
 areas = ["Color", "Gizmos", "Rendering", "Text", "UI"]
 file_name = "12163_Migrate_from_LegacyColor_to_bevy_colorColor.md"
 
 [[guides]]
 title = "Make default behavior for `BackgroundColor` and `BorderColor` more intuitive"
-url = "https://github.com/bevyengine/bevy/pull/14017"
+prs = ["14017",]
 areas = ["Rendering", "UI"]
 file_name = "14017_Make_default_behavior_for_BackgroundColor_and_BorderColor_.md"
 
 [[guides]]
 title = "Register missing types manually"
-url = "https://github.com/bevyengine/bevy/pull/12314"
+prs = ["12314",]
 areas = ["Reflection"]
 file_name = "12314_Clean_up_type_registrations.md"
 
 [[guides]]
 title = "`OnEnter` state schedules now run before Startup schedules"
-url = "https://github.com/bevyengine/bevy/pull/11426"
+prs = ["11426",]
 areas = ["App", "ECS"]
 file_name = "11426_on_enter_startup_states.md"
 
 [[guides]]
 title = "Fix `Node2d` typo"
-url = "https://github.com/bevyengine/bevy/pull/12038"
+prs = ["12038",]
 areas = []
 file_name = "12038_fix_some_typos.md"
 
 [[guides]]
 title = "Update to `fixedbitset` 0.5"
-url = "https://github.com/bevyengine/bevy/pull/12512"
+prs = ["12512",]
 areas = []
 file_name = "12512_Update_to_fixedbitset_05.md"
 
 [[guides]]
 title = "Move WASM panic handler from `LogPlugin` to `PanicHandlerPlugin`"
-url = "https://github.com/bevyengine/bevy/pull/12557"
+prs = ["12557",]
 areas = []
 file_name = "12557_refactor_separate_out_PanicHandlerPlugin.md"
 
 [[guides]]
 title = "`AnimationClip` now uses UUIDs and `NoOpTypeIdHash` is now `NoOpHash`"
-url = "https://github.com/bevyengine/bevy/pull/11707"
+prs = ["11707",]
 areas = ["Animation"]
 file_name = "11707_Rework_animation_to_be_done_in_two_phases.md"
 
 [[guides]]
 title = "Implement the `AnimationGraph` to blend animations together"
-url = "https://github.com/bevyengine/bevy/pull/11989"
+prs = ["11989",]
 areas = ["Animation"]
 file_name = "11989_Implement_the_AnimationGraph_allowing_for_multiple_animati.md"
 
 [[guides]]
 title = "Multiplying colors by `f32` no longer ignores alpha channel"
-url = "https://github.com/bevyengine/bevy/pull/12575"
+prs = ["12575",]
 areas = ["Animation", "Color", "Math", "Rendering"]
 file_name = "12575_Color_maths_4.md"
 
 [[guides]]
 title = "Separate `SubApp` from `App`"
-url = "https://github.com/bevyengine/bevy/pull/9202"
+prs = ["9202",]
 areas = ["App"]
 file_name = "9202_Refactor_App_and_SubApp_internals_for_better_separation.md"
 
 [[guides]]
 title = "Make `AppExit` more specific about exit reason"
-url = "https://github.com/bevyengine/bevy/pull/13022"
+prs = ["13022",]
 areas = ["App"]
 file_name = "13022_Make_AppExit_more_specific_about_exit_reason.md"
 
 [[guides]]
 title = "Deprecate dynamic plugins"
-url = "https://github.com/bevyengine/bevy/pull/13080"
+prs = ["13080",]
 areas = ["App"]
 file_name = "13080_Deprecate_dynamic_plugins.md"
 
 [[guides]]
 title = "Move state initialization methods to `bevy::state`"
-url = "https://github.com/bevyengine/bevy/pull/13637"
+prs = ["13637",]
 areas = ["App", "ECS"]
 file_name = "13637_Move_state_installation_methods_from_bevy_app_to_bevy_stat.md"
 
 [[guides]]
 title = "Remove the `UpdateAssets` and `AssetEvents` schedules"
-url = "https://github.com/bevyengine/bevy/pull/11986"
+prs = ["11986",]
 areas = ["Assets"]
 file_name = "11986_Remove_the_UpdateAssets_and_AssetEvents_schedules.md"
 
 [[guides]]
 title = "Use `async fn` in traits rather than `BoxedFuture`"
-url = "https://github.com/bevyengine/bevy/pull/12550"
+prs = ["12550",]
 areas = ["Assets"]
 file_name = "12550_Use_asyncfn_in_traits_rather_than_BoxedFuture.md"
 
 [[guides]]
 title = "Add `Ignore` variant to `ProcessResult`"
-url = "https://github.com/bevyengine/bevy/pull/12605"
+prs = ["12605",]
 areas = ["Assets"]
 file_name = "12605_Make_AssetActionIgnore_not_copy_assets_to_imported_assets.md"
 
 [[guides]]
 title = "Removed `Into<AssetId<T>>` for `Handle<T>`"
-url = "https://github.com/bevyengine/bevy/pull/12655"
+prs = ["12655",]
 areas = ["Assets"]
 file_name = "12655_Removed_IntoAssedIdT_for_HandleT_as_mentioned_in_12600.md"
 
 [[guides]]
 title = "Add `AsyncSeek` trait to `Reader` to be able to seek inside asset loaders"
-url = "https://github.com/bevyengine/bevy/pull/12547"
+prs = ["12547",]
 areas = ["Assets"]
 file_name = "12547_Add_AsyncSeek_trait_to_Reader_to_be_able_to_seek_inside_as.md"
 
 [[guides]]
 title = "Add error info to `LoadState::Failed`"
-url = "https://github.com/bevyengine/bevy/pull/12709"
+prs = ["12709",]
 areas = ["Assets"]
 file_name = "12709_Error_info_has_been_added_to_LoadStateFailed.md"
 
 [[guides]]
 title = "Make `AssetMetaCheck` a field of `AssetPlugin`"
-url = "https://github.com/bevyengine/bevy/pull/13177"
+prs = ["13177",]
 areas = ["Assets"]
 file_name = "13177_Make_AssetMetaCheck_a_field_on_the_asset_plugin.md"
 
 [[guides]]
 title = "Make `LoadContext` use the builder pattern"
-url = "https://github.com/bevyengine/bevy/pull/13465"
+prs = ["13465",]
 areas = ["Assets"]
 file_name = "13465_Make_LoadContext_use_the_builder_pattern_for_loading_depen.md"
 
 [[guides]]
 title = "Use `RenderAssetUsages` to configure gLTF meshes & materials during load"
-url = "https://github.com/bevyengine/bevy/pull/12302"
+prs = ["12302",]
 areas = ["Assets", "Rendering"]
 file_name = "12302_Allow_setting_RenderAssetUsages_for_gLTF_meshes__materials.md"
 
 [[guides]]
 title = "Consolidate `RenderMaterials` and similar into `RenderAssets`, implement `RenderAsset` for destination type"
-url = "https://github.com/bevyengine/bevy/pull/12827"
+prs = ["12827",]
 areas = ["Assets", "Rendering"]
 file_name = "12827_Consolidate_RenderUiMaterials2d_into_RenderAssets.md"
 
 [[guides]]
 title = "Fix leftover references to children when despawning audio entities"
-url = "https://github.com/bevyengine/bevy/pull/12407"
+prs = ["12407",]
 areas = ["Audio"]
 file_name = "12407_Fix_leftover_references_to_children_when_despawning_audio_.md"
 
 [[guides]]
 title = "Move WGSL math constants and color operations from `bevy_pbr` to `bevy_render`"
-url = "https://github.com/bevyengine/bevy/pull/13209"
+prs = ["13209",]
 areas = ["Color"]
 file_name = "13209_move_wgsl_color_operations_from_bevy_pbr_to_bevy_render.md"
 
 [[guides]]
 title = "Remove old color space utilities"
-url = "https://github.com/bevyengine/bevy/pull/12105"
+prs = ["12105",]
 areas = ["Color", "Rendering"]
 file_name = "12105_Made_bevy_color_a_dependency_of_bevy_render.md"
 
 [[guides]]
 title = "Use `LinearRgba` in `ColorAttachment`"
-url = "https://github.com/bevyengine/bevy/pull/12116"
+prs = ["12116",]
 areas = ["Color", "Rendering"]
 file_name = "12116_Port_bevy_core_pipeline_to_LinearRgba.md"
 
 [[guides]]
 title = "Remove `close_on_esc`"
-url = "https://github.com/bevyengine/bevy/pull/12859"
+prs = ["12859",]
 areas = ["Dev-Tools"]
 file_name = "12859_remove_close_on_esc.md"
 
 [[guides]]
 title = "Make `sysinfo` diagnostic plugin optional"
-url = "https://github.com/bevyengine/bevy/pull/12164"
+prs = ["12164",]
 areas = ["Diagnostics"]
 file_name = "12164_Make_sysinfo_diagnostic_plugin_optional.md"
 
 [[guides]]
 title = "Improve `tracing` layer customization"
-url = "https://github.com/bevyengine/bevy/pull/13159"
+prs = ["13159",]
 areas = ["Diagnostics"]
 file_name = "13159_Improve_tracing_layer_customization.md"
 
 [[guides]]
 title = "Generalised ECS reactivity with Observers"
-url = "https://github.com/bevyengine/bevy/pull/10839"
+prs = ["10839",]
 areas = ["ECS"]
 file_name = "10839_Generalised_ECS_reactivity_with_Observers.md"
 
 [[guides]]
 title = "Immediately apply deferred system params in `System::run`"
-url = "https://github.com/bevyengine/bevy/pull/11823"
+prs = ["11823",]
 areas = ["ECS"]
 file_name = "11823_Immediately_apply_deferred_system_params_in_Systemrun.md"
 
 [[guides]]
 title = "Move `Command` and `CommandQueue` into `bevy::ecs::world`"
-url = "https://github.com/bevyengine/bevy/pull/12234"
+prs = ["12234",]
 areas = ["ECS"]
 file_name = "12234_Move_commands_module_into_bevyecsworld.md"
 
 [[guides]]
 title = "Make `Component::Storage` a constant"
-url = "https://github.com/bevyengine/bevy/pull/12311"
+prs = ["12311",]
 areas = ["ECS"]
 file_name = "12311_Remove_ComponentStorage_and_associated_types.md"
 
 [[guides]]
 title = "Don't store `Access<ArchetypeComponentId>` within `QueryState`"
-url = "https://github.com/bevyengine/bevy/pull/12474"
+prs = ["12474",]
 areas = ["ECS"]
 file_name = "12474_Remove_archetype_component_access_from_QueryState.md"
 
 [[guides]]
 title = "Remove `WorldCell`"
-url = "https://github.com/bevyengine/bevy/pull/12551"
+prs = ["12551",]
 areas = ["ECS"]
 file_name = "12551_Remove_WorldCell.md"
 
 [[guides]]
 title = "Return iterator instead of slice for `QueryState::matched_tables` and `QueryState::matches_archtypes`"
-url = "https://github.com/bevyengine/bevy/pull/12476"
+prs = ["12476",]
 areas = ["ECS"]
 file_name = "12476_Store_only_the_IDs_needed_for_Query_iteration.md"
 
 [[guides]]
 title = "Remove system stepping from default features"
-url = "https://github.com/bevyengine/bevy/pull/12847"
+prs = ["12847",]
 areas = ["ECS"]
 file_name = "12847_Remove_stepping_from_default_features.md"
 
 [[guides]]
 title = "Optimize event updates and virtual time"
-url = "https://github.com/bevyengine/bevy/pull/12936"
+prs = ["12936",]
 areas = ["ECS"]
 file_name = "12936_Optimize_Event_Updates.md"
 
 [[guides]]
 title = "Make `SystemParam::new_archetype` and `QueryState::new_archetype` unsafe"
-url = "https://github.com/bevyengine/bevy/pull/13044"
+prs = ["13044",]
 areas = ["ECS"]
 file_name = "13044_Make_SystemParamnew_archetype_and_QueryStatenew_archetype_.md"
 
 [[guides]]
 title = "Better `SystemId` and `Entity` conversion"
-url = "https://github.com/bevyengine/bevy/pull/13090"
+prs = ["13090",]
 areas = ["ECS"]
 file_name = "13090_Better_SystemId_to_Entity_conversions.md"
 
 [[guides]]
 title = "Make `NextState` an enum"
-url = "https://github.com/bevyengine/bevy/pull/11426"
+prs = ["11426",]
 areas = ["ECS"]
 file_name = "11426_Computed_State__Sub_States.md"
 
 [[guides]]
 title = "Separate states from core ECS"
-url = "https://github.com/bevyengine/bevy/pull/13216"
+prs = ["13216",]
 areas = ["ECS"]
 file_name = "13216_Separate_state_crate.md"
 
 [[guides]]
 title = "Constrain `WorldQuery::get_state()` to only accept `Components`"
-url = "https://github.com/bevyengine/bevy/pull/13343"
+prs = ["13343",]
 areas = ["ECS"]
 file_name = "13343_constrain_WorldQueryget_state_to_only_use_Components.md"
 
 [[guides]]
 title = "Unify state transition names to `exited` and `entered`"
-url = "https://github.com/bevyengine/bevy/pull/13594"
+prs = ["13594",]
 areas = ["ECS"]
 file_name = "13594_Unify_transition_names_to_exited_and_entered.md"
 
 [[guides]]
 title = "Make `apply_state_transition` private"
-url = "https://github.com/bevyengine/bevy/pull/13626"
+prs = ["13626",]
 areas = ["ECS"]
 file_name = "13626_Combine_transition_systems_of_Substates.md"
 
 [[guides]]
 title = "Replace `FromWorld` requirement with `FromReflect` on `ReflectResource`"
-url = "https://github.com/bevyengine/bevy/pull/12136"
+prs = ["12136",]
 areas = ["ECS", "Reflection"]
 file_name = "12136_Replace_FromWorld_requirement_on_ReflectResource_and_refle.md"
 
 [[guides]]
 title = "Make `ReflectComponentFns` and `ReflectBundleFns` methods work with `EntityMut`"
-url = "https://github.com/bevyengine/bevy/pull/12895"
+prs = ["12895",]
 areas = ["ECS", "Reflection"]
 file_name = "12895_Make_some_ReflectComponentReflectBundle_methods_work_with_.md"
 
 [[guides]]
 title = "Require `TypeRegistry` in `ReflectBundle::insert()`"
-url = "https://github.com/bevyengine/bevy/pull/12499"
+prs = ["12499",]
 areas = ["ECS", "Reflection"]
 file_name = "12499_Make_from_reflect_or_world_also_try_ReflectDefault_and_imp.md"
 
 [[guides]]
 title = "Rename `multi-threaded` feature to `multi_threaded`"
-url = "https://github.com/bevyengine/bevy/pull/12997"
+prs = ["12997",]
 areas = ["ECS", "Tasks"]
 file_name = "12997_multi_threaded_feature_rename.md"
 
 [[guides]]
 title = "Moves `intern` and `label` modules from `bevy::utils` to `bevy::ecs`"
-url = "https://github.com/bevyengine/bevy/pull/12772"
+prs = ["12772",]
 areas = ["ECS", "Utils"]
 file_name = "12772_Moves_intern_and_label_modules_into_bevy_ecs.md"
 
 [[guides]]
 title = "Gizmo line joints"
-url = "https://github.com/bevyengine/bevy/pull/12252"
+prs = ["12252",]
 areas = ["Gizmos"]
 file_name = "12252_Gizmo_line_joints.md"
 
 [[guides]]
 title = "Gizmo line styles"
-url = "https://github.com/bevyengine/bevy/pull/12394"
+prs = ["12394",]
 areas = ["Gizmos"]
 file_name = "12394_Gizmo_line_styles.md"
 
 [[guides]]
 title = "Rename `segments()` methods to `resolution()`"
-url = "https://github.com/bevyengine/bevy/pull/13438"
+prs = ["13438",]
 areas = ["Gizmos"]
 file_name = "13438_Inconsistent_segmentsresolution_naming.md"
 
 [[guides]]
 title = "Make gizmos take primitives as a reference"
-url = "https://github.com/bevyengine/bevy/pull/13534"
+prs = ["13534",]
 areas = ["Gizmos"]
 file_name = "13534_Make_gizmos_take_primitives_by_ref.md"
 
 [[guides]]
 title = "More gizmos builders"
-url = "https://github.com/bevyengine/bevy/pull/13261"
+prs = ["13261",]
 areas = ["Gizmos"]
 file_name = "13261_More_gizmos_builders.md"
 
 [[guides]]
 title = "Rename touchpad input to gesture"
-url = "https://github.com/bevyengine/bevy/pull/13660"
+prs = ["13660",]
 areas = ["Input"]
 file_name = "13660_rename_touchpad_to_gesture_and_add_new_gestures.md"
 
 [[guides]]
 title = "Deprecate `ReceivedCharacter`"
-url = "https://github.com/bevyengine/bevy/pull/12868"
+prs = ["12868",]
 areas = ["Input", "Windowing"]
 file_name = "12868_Deprecate_ReceivedCharacter.md"
 
 [[guides]]
 title = "Add `WinitEvent::KeyboardFocusLost`"
-url = "https://github.com/bevyengine/bevy/pull/13678"
+prs = ["13678",]
 areas = ["Input", "Windowing"]
 file_name = "13678_flush_key_input_cache_when_Bevy_loses_focus_Adopted.md"
 
 [[guides]]
 title = "Move direction types out of `bevy::math::primitives`"
-url = "https://github.com/bevyengine/bevy/pull/12018"
+prs = ["12018",]
 areas = ["Math"]
 file_name = "12018_Add_Direction3dA_and_move_direction_types_out_of_primitive.md"
 
 [[guides]]
 title = "Rename `Direction2d/3d` to `Dir2/3`"
-url = "https://github.com/bevyengine/bevy/pull/12189"
+prs = ["12189",]
 areas = ["Math"]
 file_name = "12189_Rename_Direction2d3d_to_Dir23.md"
 
 [[guides]]
 title = "Make cardinal splines include endpoints"
-url = "https://github.com/bevyengine/bevy/pull/12574"
+prs = ["12574",]
 areas = ["Math"]
 file_name = "12574_Make_cardinal_splines_include_endpoints.md"
 
 [[guides]]
 title = "Replace `Point` with `VectorSpace`"
-url = "https://github.com/bevyengine/bevy/pull/12747"
+prs = ["12747",]
 areas = ["Math"]
 file_name = "12747_Move_Point_out_of_cubic_splines_module_and_expand_it.md"
 
 [[guides]]
 title = "UV-mapping change for `Triangle2d`"
-url = "https://github.com/bevyengine/bevy/pull/12686"
+prs = ["12686",]
 areas = ["Math"]
 file_name = "12686_Meshing_for_Triangle3d_primitive.md"
 
 [[guides]]
 title = "Use `Vec3A` for 3D bounding volumes and raycasts"
-url = "https://github.com/bevyengine/bevy/pull/13087"
+prs = ["13087",]
 areas = ["Math"]
 file_name = "13087_Use_Vec3A_for_3D_bounding_volumes_and_raycasts.md"
 
 [[guides]]
 title = "Update `glam` to 0.27"
-url = "https://github.com/bevyengine/bevy/pull/12757"
+prs = ["12757",]
 areas = ["Math"]
 file_name = "12757_Update_glam_version_requirement_from_025_to_027.md"
 
 [[guides]]
 title = "Common `MeshBuilder` trait"
-url = "https://github.com/bevyengine/bevy/pull/13411"
+prs = ["13411",]
 areas = ["Math", "Rendering"]
 file_name = "13411_Common_MeshBuilder_trait.md"
 
 [[guides]]
 title = "Add angle range to `TorusMeshBuilder`"
-url = "https://github.com/bevyengine/bevy/pull/13605"
+prs = ["13605",]
 areas = ["Math", "Rendering"]
 file_name = "13605_Additional_options_to_mesh_primitives.md"
 
 [[guides]]
 title = "Add subdivisions to `PlaneMeshBuilder`"
-url = "https://github.com/bevyengine/bevy/pull/13580"
+prs = ["13580",]
 areas = ["Math", "Rendering"]
 file_name = "13580_Add_subdivisions_to_PlaneMeshBuilder.md"
 
 [[guides]]
 title = "Make `Transform::rotate_axis` and `Transform::rotate_local_axis` use `Dir3`"
-url = "https://github.com/bevyengine/bevy/pull/12986"
+prs = ["12986",]
 areas = ["Math", "Transform"]
 file_name = "12986_Make_Transformrotate_axis_and_Transformrotate_local_axis_u.md"
 
 [[guides]]
 title = "Use `Dir3` for local axis methods in `GlobalTransform`"
-url = "https://github.com/bevyengine/bevy/pull/13264"
+prs = ["13264",]
 areas = ["Math", "Transform"]
 file_name = "13264_Use_Dir3_for_local_axis_methods_in_GlobalTransform.md"
 
 [[guides]]
 title = "Fix `Ord` and `PartialOrd` differing for `FloatOrd`"
-url = "https://github.com/bevyengine/bevy/pull/12711"
+prs = ["12711",]
 areas = ["Math", "Utils"]
 file_name = "12711_Fix_Ord_and_PartialOrd_differing_for_FloatOrd_and_optimize.md"
 
 [[guides]]
 title = "Move `FloatOrd` into `bevy::math`"
-url = "https://github.com/bevyengine/bevy/pull/12732"
+prs = ["12732",]
 areas = ["Math", "Utils"]
 file_name = "12732_Move_FloatOrd_into_bevy_math.md"
 
 [[guides]]
 title = "Change `ReflectSerialize` trait bounds"
-url = "https://github.com/bevyengine/bevy/pull/12024"
+prs = ["12024",]
 areas = ["Reflection"]
 file_name = "12024_reflect_treat_proxy_types_correctly_when_serializing.md"
 
 [[guides]]
 title = "Recursive registration of types"
-url = "https://github.com/bevyengine/bevy/pull/5781"
+prs = ["5781",]
 areas = ["Reflection"]
 file_name = "5781_bevy_reflect_Recursive_registration.md"
 
 [[guides]]
 title = "Rename `UntypedReflectDeserializer` to `ReflectDeserializer`"
-url = "https://github.com/bevyengine/bevy/pull/12721"
+prs = ["12721",]
 areas = ["Reflection"]
 file_name = "12721_bevy_reflect_Rename_UntypedReflectDeserializer_to_ReflectD.md"
 
 [[guides]]
 title = "Implement `Reflect` for `Result` as an enum"
-url = "https://github.com/bevyengine/bevy/pull/13182"
+prs = ["13182",]
 areas = ["Reflection"]
 file_name = "13182_Implement_Reflect_for_ResultT_E_as_enum.md"
 
 [[guides]]
 title = "Serialize scene with `&TypeRegistry` and rename `serialize_ron()` to `serialize()`"
-url = "https://github.com/bevyengine/bevy/pull/12715"
+prs = ["12715",]
 areas = ["Reflection", "Scenes"]
 file_name = "12715_Fix_TypeRegistry_use_in_dynamic_scene.md"
 
 [[guides]]
 title = "Rename `Camera3dBundle::dither` to `deband_dither`"
-url = "https://github.com/bevyengine/bevy/pull/11939"
+prs = ["11939",]
 areas = ["Rendering"]
 file_name = "11939_rename_Camera3dBundles_dither_field_to_deband_dither_to_al.md"
 
 [[guides]]
 title = "Rename `affine_to_square()` to `affine3_to_square()`"
-url = "https://github.com/bevyengine/bevy/pull/11904"
+prs = ["11904",]
 areas = ["Rendering"]
 file_name = "11904_Add_support_for_KHR_texture_transform.md"
 
 [[guides]]
 title = "Move `AlphaMode` into `bevy::render`"
-url = "https://github.com/bevyengine/bevy/pull/12012"
+prs = ["12012",]
 areas = ["Rendering"]
 file_name = "12012_Move_AlphaMode_into_bevy_render.md"
 
 [[guides]]
 title = "Use `UVec2` when working with texture dimensions"
-url = "https://github.com/bevyengine/bevy/pull/11698"
+prs = ["11698",]
 areas = ["Rendering"]
 file_name = "11698_Prefer_UVec2_when_working_with_texture_dimensions.md"
 
 [[guides]]
 title = "Fix `CameraProjectionPlugin` not implementing `Plugin` in some cases"
-url = "https://github.com/bevyengine/bevy/pull/11766"
+prs = ["11766",]
 areas = ["Rendering"]
 file_name = "11766_Fix_CameraProjectionPlugin_not_implementing_Plugin_in_some.md"
 
 [[guides]]
 title = "Replace `random1D()` with `rand_f()` shader function"
-url = "https://github.com/bevyengine/bevy/pull/11956"
+prs = ["11956",]
 areas = ["Rendering"]
 file_name = "11956_Add_random_shader_utils_fix_cluster_debug_visualization.md"
 
 [[guides]]
 title = "Intern mesh vertex buffer layouts"
-url = "https://github.com/bevyengine/bevy/pull/12216"
+prs = ["12216",]
 areas = ["Rendering"]
 file_name = "12216_Intern_mesh_vertex_buffer_layouts_so_that_we_dont_have_to_.md"
 
 [[guides]]
 title = "Make `GpuArrayBufferIndex::index` a u32"
-url = "https://github.com/bevyengine/bevy/pull/12250"
+prs = ["12250",]
 areas = ["Rendering"]
 file_name = "12250_Batching_replace_GpuArrayBufferIndexindex_with_a_u32.md"
 
 [[guides]]
 title = "Allow disabling shadows through `MaterialPlugin`"
-url = "https://github.com/bevyengine/bevy/pull/12538"
+prs = ["12538",]
 areas = ["Rendering"]
 file_name = "12538_Add_setting_to_enabledisable_shadows_to_MaterialPlugin.md"
 
 [[guides]]
 title = "Remove `SpritePipeline::COLORED`"
-url = "https://github.com/bevyengine/bevy/pull/12559"
+prs = ["12559",]
 areas = ["Rendering"]
 file_name = "12559_Remove_needless_color_specializaion_for_SpritePipeline.md"
 
 [[guides]]
 title = "Sorted and binned render phase items, resources, and non-meshes"
-url = "https://github.com/bevyengine/bevy/pull/12453"
+prs = ["12453",]
 areas = ["Rendering"]
 file_name = "12453_13277_14029_sorted_and_binned_render_phase_items.md"
 
 [[guides]]
 title = "GPU frustum culling"
-url = "https://github.com/bevyengine/bevy/pull/12889"
+prs = ["12889",]
 areas = ["Rendering"]
 file_name = "12889_Implement_GPU_frustum_culling.md"
 
 [[guides]]
 title = "Remove `DeterministicRenderingConfig`"
-url = "https://github.com/bevyengine/bevy/pull/12811"
+prs = ["12811",]
 areas = ["Rendering"]
 file_name = "12811_remove_DeterministicRenderingConfig.md"
 
 [[guides]]
 title = "Optimize `queue_material_meshes` and remove some bit manipulation"
-url = "https://github.com/bevyengine/bevy/pull/12791"
+prs = ["12791",]
 areas = ["Rendering"]
 file_name = "12791_Microoptimize_queue_material_meshes_primarily_to_remove_bi.md"
 
 [[guides]]
 title = "Disable `RAY_QUERY` and `RAY_TRACING_ACCELERATION_STRUCTURE` by default"
-url = "https://github.com/bevyengine/bevy/pull/12862"
+prs = ["12862",]
 areas = ["Rendering"]
 file_name = "12862_Disable_RAY_QUERY_and_RAY_TRACING_ACCELERATION_STRUCTURE_b.md"
 
 [[guides]]
 title = "Upload previous frame's `inverse_view` to GPU"
-url = "https://github.com/bevyengine/bevy/pull/12902"
+prs = ["12902",]
 areas = ["Rendering"]
 file_name = "12902_Add_previous_view_uniformsinverse_view.md"
 
 [[guides]]
 title = "Generate `MeshUniform`s on the GPU when available."
-url = "https://github.com/bevyengine/bevy/pull/12773"
+prs = ["12773",]
 areas = ["Rendering"]
 file_name = "12773_Generate_MeshUniforms_on_the_GPU_via_compute_shader_where_.md"
 
 [[guides]]
 title = "Add texture coord flipping to `StandardMaterial`"
-url = "https://github.com/bevyengine/bevy/pull/12917"
+prs = ["12917",]
 areas = ["Rendering"]
 file_name = "12917_flipping_texture_coords_methods_has_been_added_to_the_Stan.md"
 
 [[guides]]
 title = "Rename `ShadowFilteringMethod`'s `Castano13` and `Jimenez14` variants"
-url = "https://github.com/bevyengine/bevy/pull/12910"
+prs = ["12910",]
 areas = ["Rendering"]
 file_name = "12910_Implement_percentagecloser_filtering_PCF_for_point_lights.md"
 
 [[guides]]
 title = "Store lists of `VisibleEntities` separately"
-url = "https://github.com/bevyengine/bevy/pull/12582"
+prs = ["12582",]
 areas = ["Rendering"]
 file_name = "12582_Divide_the_single_VisibleEntities_list_into_separate_lists.md"
 
 [[guides]]
 title = "Make `Text` require `SpriteSource`"
-url = "https://github.com/bevyengine/bevy/pull/12945"
+prs = ["12945",]
 areas = ["Rendering"]
 file_name = "12945_Fix_rendering_of_sprites_text_and_meshlets_after_12582.md"
 
 [[guides]]
 title = "Expose `desired_maximum_frame_latency`"
-url = "https://github.com/bevyengine/bevy/pull/12954"
+prs = ["12954",]
 areas = ["Rendering"]
 file_name = "12954_Expose_desired_maximum_frame_latency_through_window_creati.md"
 
 [[guides]]
 title = "Merge `VisibilitySystems` frusta variants"
-url = "https://github.com/bevyengine/bevy/pull/11808"
+prs = ["11808",]
 areas = ["Rendering"]
 file_name = "11808_Fix_CameraProjection_panic_and_improve_CameraProjectionPlu.md"
 
 [[guides]]
 title = "Expand color grading"
-url = "https://github.com/bevyengine/bevy/pull/13121"
+prs = ["13121",]
 areas = ["Rendering"]
 file_name = "13121_Implement_filmic_color_grading.md"
 
 [[guides]]
 title = "Rename `BufferVec` to `RawBufferVec`"
-url = "https://github.com/bevyengine/bevy/pull/13199"
+prs = ["13199",]
 areas = ["Rendering"]
 file_name = "13199_Add_BufferVec_an_higherperformance_alternative_to_StorageB.md"
 
 [[guides]]
 title = "Implement clearcoat"
-url = "https://github.com/bevyengine/bevy/pull/13031"
+prs = ["13031",]
 areas = ["Rendering"]
 file_name = "13031_Implement_clearcoat_per_the_Filament_and_the_KHR_materials.md"
 
 [[guides]]
 title = "Split `Node2d::MainPass`"
-url = "https://github.com/bevyengine/bevy/pull/12982"
+prs = ["12982",]
 areas = ["Rendering"]
 file_name = "12982_Clean_up_2d_render_phases.md"
 
 [[guides]]
 title = "Remove limit on `RenderLayers`"
-url = "https://github.com/bevyengine/bevy/pull/13317"
+prs = ["13317",]
 areas = ["Rendering"]
 file_name = "13317_12502_Remove_limit_on_RenderLayers.md"
 
 [[guides]]
 title = "Fix astronomic emissive colors required for bloom"
-url = "https://github.com/bevyengine/bevy/pull/13350"
+prs = ["13350",]
 areas = ["Rendering"]
 file_name = "13350_Add_emissive_exposure_weight_to_the_StandardMaterial.md"
 
 [[guides]]
 title = "More idiomatic `TextureAtlasBuilder`"
-url = "https://github.com/bevyengine/bevy/pull/13238"
+prs = ["13238",]
 areas = ["Rendering"]
 file_name = "13238_More_idiomatic_texture_atlas_builder.md"
 
 [[guides]]
 title = "Normalise matrix naming"
-url = "https://github.com/bevyengine/bevy/pull/13489"
+prs = ["13489",]
 areas = ["Rendering"]
 file_name = "13489_Normalise_matrix_naming.md"
 
 [[guides]]
 title = "Rename \"point light\" to \"clusterable object\" in cluster contexts"
-url = "https://github.com/bevyengine/bevy/pull/13654"
+prs = ["13654",]
 areas = ["Rendering"]
 file_name = "13654_Rename_point_light_to_clusterable_object_in_cluster_contex.md"
 
 [[guides]]
 title = "Make `Mesh::merge()` take a reference of `Mesh`"
-url = "https://github.com/bevyengine/bevy/pull/13710"
+prs = ["13710",]
 areas = ["Rendering"]
 file_name = "13710_Made_Meshmerge_take_a_reference_of_Mesh.md"
 
 [[guides]]
 title = "Store `ClearColorConfig` instead of `LoadOp<Color>` in `CameraOutputMode`"
-url = "https://github.com/bevyengine/bevy/pull/13419"
+prs = ["13419",]
 areas = ["Rendering"]
 file_name = "13419_Allow_mix_of_hdr_and_nonhdr_cameras_to_same_render_target.md"
 
 [[guides]]
 title = "`wgpu` 0.20"
-url = "https://github.com/bevyengine/bevy/pull/13186"
+prs = ["13186",]
 areas = ["Rendering"]
 file_name = "13186_Wgpu_020.md"
 
 [[guides]]
 title = "Deprecate `SpriteSheetBundle` and `AtlasImageBundle`"
-url = "https://github.com/bevyengine/bevy/pull/12218"
+prs = ["12218",]
 areas = ["Rendering", "UI"]
 file_name = "12218_Deprecate_SpriteSheetBundle_and_AtlasImageBundle.md"
 
 [[guides]]
 title = "Decouple `BackgroundColor` from `UiImage`"
-url = "https://github.com/bevyengine/bevy/pull/11165"
+prs = ["11165",]
 areas = ["Rendering", "UI"]
 file_name = "11165_Decouple_BackgroundColor_from_UiImage.md"
 
 [[guides]]
 title = "Remove generic camera from `extract_default_ui_camera_view()` system"
-url = "https://github.com/bevyengine/bevy/pull/13462"
+prs = ["13462",]
 areas = ["Rendering", "UI"]
 file_name = "13462_Fix_UI_elements_randomly_not_appearing_after_13277.md"
 
 [[guides]]
 title = "Rename `need_new_surfaces()` system to `need_surface_configuration()`"
-url = "https://github.com/bevyengine/bevy/pull/12055"
+prs = ["12055",]
 areas = ["Rendering", "Windowing"]
 file_name = "12055_configure_surface_needs_to_be_on_the_main_thread_on_iOS.md"
 
 [[guides]]
 title = "Require windowing backends to store windows in `WindowWrapper`"
-url = "https://github.com/bevyengine/bevy/pull/12978"
+prs = ["12978",]
 areas = ["Rendering", "Windowing"]
 file_name = "12978_Introduce_a_WindowWrapper_to_extend_the_lifetime_of_the_wi.md"
 
 [[guides]]
 title = "Add an index argument to parallel iteration helpers"
-url = "https://github.com/bevyengine/bevy/pull/12169"
+prs = ["12169",]
 areas = ["Tasks"]
 file_name = "12169_Add_an_index_argument_to_parallel_iteration_helpers_in_bev.md"
 
 [[guides]]
 title = "Fix spawning `NodeBundle` destroying previous ones"
-url = "https://github.com/bevyengine/bevy/pull/12698"
+prs = ["12698",]
 areas = ["UI"]
 file_name = "12698_Restore_pre_0131_Root_Node_Layout_behavior.md"
 
 [[guides]]
 title = "Rename `Rect::inset()` to `inflate()`"
-url = "https://github.com/bevyengine/bevy/pull/13452"
+prs = ["13452",]
 areas = ["UI"]
 file_name = "13452_Rename_Rect_inset_method_to_inflate.md"
 
 [[guides]]
 title = "Updates default font size to 24px"
-url = "https://github.com/bevyengine/bevy/pull/13603"
+prs = ["13603",]
 areas = ["UI"]
 file_name = "13603_Updates_default_Text_font_size_to_24px.md"
 
 [[guides]]
 title = "Disentangle `bevy::utils` / `bevy::core`'s re-exported crates"
-url = "https://github.com/bevyengine/bevy/pull/12313"
+prs = ["12313",]
 areas = ["Utils"]
 file_name = "12313_Disentangle_bevy_utilsbevy_cores_reexported_dependencies.md"
 
 [[guides]]
 title = "Re-add `Window::fit_canvas_to_parent`"
-url = "https://github.com/bevyengine/bevy/pull/11278"
+prs = ["11278",]
 areas = ["Windowing"]
 file_name = "11278_Fix_fit_canvas_to_parent.md"
 
 [[guides]]
 title = "Remove window from `WinitWindows` when it is closed"
-url = "https://github.com/bevyengine/bevy/pull/12749"
+prs = ["12749",]
 areas = ["Windowing"]
 file_name = "12749_Clean_up_WinitWindowsremove_window.md"
 
 [[guides]]
 title = "Make window close the frame after it is requested"
-url = "https://github.com/bevyengine/bevy/pull/13236"
+prs = ["13236",]
 areas = ["Windowing"]
 file_name = "13236_Ensure_clean_exit.md"
 
 [[guides]]
 title = "Upgrade to `winit` 0.30"
-url = "https://github.com/bevyengine/bevy/pull/13366"
+prs = ["13366",]
 areas = ["Windowing"]
 file_name = "13366_fix_upgrade_to_winit_v030.md"
 
 [[guides]]
 title = "Separating Finite and Infinite 3d Planes"
-url = "https://github.com/bevyengine/bevy/pull/12426"
+prs = ["12426",]
 areas = ["Math", "Rendering"]
 file_name = "12426_separating_finite_and_infinite_3d_planes.md"
 
 [[guides]]
 title = "Contextually clearing gizmos"
-url = "https://github.com/bevyengine/bevy/pull/10973"
+prs = ["10973",]
 areas = ["Gizmos"]
 file_name = "10973_Contextually_clearing_gizmos.md"

--- a/release-content/0.14/release-notes/_release-notes.toml
+++ b/release-content/0.14/release-notes/_release-notes.toml
@@ -1,103 +1,103 @@
 [[release_notes]]
 title = "Virtual Geometry (Experimental)"
 authors = ["@JMS55", "@atlv24", "@zeux", "@ricky26"]
-url = "https://github.com/bevyengine/bevy/pull/10164"
+prs = ["10164",]
 file_name = "10164_Meshlet_rendering_initial_feature.md"
 
 [[release_notes]]
 title = "Sharp Screen-Space Reflections"
 authors = ["@pcwalton"]
-url = "https://github.com/bevyengine/bevy/pull/13418"
+prs = ["13418",]
 file_name = "13418_Implement_optin_sharp_screenspace_reflections_for_the_defe.md"
 
 [[release_notes]]
 title = "Volumetric Fog and Volumetric Lighting (light shafts / god rays)"
 authors = ["@pcwalton"]
-url = "https://github.com/bevyengine/bevy/pull/13057"
+prs = ["13057",]
 file_name = "13057_Implement_volumetric_fog_and_volumetric_lighting_also_know.md"
 
 [[release_notes]]
 title = "Per-Object Motion Blur"
 authors = ["@aevyrie", "@torsteingrindvik"]
-url = "https://github.com/bevyengine/bevy/pull/9924"
+prs = ["9924",]
 file_name = "9924_PerObject_Motion_Blur.md"
 
 [[release_notes]]
 title = "Filmic Color Grading"
 authors = ["@pcwalton"]
-url = "https://github.com/bevyengine/bevy/pull/13121"
+prs = ["13121",]
 file_name = "13121_Implement_filmic_color_grading.md"
 
 [[release_notes]]
 title = "Auto Exposure"
 authors = ["@Kurble", "@alice-i-cecile"]
-url = "https://github.com/bevyengine/bevy/pull/12792"
+prs = ["12792",]
 file_name = "12792_Implement_Auto_Exposure_plugin.md"
 
 [[release_notes]]
 title = "Fast Depth of Field"
 authors = ["@pcwalton", "@alice-i-cecile", "@Kurble"]
-url = "https://github.com/bevyengine/bevy/pull/13009"
+prs = ["13009",]
 file_name = "13009_Implement_fast_depth_of_field_as_a_postprocessing_effect.md"
 
 [[release_notes]]
 title = "PBR Anisotropy"
 authors = ["@pcwalton"]
-url = "https://github.com/bevyengine/bevy/pull/13450"
+prs = ["13450",]
 file_name = "13450_Implement_PBR_anisotropy_per_KHR_materials_anisotropy.md"
 
 [[release_notes]]
 title = "Percentage-Closer Filtering (PCF) for Point Lights"
 authors = ["@pcwalton"]
-url = "https://github.com/bevyengine/bevy/pull/12910"
+prs = ["12910",]
 file_name = "12910_Implement_percentagecloser_filtering_PCF_for_point_lights.md"
 
 [[release_notes]]
 title = "Subpixel Morphological Antialiasing (SMAA)"
 authors = ["@pcwalton", "@alice-i-cecile"]
-url = "https://github.com/bevyengine/bevy/pull/13423"
+prs = ["13423",]
 file_name = "13423_Implement_subpixel_morphological_antialiasing_or_SMAA.md"
 
 [[release_notes]]
 title = "Visibility Ranges (hierarchical levels of detail / HLODs)"
 authors = ["@pcwalton", "@cart"]
-url = "https://github.com/bevyengine/bevy/pull/12916"
+prs = ["12916",]
 file_name = "12916_Implement_visibility_ranges_also_known_as_hierarchical_lev.md"
 
 [[release_notes]]
 title = "ECS Hooks and Observers"
 authors = ["@james-j-obrien", "@cart"]
-url = "https://github.com/bevyengine/bevy/pull/10839"
+prs = ["10839",]
 file_name = "10756_hooks_and_observers.md"
 
 [[release_notes]]
 title = "glTF KHR_texture_transform Support"
 authors = ["@janhohenheim", "@yrns", "@Kanabenki"]
-url = "https://github.com/bevyengine/bevy/pull/11904"
+prs = ["11904",]
 file_name = "11904_Add_support_for_KHR_texture_transform.md"
 
 [[release_notes]]
 title = "UI Node Border Radius"
 authors = ["@chompaa", "@pablo-lua", "@alice-i-cecile", "@bushrat011899"]
-url = "https://github.com/bevyengine/bevy/pull/12500"
+prs = ["12500",]
 file_name = "12500_Add_border_radius_to_UI_nodes_adopted.md"
 
 [[release_notes]]
 title = "Animation Blending with the `AnimationGraph`"
 authors = ["@pcwalton", "@rparrett", "@james7132"]
-url = "https://github.com/bevyengine/bevy/pull/11989"
+prs = ["11989",]
 file_name = "11989_Implement_the_AnimationGraph_allowing_for_multiple_animati.md"
 
 [[release_notes]]
 title = "Improved Color API"
 authors = ["@viridia", "@mockersf"]
-url = "https://github.com/bevyengine/bevy/pull/12013"
+prs = ["12013",]
 file_name = "12013_Upstreaming_bevy_color.md"
 
 [[release_notes]]
 title = "Extruded Shapes"
 authors = ["@lynn-lumen"]
-url = "https://github.com/bevyengine/bevy/pull/13270"
+prs = ["13270",]
 file_name = "13270_Extrusion.md"
 
 [[release_notes]]
@@ -109,109 +109,109 @@ authors = [
 	"@solis-lumine-vorago",
 	"@alice-i-cecile",
 ]
-url = "https://github.com/bevyengine/bevy/pull/12211"
+prs = ["12211",]
 file_name = "New_gizmos_types.md"
 
 [[release_notes]]
 title = "Gizmo Line Styles and Joints"
 authors = ["@lynn-lumen"]
-url = "https://github.com/bevyengine/bevy/pull/12394"
+prs = ["12394",]
 file_name = "12394_Gizmo_line_styles.md"
 
 [[release_notes]]
 title = "UI Node Outline Gizmos"
 authors = ["@pablo-lua", "@nicopap", "@alice-i-cecile"]
-url = "https://github.com/bevyengine/bevy/pull/11237"
+prs = ["11237",]
 file_name = "11237_Add_a_gizmobased_overlay_to_show_UI_node_outlines_Adopted.md"
 
 [[release_notes]]
 title = "Contextually Clearing Gizmos"
 authors = ["@Aceeri"]
-url = "https://github.com/bevyengine/bevy/pull/10973"
+prs = ["10973",]
 file_name = "10973_Contextually_clearing_gizmos.md"
 
 [[release_notes]]
 title = "Query Joins"
 authors = ["@hymm"]
-url = "https://github.com/bevyengine/bevy/pull/11535"
+prs = ["11535",]
 file_name = "11535_Query_Joins.md"
 
 [[release_notes]]
 title = "Computed States & Sub-States"
 authors = ["@lee-orr", "@marcelchampagne", "@MiniaczQ", "@alice-i-cecile"]
-url = "https://github.com/bevyengine/bevy/pull/11426"
+prs = ["11426",]
 file_name = "11426_Computed_States__Sub_States.md"
 
 [[release_notes]]
 title = "State Scoped Entities"
 authors = ["@MiniaczQ", "@alice-i-cecile", "@mockersf"]
-url = "https://github.com/bevyengine/bevy/pull/13649"
+prs = ["13649",]
 file_name = "13649_State_Scoped_Entities.md"
 
 [[release_notes]]
 title = "State Identity Transitions"
 authors = ["@MiniaczQ", "@alice-i-cecile"]
-url = "https://github.com/bevyengine/bevy/pull/13579"
+prs = ["13579",]
 file_name = "13579_State_Identity_Transitions.md"
 
 [[release_notes]]
 title = "GPU Frustum Culling"
 authors = ["@pcwalton"]
-url = "https://github.com/bevyengine/bevy/pull/12889"
+prs = ["12889",]
 file_name = "12889_Implement_GPU_frustum_culling.md"
 
 [[release_notes]]
 title = "World Command Queue"
 authors = ["@james7132", "@james-j-obrien"]
-url = "https://github.com/bevyengine/bevy/pull/11823"
+prs = ["11823",]
 file_name = "11823_Immediately_apply_deferred_system_params_in_Systemrun.md"
 
 [[release_notes]]
 title = "Reduced Multi-Threaded Execution Overhead"
 authors = ["@chescock", "@james7132"]
-url = "https://github.com/bevyengine/bevy/pull/11906"
+prs = ["11906",]
 file_name = "11906_Run_the_multithreaded_executor_at_the_end_of_each_system_t.md"
 
 [[release_notes]]
 title = "Decouple `BackgroundColor` from `UiImage`"
 authors = ["@benfrankel"]
-url = "https://github.com/bevyengine/bevy/pull/11165"
+prs = ["11165",]
 file_name = "11165_Decouple_BackgroundColor_from_UiImage.md"
 
 [[release_notes]]
 title = "Combined WinitEvent"
 authors = ["@UkoeHB"]
-url = "https://github.com/bevyengine/bevy/pull/12100"
+prs = ["12100",]
 file_name = "12100_Add_WinitEvent_aggregate_event_for_synchronized_window_eve.md"
 
 [[release_notes]]
 title = "Recursive Reflect Registration"
 authors = ["@MrGVSV", "@soqb", "@cart", "@james7132"]
-url = "https://github.com/bevyengine/bevy/pull/5781"
+prs = ["5781",]
 file_name = "5781_bevy_reflect_Recursive_registration.md"
 
 [[release_notes]]
 title = "`Rot2` Type for 2D Rotations"
 authors = ["@Jondolf", "@IQuick143", "@tguichaoua"]
-url = "https://github.com/bevyengine/bevy/pull/11658"
+prs = ["11658",]
 file_name = "11658_Add_Rotation2d.md"
 
 [[release_notes]]
 title = "Alignment API for Transforms"
 authors = ["@mweatherley"]
-url = "https://github.com/bevyengine/bevy/pull/12187"
+prs = ["12187",]
 file_name = "12187_Alignment_API_for_Transforms.md"
 
 [[release_notes]]
 title = "Random Sampling of Shapes and Directions"
 authors = ["@13ros27", "@mweatherley", "@lynn-lumen"]
-url = "https://github.com/bevyengine/bevy/pull/12484"
+prs = ["12484",]
 file_name = "12484_Uniform_point_sampling_methods_for_some_primitive_shapes.md"
 
 [[release_notes]]
 title = "Tools for Profiling GPU Performance"
 authors = ["@LeshaInc"]
-url = "https://github.com/bevyengine/bevy/pull/9135"
+prs = ["9135",]
 file_name = "9135_Add_pipeline_statistics.md"
 
 [[release_notes]]
@@ -225,7 +225,7 @@ authors = [
 	"@aristaeus",
 	"@mweatherley",
 ]
-url = "https://github.com/bevyengine/bevy/pull/12508"
+prs = ["12508",]
 file_name = "new_math_primitives.md"
 
 [[release_notes]]
@@ -238,131 +238,131 @@ authors = [
 	"@IQuick143",
 	"@alice-i-cecile",
 ]
-url = "https://github.com/bevyengine/bevy/pull/12747"
+prs = ["12747",]
 file_name = "12747_Move_Point_out_of_cubic_splines_module_and_expand_it.md"
 
 [[release_notes]]
 title = "2D Mesh Wireframes"
 authors = ["@msvbg", "@IceSentry"]
-url = "https://github.com/bevyengine/bevy/pull/12135"
+prs = ["12135",]
 file_name = "12135_Support_wireframes_for_2D_meshes.md"
 
 [[release_notes]]
 title = "Custom Reflect Field Attributes"
 authors = ["@MrGVSV"]
-url = "https://github.com/bevyengine/bevy/pull/11659"
+prs = ["11659",]
 file_name = "11659_bevy_reflect_Custom_attributes.md"
 
 [[release_notes]]
 title = "Query Iteration Sorting"
 authors = ["@Victoronz"]
-url = "https://github.com/bevyengine/bevy/pull/13417"
+prs = ["13417",]
 file_name = "13417_implement_the_full_set_of_sort_methods_on_QueryIter.md"
 
 [[release_notes]]
 title = "SystemBuilder"
 authors = ["@james-j-obrien"]
-url = "https://github.com/bevyengine/bevy/pull/13123"
+prs = ["13123",]
 file_name = "13123_Implement_a_SystemBuilder_for_building_SystemParams.md"
 
 [[release_notes]]
 title = "Throttle Render Assets"
 authors = ["@robtfm", "@IceSentry", "@mockersf"]
-url = "https://github.com/bevyengine/bevy/pull/12622"
+prs = ["12622",]
 file_name = "12622_Throttle_render_assets.md"
 
 [[release_notes]]
 title = "StandardMaterial UV Channel Selection"
 authors = ["@geckoxx"]
-url = "https://github.com/bevyengine/bevy/pull/13200"
+prs = ["13200",]
 file_name = "13200_Add_UV_channel_selection_to_StandardMaterial.md"
 
 [[release_notes]]
 title = "Remove limit on RenderLayers"
 authors = ["@tychedelia", "@robtfm", "@UkoeHB"]
-url = "https://github.com/bevyengine/bevy/pull/13317"
+prs = ["13317",]
 file_name = "13317_12502_Remove_limit_on_RenderLayers.md"
 
 [[release_notes]]
 title = "`on_unimplemented` Diagnostics"
 authors = ["@bushrat011899", "@alice-i-cecile", "@Themayu"]
-url = "https://github.com/bevyengine/bevy/pull/13347"
+prs = ["13347",]
 file_name = "13347_Add_on_unimplemented_Diagnostics_to_Most_Public_Traits.md"
 
 [[release_notes]]
 title = "Motion Vectors and TAA for Animated Meshes"
 authors = ["@pcwalton"]
-url = "https://github.com/bevyengine/bevy/pull/13572"
+prs = ["13572",]
 file_name = "13572_Implement_motion_vectors_and_TAA_for_skinned_meshes_and_me.md"
 
 [[release_notes]]
 title = "Improved Matrix Naming"
 authors = ["@ricky26"]
-url = "https://github.com/bevyengine/bevy/pull/13489"
+prs = ["13489",]
 file_name = "13489_Normalise_matrix_naming.md"
 
 [[release_notes]]
 title = "Typed glTF Labels"
 authors = ["@mockersf", "@rparrett", "@alice-i-cecile"]
-url = "https://github.com/bevyengine/bevy/pull/13586"
+prs = ["13586",]
 file_name = "13586_glTF_labels_add_enum_to_avoid_misspelling_and_keep_uptodat.md"
 
 [[release_notes]]
 title = "winit v0.30"
 authors = ["@pietrosophya", "@mockersf"]
-url = "https://github.com/bevyengine/bevy/pull/13366"
+prs = ["13366",]
 file_name = "13366_fix_upgrade_to_winit_v030.md"
 
 [[release_notes]]
 title = "Scene, Mesh, and Material glTF Extras"
 authors = ["@kaosat-dev"]
-url = "https://github.com/bevyengine/bevy/pull/13453"
+prs = ["13453",]
 file_name = "13453_add_handling_of_all_missing_gltf_extras_scene_mesh__materi.md"
 
 [[release_notes]]
 title = "Resource Entity Mapping in Scenes"
 authors = ["@brandon-reinhart"]
-url = "https://github.com/bevyengine/bevy/pull/13650"
+prs = ["13650",]
 file_name = "13650_Map_entities_from_a_resource_when_written_to_the_world.md"
 
 [[release_notes]]
 title = "CompassQuadrant and CompassOctant"
 authors = ["@BobG1983", "@alice-i-cecile"]
-url = "https://github.com/bevyengine/bevy/pull/13653"
+prs = ["13653",]
 file_name = "13653_Added_CompassQuadrant_and_CompassOctant_as_per_13647.md"
 
 [[release_notes]]
 title = "Support `AsyncSeek` When Loading Assets"
 authors = ["@BeastLe9enD"]
-url = "https://github.com/bevyengine/bevy/pull/12547"
+prs = ["12547",]
 file_name = "12547_Add_AsyncSeek_trait_to_Reader_to_be_able_to_seek_inside_as.md"
 
 [[release_notes]]
 title = "LoadState::Failed Now Has Error Info"
 authors = ["@bugsweeper"]
-url = "https://github.com/bevyengine/bevy/pull/12709"
+prs = ["12709",]
 file_name = "12709_Error_info_has_been_added_to_LoadStateFailed.md"
 
 [[release_notes]]
 title = "`AppExit` Errors"
 authors = ["@Brezak", "@alice-i-cecile"]
-url = "https://github.com/bevyengine/bevy/pull/13022"
+prs = ["13022",]
 file_name = "13022_Make_AppExit_more_specific_about_exit_reason.md"
 
 [[release_notes]]
 title = "Make dynamic_linking a no-op on WASM targets"
 authors = ["@james7132"]
-url = "https://github.com/bevyengine/bevy/pull/12672"
+prs = ["12672",]
 file_name = "12672_Make_dynamic_linking_a_noop_on_wasm_targets.md"
 
 [[release_notes]]
 title = "Deprecate Dynamic Plugins"
 authors = ["@BD103"]
-url = "https://github.com/bevyengine/bevy/pull/13080"
+prs = ["13080",]
 file_name = "13080_Deprecate_dynamic_plugins.md"
 
 [[release_notes]]
 title = "Bevy Working Groups"
 authors = ["@alice-i-cecile"]
-url = "https://github.com/bevyengine/bevy/pull/13162"
+prs = ["13162",]
 file_name = "13162_Add_a_process_for_working_groups.md"

--- a/sass/pages/_migration_guide.scss
+++ b/sass/pages/_migration_guide.scss
@@ -40,3 +40,4 @@ ul.migration-guide-pr-list {
   list-style: none;
   padding: 0px;
 }
+

--- a/sass/pages/_migration_guide.scss
+++ b/sass/pages/_migration_guide.scss
@@ -35,3 +35,8 @@
   border-style: solid;
   border-width: 1px;
 }
+
+ul.migration-guide-pr-list {
+  list-style: none;
+  padding: 0px;
+}

--- a/templates/shortcodes/migration_guides.md
+++ b/templates/shortcodes/migration_guides.md
@@ -11,7 +11,12 @@
 {% for guide in guides_data.guides %}
 {% set guide_body = load_data(path=macros::path_join(path_a=base_path, path_b=guide.file_name)) %}
 
-### [{{ guide.title }}]({{ guide.url }})
+### {{ guide.title }}
+<ul class="migration-guide-pr-list">
+{% for pr in guide.prs %}
+<li><a href="https://github.com/bevyengine/bevy/pull/{{ pr }}">PR #{{ pr }}</a></li>
+{% endfor %}
+</ul>
 
 <div class="migration-guide-area-tags">
 {% for area in guide.areas %}

--- a/templates/shortcodes/release_notes.md
+++ b/templates/shortcodes/release_notes.md
@@ -9,7 +9,9 @@
 
 <ul class="release-feature-meta">
   <li>Authors: {{ release_note.authors | join(sep=", ")}}</li>
-  <li><a href="{{ release_note.url }}">Pull Request</a></li>
+  {% for pr in release_note.prs %}
+  <li><a href="https://github.com/bevyengine/bevy/pull/{{ pr }}">PR #{{ pr }}</a></li>
+  {% endfor %}
 </ul>
 
 {{ release_note_body | replace(from='POST_PATH', to=page.colocated_path) | markdown }}


### PR DESCRIPTION
# Objective

Fixes #1354
Fixes #1350 I believe
Adds support for Meta category labels to the `generate-release` tool solving https://github.com/bevyengine/bevy-website/pull/1646#issuecomment-2407903312

This PR aims to make the release notes and migration guides generators easier to use with merged release notes, and edited release notes. (Also, overall improving the tool in slight ways as I go along, by accident).

## Solution

It now tracks whether a PR exists by the release note and migration guide metadata, and allows for multiple PRs per a note or guide, and PR URLs per note or guide. It should only ever create a file if a PR is not included in any notes or guides metadata, so no more overwriting note files or note or guide metadata if it isn't a new PR as far as the generator is concerned. If a release note or migration guide PR is removed from the entries, and has no notes or guides associated with it's number, it will be regenerated and appended to the end of the metadata file whilst preserving the preexisting notes or guides.

This PR also edits the Zola page templates to create the URls from the `prs` list in the metadata, and migrated the 0.14 release note and migration guides to work with this system.

The Contributing guide and `generate-release` README.md have been slightly updated.

## Testing
Run the tool: `cargo run -p generate-release -- --from v0.14.2 --to main --release-version 0.15 release-notes` to initially generate, then modify the notes entries in `release-content/0.15/release-notes/_release-notes.toml` and or in the related PR files, then re-run the tool to see how it doesn't modify your edits, but if you removed a PR completely (isn't in any of the notes associated metadata), then it will regenerate that one note and appends it to the end of the file while preserving the other notes.

`cargo run -p generate-release -- --from v0.14.2 --to main --release-version 0.15 migration-guides` to do the same for migration guides (same testing methodology, too).

To test the Zola pages, you can follow the instructions in [`generate-release`'s README.md](https://github.com/TrialDragon/bevy-website/blob/trialdragon/1354_merging_multiple_prs/generate-release/README.md) for generating a release to create the initial files. Then, run `zola serve` to A) see the site start up locally, hopefully without errors (be aware that the contributors subcommand may produce `WX\shixi` as a contributor name, which breaks Zola, and so has to be deleted for Zola to work), and B) check the mock news post to see if everything looks correct, or acceptable.