### PR TITLE
Sort migrations by area and improve styling

### DIFF
--- a/content/learn/migration-guides/0.10-to-0.11.md
+++ b/content/learn/migration-guides/0.10-to-0.11.md
@@ -9,7 +9,7 @@ weight = 6
 
 Bevy relies heavily on improvements in the Rust language and compiler.
 As a result, the Minimum Supported Rust Version (MSRV) is "the latest stable release" of Rust.
-<div class="migration-guide">
+<div class="migration-guide-legacy">
 
 ### [Schedule-First: the new and improved add_systems](https://github.com/bevyengine/bevy/pull/8079)
 

--- a/content/learn/migration-guides/0.11-to-0.12.md
+++ b/content/learn/migration-guides/0.11-to-0.12.md
@@ -9,7 +9,7 @@ weight = 7
 
 Bevy relies heavily on improvements in the Rust language and compiler.
 As a result, the Minimum Supported Rust Version (MSRV) is "the latest stable release" of Rust.
-<div class="migration-guide">
+<div class="migration-guide-legacy">
 
 ### [API updates to the AnimationPlayer](https://github.com/bevyengine/bevy/pull/9002)
 

--- a/content/learn/migration-guides/0.12-to-0.13.md
+++ b/content/learn/migration-guides/0.12-to-0.13.md
@@ -8,7 +8,7 @@ long_title = "Migration Guide: 0.12 to 0.13"
 
 Bevy relies heavily on improvements in the Rust language and compiler.
 As a result, the Minimum Supported Rust Version (MSRV) is "the latest stable release" of Rust.
-<div class="migration-guide">
+<div class="migration-guide-legacy">
 
 ### [Support all types of animation interpolation from gltf](https://github.com/bevyengine/bevy/pull/10755)
 

--- a/content/learn/migration-guides/0.9-to-0.10.md
+++ b/content/learn/migration-guides/0.9-to-0.10.md
@@ -9,7 +9,7 @@ weight = 5
 
 Bevy relies heavily on improvements in the Rust language and compiler.
 As a result, the Minimum Supported Rust Version (MSRV) is "the latest stable release" of Rust.
-<div class="migration-guide">
+<div class="migration-guide-legacy">
 
 ### [Migrate engine to Schedule v3 (stageless)](https://github.com/bevyengine/bevy/pull/7267)
 

--- a/generate-release/src/migration_guides.rs
+++ b/generate-release/src/migration_guides.rs
@@ -1,5 +1,4 @@
 use anyhow::Context;
