### PR TITLE
Apply `escape` before `markdown` filter so that generics in titles don't break the changelog HTML output 

### DIFF
--- a/templates/shortcodes/changelog.md
+++ b/templates/shortcodes/changelog.md
@@ -17,7 +17,7 @@ For a complete list of changes, check out the PRs listed below.
 
 <ul class="pr-list">
 {% for pr in area.prs %}
-<li class="pr-list__item"><a href="https://github.com/bevyengine/bevy/pull/{{pr.number}}">{{pr.title | markdown}}</a></li>
+<li class="pr-list__item"><a href="https://github.com/bevyengine/bevy/pull/{{pr.number}}">{{pr.title | escape | markdown}}</a></li>
 {% endfor %}
 </ul>
 {% endfor %}


### PR DESCRIPTION
Changelog indentation breaks when an entry has generics in the title. For example, see how after the `App` section each new sections adds extra indentation: https://bevyengine.org/news/bevy-0-14/#app

![image](https://github.com/user-attachments/assets/f674ba69-ff53-400e-9da3-e32e45d6fdbc)

The culprit is the last entry in the `App` section: `Fix is_plugin_added::<Self>() being true during build`. The `<Self>` generic is treated as HTML:

![image](https://github.com/user-attachments/assets/0464b406-d6b7-4b7e-b041-13dfe72227c3)

The solution is to `escape` before applying `markdown` filter:

![image](https://github.com/user-attachments/assets/5092d7b6-4d92-493a-95c2-918a3663f798)
