### PR TITLE
Add stub for required components

### DIFF
--- a/release-content/0.15/release-notes/14791_Required_Components.md
+++ b/release-content/0.15/release-notes/14791_Required_Components.md
@@ -1,0 +1,4 @@
+<!-- Required Components -->
+<!-- https://github.com/bevyengine/bevy/pull/14791 -->
+
+<!-- TODO -->

--- a/release-content/0.15/release-notes/_release-notes.toml
+++ b/release-content/0.15/release-notes/_release-notes.toml
@@ -506,3 +506,10 @@ authors = ["@Jondolf"]
 contributors = ["@mockersf", "@tbillington", "@aevyrie"]
 prs = [15800]
 file_name = "15800_Add_mesh_picking_backend_and_MeshRayCast_system_parameter.md"
+[[release_notes]]
+title = "Required Components"
+authors = ["@cart",]
+contributors = ["@alice-i-cecile", "@killercup", "@BD103"]
+prs = [14791]
+file_name = "14791_Required_Components.md"
+

--- a/release-content/0.15/release-notes/_release-notes.toml
+++ b/release-content/0.15/release-notes/_release-notes.toml
@@ -506,6 +506,7 @@ authors = ["@Jondolf"]
 contributors = ["@mockersf", "@tbillington", "@aevyrie"]
 prs = [15800]
 file_name = "15800_Add_mesh_picking_backend_and_MeshRayCast_system_parameter.md"
+
 [[release_notes]]
 title = "Required Components"
 authors = ["@cart",]


### PR DESCRIPTION
While investigating #1724, I re-ran the tool. It only found the require components PR, which I've added the release notes label to after running the tool the first time.

We might as well add the stub for it now though.