### PR TITLE
Add 0.15 release notes for `Reflectable`

### DIFF
--- a/release-content/0.15/release-notes/5772_bevy_reflect_Add_Reflectable_trait.md
+++ b/release-content/0.15/release-notes/5772_bevy_reflect_Add_Reflectable_trait.md
@@ -1,4 +1,16 @@
-<!-- bevy_reflect: Add `Reflectable` trait -->
-<!-- https://github.com/bevyengine/bevy/pull/5772 -->
+Bevy's reflection crate, [`bevy_reflect`], is powered by many different traits working together
+to provide the full reflection API. These include traits like [`Reflect`], but also other traits
+like [`TypePath`], [`Typed`], and [`GetTypeRegistration`].
 
-<!-- TODO -->
+This can make adding the right bounds on generic parameters a bit confusing,
+and it's easy to forget to include one of these traits.
+
+To make this simpler, 0.15 introduces the [`Reflectable`] trait. All the traits listed above are
+supertraits of `Reflectable`, allowing it to be used in place of all of them where necessary.
+
+[`bevy_reflect`]: https://docs.rs/bevy_reflect/0.15/bevy_reflect/
+[`Reflect`]: https://docs.rs/bevy_reflect/0.15/bevy_reflect/trait.Reflect.html
+[`TypePath`]: https://docs.rs/bevy_reflect/0.15/bevy_reflect/trait.TypePath.html
+[`Typed`]: https://docs.rs/bevy_reflect/0.15/bevy_reflect/trait.Typed.html
+[`GetTypeRegistration`]: https://docs.rs/bevy_reflect/0.15/bevy_reflect/trait.GetTypeRegistration.html
+[`Reflectable`]: https://docs.rs/bevy_reflect/0.15/bevy_reflect/trait.Reflectable.html


### PR DESCRIPTION
Fixes #1687

I chose not to include a code snippet here as I didn't think it was particularly interesting to show `T: Reflect + GetTypeRegistration + Typed + TypePath` -> `T: Reflectable`, but let me know if it would be better with an example!