### PR TITLE
Remove text batching release notes

### DIFF
--- a/release-content/0.15/release-notes/14848_Improved_text_batching.md
+++ b/release-content/0.15/release-notes/14848_Improved_text_batching.md
@@ -1,4 +1,0 @@
-<!-- Improved text batching -->
-<!-- https://github.com/bevyengine/bevy/pull/14848 -->
-
-<!-- TODO -->

--- a/release-content/0.15/release-notes/_release-notes.toml
+++ b/release-content/0.15/release-notes/_release-notes.toml
@@ -410,13 +410,6 @@ prs = [15204]
 file_name = "15204_box_shadow.md"
 
 [[release_notes]]
-title = "Improved text batching"
-authors = ["@ickshonpe"]
-contributors = ["@kristoff3r"]
-prs = [14848]
-file_name = "14848_Improved_text_batching.md"
-
-[[release_notes]]
 title = "Add mesh picking backend and `MeshRayCast` system parameter"
 authors = ["@Jondolf"]
 contributors = ["@mockersf", "@tbillington", "@aevyrie"]


### PR DESCRIPTION
As discussed in #1722, these no longer warrant a release note due to the additional performance-impacting changes.