-use rayon::vec;
 use serde::Deserialize;
 
 use crate::{

--- a/generate-release/src/migration_guides.rs
+++ b/generate-release/src/migration_guides.rs
@@ -59,9 +59,9 @@ pub fn generate_migration_guides(
             .transpose()?;
 
         eprintln!("metadata exists? {}", preexisting_metadata.is_some());
-// Populate the metadata to be written with the
-// preexisting metadata so that it is not lost,
-// or overwritten.
+        // Populate the metadata to be written with the
+        // preexisting metadata so that it is not lost,
+        // or overwritten.
         preexisting_metadata
             .map(|metadata| metadata.guides)
             .unwrap_or_default()

--- a/generate-release/src/migration_guides.rs
+++ b/generate-release/src/migration_guides.rs
@@ -57,7 +57,7 @@ pub fn generate_migration_guides(
             .as_deref()
             .map(toml::from_str)
             .transpose()?;
-    
+
         eprintln!("metadata exists? {}", preexisting_metadata.is_some());
 
         preexisting_metadata
@@ -125,7 +125,7 @@ pub fn generate_migration_guides(
                 let b_areas = b.areas.clone().into_iter().collect::<Vec<_>>().join(" ");
 
                 a_areas.cmp(&b_areas)
-            },
+            }
             (false, true) => std::cmp::Ordering::Less,
             (true, false) => std::cmp::Ordering::Greater,
             (true, true) => std::cmp::Ordering::Equal,

--- a/generate-release/src/migration_guides.rs
+++ b/generate-release/src/migration_guides.rs
@@ -1,4 +1,5 @@
 use anyhow::Context;
+use rayon::vec;
 use serde::Deserialize;
 
 use crate::{
@@ -7,7 +8,7 @@ use crate::{
     markdown::write_markdown_section,
 };
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     fs::{self, OpenOptions},
     io::Write as IoWrite,
     path::PathBuf,
@@ -25,7 +26,7 @@ struct MigrationGuides {
 struct MigrationGuide {
     title: String,
     prs: Vec<u64>,
-    areas: Vec<String>,
+    areas: BTreeSet<String>,
     file_name: String,
 }
 
@@ -42,61 +43,46 @@ pub fn generate_migration_guides(
     // Create the directory that will contain all the migration guides
     std::fs::create_dir_all(&path).context(format!("Failed to create {path:?}"))?;
 
-    // We'll write the file once at the end when all the metdaata is generated
-    let mut guides_metadata = Vec::new();
+    let mut guides_metadata = if overwrite_existing {
+        vec![]
+    } else {
+        // If there is metadata that already exists,
+        // and would contain info such as which PR already
+        // has an entry, then get it and use it for that.
+        let preexisting_metadata_file = fs::read_to_string(path.join("_guides.toml")).ok();
+        // Deserializes the file inside the option into the `MigrationGuides` struct,
+        // and then transposes / swaps the internal result of that operation to external,
+        // and returns the error of that result if there is one,
+        // else we have our preexisting metadata, ready to use.
+        let preexisting_metadata: Option<MigrationGuides> = preexisting_metadata_file
+            .as_deref()
+            .map(toml::from_str)
+            .transpose()?;
+    
+        eprintln!("metadata exists? {}", preexisting_metadata.is_some());
 
-    // If there is metadata that already exists,
-    // and would contain info such as which PR already
-    // has an entry, then get it and use it for that.
-    let preexisting_metadata_file = fs::read_to_string(path.join("_guides.toml")).ok();
-    // Deserializes the file inside the option into the `MigrationGuides` struct,
-    // and then transposes / swaps the internal result of that operation to external,
-    // and returns the error of that result if there is one,
-    // else we have our preexisting metadata, ready to use.
-    let preexisting_metadata: Option<MigrationGuides> = preexisting_metadata_file
-        .as_deref()
-        .map(toml::from_str)
-        .transpose()?;
-
-    eprintln!("metadata exists? {}", preexisting_metadata.is_some());
-
-    let mut new_prs = false;
+        preexisting_metadata
+            .map(|metadata| metadata.guides)
+            .unwrap_or_default()
+    };
 
     // Write all the separate migration guide files
     for (area, prs) in areas {
-        let mut prs = prs;
-        // The PRs inside each area are sorted by close date
-        // This doesn't really matter for the final output,
-        // but it's useful to keep the metadata file in the same order between runs
-        prs.sort_by_key(|k| k.1.closed_at);
-
         for (title, pr) in prs {
             // If a PR is already included in the migration guides,
             // then do not generate anything for this PR.
-            //
-            // If overwrite_existing is true, then ignore
-            // if the PRs may have already been generated.
-            if preexisting_metadata.is_some() && !overwrite_existing {
-                let preexisting_metadata = preexisting_metadata.clone().expect(
-                    "that preexisting metadata exists at the _guides.toml for this release version",
-                );
-                let mut pr_already_generated = false;
+            let mut pr_already_generated = false;
 
-                for migration_guide in preexisting_metadata.guides {
-                    if migration_guide.prs.contains(&pr.number) {
-                        pr_already_generated = true;
-                    }
-                }
-
-                if pr_already_generated {
-                    eprintln!("PR #{} already exists", pr.number);
-                    continue;
+            for migration_guide in guides_metadata.iter() {
+                if migration_guide.prs.contains(&pr.number) {
+                    pr_already_generated = true;
                 }
             }
 
-            // If the code has reached this point then that means
-            // there is new PRs to be recorded.
-            new_prs = true;
+            if pr_already_generated {
+                eprintln!("PR #{} already exists", pr.number);
+                continue;
+            }
 
             // Slugify the title
             let title_slug = title
@@ -112,45 +98,62 @@ pub fn generate_migration_guides(
             // 64 is completely arbitrary but felt long enough and is a nice power of 2
             file_name.truncate(64);
 
-            // Generate the metadata block for this migration
-            // We always re-generate it because we need to keep the ordering if a new migration is added
-            let metadata_block = generate_metadata_block(&title, &file_name, &area, pr.number);
+            // Add the markdown extension
+            file_name = format!("{file_name}.md");
 
-            let file_path = path.join(format!("{file_name}.md"));
+            let file_path = path.join(&file_name);
 
             if write_migration_file(
                 &file_path,
                 pr.body.as_ref().context("PR has no body")?,
                 pr.number,
             )? {
-                guides_metadata.push(metadata_block);
+                guides_metadata.push(MigrationGuide {
+                    title,
+                    prs: vec![pr.number],
+                    areas: area.clone().into_iter().collect(),
+                    file_name,
+                });
             }
         }
     }
 
-    if !new_prs {
-        return Ok(());
-    }
+    // Sort by: Area ASC (empty areas at the end), Title ASC
+    guides_metadata.sort_by(|a, b| {
+        let areas_cmp = match (a.areas.is_empty(), b.areas.is_empty()) {
+            (false, false) => {
+                let a_areas = a.areas.clone().into_iter().collect::<Vec<_>>().join(" ");
+                let b_areas = b.areas.clone().into_iter().collect::<Vec<_>>().join(" ");
 
-    let mut guides_toml = if overwrite_existing {
-        // Replace and overwrite file.
-        OpenOptions::new()
-            .write(true)
-            .truncate(true)
-            .create(true)
-            .open(path.join("_guides.toml"))
-            .context("Failed to create _guides.toml")?
-    } else {
-        // Append to the metadata file,
-        // creating it if necessary.
-        OpenOptions::new()
-            .append(true)
-            .create(true)
-            .open(path.join("_guides.toml"))
-            .context("Failed to create _guides.toml")?
-    };
+                a_areas.cmp(&b_areas)
+            },
+            (false, true) => std::cmp::Ordering::Less,
+            (true, false) => std::cmp::Ordering::Greater,
+            (true, true) => std::cmp::Ordering::Equal,
+        };
+
+        areas_cmp.then_with(|| a.title.cmp(&b.title))
+    });
+
+    // Replace and overwrite file.
+    let mut guides_toml = OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .create(true)
+        .open(path.join("_guides.toml"))
+        .context("Failed to create _guides.toml")?;
+
     for metadata in guides_metadata {
-        writeln!(&mut guides_toml, "{metadata}")?;
+        // Generate the metadata block for this migration
+        // We always re-generate it because we need to keep the ordering if a new migration is added
+        let metadata_block = generate_metadata_block(
+            &metadata.title,
+            &metadata.file_name,
+            &metadata.areas.into_iter().collect::<Vec<_>>(),
+            &metadata.prs,
+        );
+
+        writeln!(&mut guides_toml, "{metadata_block}")?;
     }
 
     Ok(())
@@ -201,15 +204,20 @@ fn generate_metadata_block(
     title: &str,
     file_name: &String,
     areas: &[String],
-    pr_number: u64,
+    pr_number: &[u64],
 ) -> String {
     format!(
         r#"[[guides]]
 title = "{title}"
-prs = [{pr_number}]
+prs = [{pr_numbers}]
 areas = [{areas}]
-file_name = "{file_name}.md"
+file_name = "{file_name}"
 "#,
+        pr_numbers = pr_number
+            .iter()
+            .map(|pr| pr.to_string())
+            .collect::<Vec<_>>()
+            .join(", "),
         areas = areas
             .iter()
             .map(|area| format!("\"{area}\""))

--- a/release-content/0.14/migration-guides/_guides.toml
+++ b/release-content/0.14/migration-guides/_guides.toml
@@ -1,46 +1,4 @@
 [[guides]]
-title = "Overhaul `Color`"
-prs = ["12163"]
-areas = ["Color", "Gizmos", "Rendering", "Text", "UI"]
-file_name = "12163_Migrate_from_LegacyColor_to_bevy_colorColor.md"
-
-[[guides]]
-title = "Make default behavior for `BackgroundColor` and `BorderColor` more intuitive"
-prs = ["14017"]
-areas = ["Rendering", "UI"]
-file_name = "14017_Make_default_behavior_for_BackgroundColor_and_BorderColor_.md"
-
-[[guides]]
-title = "Register missing types manually"
-prs = ["12314"]
-areas = ["Reflection"]
-file_name = "12314_Clean_up_type_registrations.md"
-
-[[guides]]
-title = "`OnEnter` state schedules now run before Startup schedules"
-prs = ["11426"]
-areas = ["App", "ECS"]
-file_name = "11426_on_enter_startup_states.md"
-
-[[guides]]
-title = "Fix `Node2d` typo"
-prs = ["12038"]
-areas = []
-file_name = "12038_fix_some_typos.md"
-
-[[guides]]
-title = "Update to `fixedbitset` 0.5"
-prs = ["12512"]
-areas = []
-file_name = "12512_Update_to_fixedbitset_05.md"
-
-[[guides]]
-title = "Move WASM panic handler from `LogPlugin` to `PanicHandlerPlugin`"
-prs = ["12557"]
-areas = []
-file_name = "12557_refactor_separate_out_PanicHandlerPlugin.md"
-
-[[guides]]
 title = "`AnimationClip` now uses UUIDs and `NoOpTypeIdHash` is now `NoOpHash`"
 prs = ["11707"]
 areas = ["Animation"]
@@ -57,6 +15,12 @@ title = "Multiplying colors by `f32` no longer ignores alpha channel"
 prs = ["12575"]
 areas = ["Animation", "Color", "Math", "Rendering"]
 file_name = "12575_Color_maths_4.md"
+
+[[guides]]
+title = "`OnEnter` state schedules now run before Startup schedules"
+prs = ["11426"]
+areas = ["App", "ECS"]
+file_name = "11426_on_enter_startup_states.md"
 
 [[guides]]
 title = "Separate `SubApp` from `App`"
@@ -147,6 +111,12 @@ title = "Fix leftover references to children when despawning audio entities"
 prs = ["12407"]
 areas = ["Audio"]
 file_name = "12407_Fix_leftover_references_to_children_when_despawning_audio_.md"
+
+[[guides]]
+title = "Overhaul `Color`"
+prs = ["12163"]
+areas = ["Color", "Gizmos", "Rendering", "Text", "UI"]
+file_name = "12163_Migrate_from_LegacyColor_to_bevy_colorColor.md"
 
 [[guides]]
 title = "Move WGSL math constants and color operations from `bevy_pbr` to `bevy_render`"
@@ -341,6 +311,12 @@ areas = ["Gizmos"]
 file_name = "13261_More_gizmos_builders.md"
 
 [[guides]]
+title = "Contextually clearing gizmos"
+prs = ["10973"]
+areas = ["Gizmos"]
+file_name = "10973_Contextually_clearing_gizmos.md"
+
+[[guides]]
 title = "Rename touchpad input to gesture"
 prs = ["13660"]
 areas = ["Input"]
@@ -357,6 +333,12 @@ title = "Add `WinitEvent::KeyboardFocusLost`"
 prs = ["13678"]
 areas = ["Input", "Windowing"]
 file_name = "13678_flush_key_input_cache_when_Bevy_loses_focus_Adopted.md"
+
+[[guides]]
+title = "Separating Finite and Infinite 3d Planes"
+prs = ["12426"]
+areas = ["Math", "Rendering"]
+file_name = "12426_separating_finite_and_infinite_3d_planes.md"
 
 [[guides]]
 title = "Move direction types out of `bevy::math::primitives`"
@@ -443,6 +425,12 @@ areas = ["Math", "Utils"]
 file_name = "12732_Move_FloatOrd_into_bevy_math.md"
 
 [[guides]]
+title = "Register missing types manually"
+prs = ["12314"]
+areas = ["Reflection"]
+file_name = "12314_Clean_up_type_registrations.md"
+
+[[guides]]
 title = "Change `ReflectSerialize` trait bounds"
 prs = ["12024"]
 areas = ["Reflection"]
@@ -471,6 +459,12 @@ title = "Serialize scene with `&TypeRegistry` and rename `serialize_ron()` to `s
 prs = ["12715"]
 areas = ["Reflection", "Scenes"]
 file_name = "12715_Fix_TypeRegistry_use_in_dynamic_scene.md"
+
+[[guides]]
+title = "Make default behavior for `BackgroundColor` and `BorderColor` more intuitive"
+prs = ["14017"]
+areas = ["Rendering", "UI"]
+file_name = "14017_Make_default_behavior_for_BackgroundColor_and_BorderColor_.md"
 
 [[guides]]
 title = "Rename `Camera3dBundle::dither` to `deband_dither`"
@@ -767,13 +761,19 @@ areas = ["Windowing"]
 file_name = "13366_fix_upgrade_to_winit_v030.md"
 
 [[guides]]
-title = "Separating Finite and Infinite 3d Planes"
-prs = ["12426"]
-areas = ["Math", "Rendering"]
-file_name = "12426_separating_finite_and_infinite_3d_planes.md"
+title = "Fix `Node2d` typo"
+prs = ["12038"]
+areas = []
+file_name = "12038_fix_some_typos.md"
 
 [[guides]]
-title = "Contextually clearing gizmos"
-prs = ["10973"]
-areas = ["Gizmos"]
-file_name = "10973_Contextually_clearing_gizmos.md"
+title = "Update to `fixedbitset` 0.5"
+prs = ["12512"]
+areas = []
+file_name = "12512_Update_to_fixedbitset_05.md"
+
+[[guides]]
+title = "Move WASM panic handler from `LogPlugin` to `PanicHandlerPlugin`"
+prs = ["12557"]
+areas = []
+file_name = "12557_refactor_separate_out_PanicHandlerPlugin.md"

--- a/sass/pages/_content.scss
+++ b/sass/pages/_content.scss
@@ -5,7 +5,7 @@ $content-font-size: 1.22rem;
   font-size: $content-font-size;
   font-weight: 400;
   line-height: 1.43;
-  color: #d2d2d2;
+  color: #bbb;
   font-style: normal;
   text-decoration: none;
   word-break: break-word;

--- a/sass/pages/_migration_guide.scss
+++ b/sass/pages/_migration_guide.scss
@@ -1,9 +1,85 @@
 .migration-guide {
+  h1, h2, h3 {
+    color: #eee;
+  }
+
+  h2 {
+    margin-block: 5rem 1rem;
+
+    &:first-child {
+      margin-top: 3rem;
+    }
+  }
+
+  h2 + h3 {
+    margin-top: 0;
+    padding-top: 0;
+    border-top: 0;
+    text-wrap: pretty;
+  }
+
+  h3 {
+    margin-block: 2rem .5rem;
+    padding-top: 2rem;
+    border-top: solid rgba(#fff, 0.05) 1px;
+  }
+}
+
+.migration-guide-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  list-style: none;
+  padding: 0px !important;
+  margin: 0px 0px 1rem !important;
+
+  li {
+    font-size: 0.9rem;
+  }
+
+  &__area {
+    padding: 0.2rem 0.3rem;
+    line-height: 1;
+    border-radius: 0.2rem;
+    border-style: solid;
+    border-width: 1px;
+    color: #888;
+  }
+}
+
+.migration-guide-legacy {
   h3 {
     margin-top: 2rem;
     padding-top: 2rem;
     margin-bottom: 0.1rem;
     border-top: solid darken($color-white, 60%) 1px;
+  }
+
+  .migration-guide-area-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.2rem;
+    color: gray;
+  }
+
+  .migration-guide-area-tag {
+    display: block;
+    font-size: 0.8rem;
+    padding-left: 0.2rem;
+    padding-right: 0.2rem;
+    padding-top: 0.2rem;
+    padding-bottom: 0.2rem;
+    margin-top: 0.3rem;
+    margin-bottom: 0.3rem;
+    line-height: 1;
+    border-radius: 0.3rem;
+    border-style: solid;
+    border-width: 1px;
+  }
+
+  ul.migration-guide-pr-list {
+    list-style: none;
+    padding: 0px;
   }
 
   p,
@@ -13,31 +89,3 @@
     font-size: 1rem;
   }
 }
-
-.migration-guide-area-tags {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.2rem;
-  color: gray;
-}
-
-.migration-guide-area-tag {
-  display: block;
-  font-size: 0.8rem;
-  padding-left: 0.2rem;
-  padding-right: 0.2rem;
-  padding-top: 0.2rem;
-  padding-bottom: 0.2rem;
-  margin-top: 0.3rem;
-  margin-bottom: 0.3rem;
-  line-height: 1;
-  border-radius: 0.3rem;
-  border-style: solid;
-  border-width: 1px;
-}
-
-ul.migration-guide-pr-list {
-  list-style: none;
-  padding: 0px;
-}
-

--- a/templates/shortcodes/migration_guides.md
+++ b/templates/shortcodes/migration_guides.md
@@ -3,7 +3,6 @@
 {% set base_path = macros::release_path(version=version, path="/migration-guides/") %}
 {% set guides_data = load_data(path=macros::path_join(path_a=base_path, path_b="/_guides.toml")) %}
 {% set previous_area = "" %}
-{% set area_changed = false %}
 
 <aside class="callout callout--warning">
   <p>Bevy relies heavily on improvements in the Rust language and compiler. As a result, the Minimum Supported Rust Version (MSRV) is "the latest stable release" of Rust.</p>
@@ -17,7 +16,6 @@
 {% else %}
 {% set area_name = "Without area" %}
 {% endif %}
-
 {% set area_changed = area_name != previous_area %}
 
 {% if area_changed %}

--- a/templates/shortcodes/migration_guides.md
+++ b/templates/shortcodes/migration_guides.md
@@ -2,6 +2,8 @@
 
 {% set base_path = macros::release_path(version=version, path="/migration-guides/") %}
 {% set guides_data = load_data(path=macros::path_join(path_a=base_path, path_b="/_guides.toml")) %}
+{% set previous_area = "" %}
+{% set area_changed = false %}
 
 <aside class="callout callout--warning">
   <p>Bevy relies heavily on improvements in the Rust language and compiler. As a result, the Minimum Supported Rust Version (MSRV) is "the latest stable release" of Rust.</p>
@@ -10,19 +12,29 @@
 <div class="migration-guide">
 {% for guide in guides_data.guides %}
 {% set guide_body = load_data(path=macros::path_join(path_a=base_path, path_b=guide.file_name)) %}
+{% if guide.areas[0] %}
+{% set area_name = guide.areas[0] %}
+{% else %}
+{% set area_name = "Without area" %}
+{% endif %}
+
+{% set area_changed = area_name != previous_area %}
+
+{% if area_changed %}
+{% set_global previous_area = area_name %}
+## {{ area_name }}
+{% endif %}
 
 ### {{ guide.title }}
-<ul class="migration-guide-pr-list">
+
+<ul class="migration-guide-meta">
 {% for pr in guide.prs %}
-<li><a href="https://github.com/bevyengine/bevy/pull/{{ pr }}">PR #{{ pr }}</a></li>
+<li class="migration-guide-meta__pr"><a href="https://github.com/bevyengine/bevy/pull/{{ pr }}">PR #{{ pr }}</a></li>
+{% endfor %}
+{% for area in guide.areas %}
+<li class="migration-guide-meta__area">{{ area }}</li>
 {% endfor %}
 </ul>
-
-<div class="migration-guide-area-tags">
-{% for area in guide.areas %}
-<div class="migration-guide-area-tag">{{ area }}</div>
-{% endfor %}
-</div>
 
 {{ guide_body }}
 


### PR DESCRIPTION
- Change `migration_guides.rs` so that it generates sorted `_guides.toml` each time
- Add area sections in migration guides and improve styling

https://github.com/user-attachments/assets/c45dc82e-2360-4f3a-923d-18ac1b021945

