### PR TITLE
Create public draft for 0.15 migration guide

### DIFF
--- a/content/learn/migration-guides/0.14-to-0.15.md
+++ b/content/learn/migration-guides/0.14-to-0.15.md
@@ -5,6 +5,7 @@ insert_anchor_links = "right"
 weight = 10
 long_title = "Migration Guide: 0.14 to 0.15"
 public_draft = 1741
+status = 'hidden'
 +++
 
 {{ migration_guides(version="0.15") }}

--- a/content/learn/migration-guides/0.14-to-0.15.md
+++ b/content/learn/migration-guides/0.14-to-0.15.md
@@ -7,4 +7,4 @@ long_title = "Migration Guide: 0.14 to 0.15"
 public_draft = 1741
 +++
 
-{{ migration_guides(version="0.14") }}
+{{ migration_guides(version="0.15") }}

--- a/content/learn/migration-guides/0.14-to-0.15.md
+++ b/content/learn/migration-guides/0.14-to-0.15.md
@@ -1,0 +1,10 @@
++++
+title = "0.14 to 0.15"
+insert_anchor_links = "right"
+[extra]
+weight = 10
+long_title = "Migration Guide: 0.14 to 0.15"
+public_draft = 1741
++++
+
+{{ migration_guides(version="0.14") }}


### PR DESCRIPTION
Once this is merged, the page will be hidden as a public_draft as long as https://github.com/bevyengine/bevy-website/issues/1741 remains open.