### PR TITLE
Change contributors shortcode styling so it's more compact

### DIFF
--- a/sass/components/_contributors.scss
+++ b/sass/components/_contributors.scss
@@ -1,0 +1,6 @@
+.contributors {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  list-style: none;
+  padding: 0 !important;
+}

--- a/sass/site.scss
+++ b/sass/site.scss
@@ -33,6 +33,7 @@
 @import "components/callout";
 @import "components/card";
 @import "components/container";
+@import "components/contributors";
 @import "components/example";
 @import "components/header";
 @import "components/icon";

--- a/templates/shortcodes/contributors.md
+++ b/templates/shortcodes/contributors.md
@@ -5,7 +5,7 @@
 
 A huge thanks to the {{ data.contributors | length }} contributors that made this release (and associated docs) possible! In random order:
 
-<ul>
+<ul class="contributors">
 {% for contributor in data.contributors %}
 <li>{{ contributor.name }}</li>
 {% endfor %}


### PR DESCRIPTION
Change `contributors.md` shortcode styling so it shows contributors in columns. The number of columns will automatically change based on the available space:

<img width="954" alt="image" src="https://github.com/user-attachments/assets/63eb24bb-8f23-4da1-893d-288b35fb7c94">

<img width="834" alt="image" src="https://github.com/user-attachments/assets/5906bcb0-a82a-4b67-ac4d-9e1d741241df">

<img width="521" alt="image" src="https://github.com/user-attachments/assets/2560efc5-b8b2-40e2-89ce-38a6c13e6265">
