### PR TITLE
Remove insert_if_new release notes

### DIFF
--- a/release-content/0.15/release-notes/14646_feat_add_insert_if_new_14397.md
+++ b/release-content/0.15/release-notes/14646_feat_add_insert_if_new_14397.md
@@ -1,4 +1,0 @@
-<!-- feat: add `insert_if_new` (#14397) -->
-<!-- https://github.com/bevyengine/bevy/pull/14646 -->
-
-<!-- TODO -->

--- a/release-content/0.15/release-notes/_release-notes.toml
+++ b/release-content/0.15/release-notes/_release-notes.toml
@@ -132,13 +132,6 @@ prs = [6042]
 file_name = "6042_bevy_reflect_Reflect_remote_types.md"
 
 [[release_notes]]
-title = "feat: add `insert_if_new` (#14397)"
-authors = ["@jpetkau"]
-contributors = ["@SkiFire13", "@alice-i-cecile"]
-prs = [14646]
-file_name = "14646_feat_add_insert_if_new_14397.md"
-
-[[release_notes]]
 title = "Allow fog density texture to be scrolled over time with an offset"
 authors = ["@jirisvd"]
 contributors = []


### PR DESCRIPTION
Closes #1675. Closes #1732.

As the linked PR discusses, it's quite hard to motivate this API with the removal of first-party bundles and generally deprioritization of the pattern.

I still think the API is useful to have in Bevy, but it's gone from "very helpful" to "niche" with the required components changes, and I don't think it warrants a release note.