### PR TITLE
Remove deprecate is_playing_animation release notes

### DIFF
--- a/release-content/0.15/migration-guides/14387_Deprecate_is_playing_animation.md
+++ b/release-content/0.15/migration-guides/14387_Deprecate_is_playing_animation.md
@@ -1,1 +1,0 @@
-The user will just need to replace functions named `is_playing_animation` with `animation_is_playing`.

--- a/release-content/0.15/migration-guides/_guides.toml
+++ b/release-content/0.15/migration-guides/_guides.toml
@@ -11,12 +11,6 @@ areas = []
 file_name = "15973_Remove_AVIF_feature.md"
 
 [[guides]]
-title = "Deprecate `is_playing_animation`"
-prs = [14387]
-areas = ["Animation"]
-file_name = "14387_Deprecate_is_playing_animation.md"
-
-[[guides]]
 title = "Make `AnimationPlayer::start` and `::play` work accordingly to documentation"
 prs = [14546]
 areas = ["Animation"]


### PR DESCRIPTION
Pretty sure all I need to do is remove these two things, but let me know if this isn't the right way to remove this from the migration guide.

Refs https://github.com/bevyengine/bevy/pull/16121