### PR TITLE
Scripts for rc

### DIFF
--- a/content/learn/contribute/project-information/release-process.md
+++ b/content/learn/contribute/project-information/release-process.md
@@ -87,7 +87,7 @@ git checkout latest
 git checkout -b release-$version
 echo
 
-prs=`gh pr list --repo bevyengine/bevy --search "milestone:$version" --state merged --json mergeCommit,mergedAt,title,number`
+prs=`gh pr list --repo bevyengine/bevy --search "milestone:$version" --state merged --json mergeCommit,mergedAt,title,number --limit 100`
 while read -r commit number title <&3; do
     echo "PR #$number: $title (https://github.com/bevyengine/bevy/pull/$number)"    
     if git cherry-pick $commit; then

--- a/content/learn/contribute/project-information/release-process.md
+++ b/content/learn/contribute/project-information/release-process.md
@@ -164,7 +164,7 @@ done 3<<(echo $prs | jq --raw-output '. |= sort_by(.mergedAt) | .[] | "\(.mergeC
 
 1. Update Bevy version used for Bevy's website's `learning-code-examples` tool (code example validation and formatting for the learning materials) to latest release.
 2. Check that docs.rs was able to build the documentation of all crates
-```shell
+```sh
 version="0.X.0-rc.Y"
 for crate in `cargo test -p 2>&1 | grep '  bevy'`
 do

--- a/content/learn/contribute/project-information/release-process.md
+++ b/content/learn/contribute/project-information/release-process.md
@@ -136,6 +136,14 @@ done 3<<(echo $prs | jq --raw-output '. |= sort_by(.mergedAt) | .[] | "\(.mergeC
 #### RC Post-Release
 
 1. Update Bevy version used for Bevy's website's `learning-code-examples` tool (code example validation and formatting for the learning materials) to latest release.
+2. Check that docs.rs was able to build the documentation of all crates
+```shell
+version="0.X.0-rc.Y"
+for crate in `cargo test -p 2>&1 | grep '  bevy'`
+do
+    curl -s -i https://docs.rs/crate/$crate/$version | grep "failed to build" | grep $version
+done
+```
 
 [`update-screenshots` workflow]: https://github.com/bevyengine/bevy-website/actions/workflows/update-screenshots.yml
 [`build-wasm-examples` workflow]: https://github.com/bevyengine/bevy-website/actions/workflows/build-wasm-examples.yml


### PR DESCRIPTION
add some helper scripts that I wrote for the 0.15 rc:
* script to check that all crate docs are correctly built on docs.rs
* script to merge all the merged PRs from a milestone to a branch that are not already on that branch
* also increase the number of PRs queried in the patch script for the day we have more than 30 PRs in a patch