### PR TITLE
Remove unwarranted release note stubs

### DIFF
--- a/release-content/0.15/release-notes/13889_Make_Tasks_functional_on_WASM.md
+++ b/release-content/0.15/release-notes/13889_Make_Tasks_functional_on_WASM.md
@@ -1,4 +1,0 @@
-<!-- Make `Task`s functional on WASM -->
-<!-- https://github.com/bevyengine/bevy/pull/13889 -->
-
-<!-- TODO -->

--- a/release-content/0.15/release-notes/14316_Fast_renormalize.md
+++ b/release-content/0.15/release-notes/14316_Fast_renormalize.md
@@ -1,4 +1,0 @@
-<!-- Fast renormalize -->
-<!-- https://github.com/bevyengine/bevy/pull/14316 -->
-
-<!-- TODO -->

--- a/release-content/0.15/release-notes/14703_Use_docfake_variadic_to_improve_docs_readability.md
+++ b/release-content/0.15/release-notes/14703_Use_docfake_variadic_to_improve_docs_readability.md
@@ -1,4 +1,0 @@
-<!-- Use `#[doc(fake_variadic)]` to improve docs readability -->
-<!-- https://github.com/bevyengine/bevy/pull/14703 -->
-
-<!-- TODO -->

--- a/release-content/0.15/release-notes/14863_Expose_bevy_math_ops.md
+++ b/release-content/0.15/release-notes/14863_Expose_bevy_math_ops.md
@@ -1,4 +1,0 @@
-<!-- Expose bevy math ops -->
-<!-- https://github.com/bevyengine/bevy/pull/14863 -->
-
-<!-- TODO -->

--- a/release-content/0.15/release-notes/14964_Migrate_bevy_transform_to_required_components.md
+++ b/release-content/0.15/release-notes/14964_Migrate_bevy_transform_to_required_components.md
@@ -1,4 +1,0 @@
-<!-- Migrate `bevy_transform` to required components -->
-<!-- https://github.com/bevyengine/bevy/pull/14964 -->
-
-<!-- TODO -->

--- a/release-content/0.15/release-notes/15341_Add_UI_GhostNode.md
+++ b/release-content/0.15/release-notes/15341_Add_UI_GhostNode.md
@@ -1,4 +1,0 @@
-<!-- Add UI `GhostNode` -->
-<!-- https://github.com/bevyengine/bevy/pull/15341 -->
-
-<!-- TODO -->

--- a/release-content/0.15/release-notes/_release-notes.toml
+++ b/release-content/0.15/release-notes/_release-notes.toml
@@ -160,13 +160,6 @@ prs = [14646]
 file_name = "14646_feat_add_insert_if_new_14397.md"
 
 [[release_notes]]
-title = "Expose bevy math ops"
-authors = ["@Lubba-64"]
-contributors = []
-prs = [14863]
-file_name = "14863_Expose_bevy_math_ops.md"
-
-[[release_notes]]
 title = "Allow fog density texture to be scrolled over time with an offset"
 authors = ["@jirisvd"]
 contributors = []

--- a/release-content/0.15/release-notes/_release-notes.toml
+++ b/release-content/0.15/release-notes/_release-notes.toml
@@ -139,13 +139,6 @@ prs = [7207]
 file_name = "7207_reflect_implement_the_unique_reflect_rfc.md"
 
 [[release_notes]]
-title = "Use `#[doc(fake_variadic)]` to improve docs readability"
-authors = ["@bash"]
-contributors = []
-prs = [14703]
-file_name = "14703_Use_docfake_variadic_to_improve_docs_readability.md"
-
-[[release_notes]]
 title = "bevy_reflect: Reflect remote types"
 authors = ["@MrGVSV"]
 contributors = []

--- a/release-content/0.15/release-notes/_release-notes.toml
+++ b/release-content/0.15/release-notes/_release-notes.toml
@@ -83,13 +83,6 @@ prs = [14106]
 file_name = "14106_Cyclic_splines.md"
 
 [[release_notes]]
-title = "Fast renormalize"
-authors = ["@IQuick143"]
-contributors = ["@Jondolf", "@BD103", "@janhohenheim"]
-prs = [14316]
-file_name = "14316_Fast_renormalize.md"
-
-[[release_notes]]
 title = "Dedicated `Reflect` implementation for `Set`-like things"
 authors = ["@RobWalt"]
 contributors = []

--- a/release-content/0.15/release-notes/_release-notes.toml
+++ b/release-content/0.15/release-notes/_release-notes.toml
@@ -410,13 +410,6 @@ prs = [12095]
 file_name = "12095_Add_features_to_switch_NativeActivity_and_GameActivity_usa.md"
 
 [[release_notes]]
-title = "Add UI `GhostNode`"
-authors = ["@villor"]
-contributors = ["@alice-i-cecile", "@UkoeHB"]
-prs = [15341]
-file_name = "15341_Add_UI_GhostNode.md"
-
-[[release_notes]]
 title = "bevy_reflect: Add `DeserializeWithRegistry` and `SerializeWithRegistry`"
 authors = ["@MrGVSV"]
 contributors = ["@aecsocket", "@alice-i-cecile"]

--- a/release-content/0.15/release-notes/_release-notes.toml
+++ b/release-content/0.15/release-notes/_release-notes.toml
@@ -55,13 +55,6 @@ prs = [14212]
 file_name = "14212_Component_Lifecycle_Hook__Observer_Trigger_for_replaced_va.md"
 
 [[release_notes]]
-title = "Make `Task`s functional on WASM"
-authors = ["@JoJoJet"]
-contributors = ["@cBournhonesque", "@janhohenheim"]
-prs = [13889]
-file_name = "13889_Make_Tasks_functional_on_WASM.md"
-
-[[release_notes]]
 title = "Allow volumetric fog to be localized to specific, optionally voxelized, regions."
 authors = ["@pcwalton"]
 contributors = ["@alice-i-cecile", "@mockersf"]

--- a/release-content/0.15/release-notes/_release-notes.toml
+++ b/release-content/0.15/release-notes/_release-notes.toml
@@ -333,13 +333,6 @@ prs = [15281]
 file_name = "15281_Add_core_and_alloc_over_std_Lints.md"
 
 [[release_notes]]
-title = "Migrate `bevy_transform` to required components"
-authors = ["@ecoskey"]
-contributors = ["@tim-blackbird", "@alice-i-cecile"]
-prs = [14964]
-file_name = "14964_Migrate_bevy_transform_to_required_components.md"
-
-[[release_notes]]
 title = "Implement gamepads as entities"
 authors = ["@s-puig"]
 contributors = ["@cart"]


### PR DESCRIPTION
I've only tackled the ones that don't warrant release notes at all, rather than attempting to merge them.

1. Closes #1710.
2. Closes #1699.
3. Closes #1676.
4. Closes #1672.
5. Closes #1664.
6. Closes #1660.