### PR TITLE
Add stub for Bevy 0.15 release blog post

### DIFF
--- a/content/news/2024-??-??-bevy-0.15/index.md
+++ b/content/news/2024-??-??-bevy-0.15/index.md
@@ -1,0 +1,40 @@
++++
+title = "Bevy 0.15"
+date = 2024-12-31 # TODO, fix date
+draft = true
+[extra]
+image = "cover.jpg" # TODO, add cover image
+show_image = true
+image_subtitle = "TODO"
+image_subtitle_link = "https://github.com/TODO"
++++
+
+Thanks to **TODO** contributors, **TODO** pull requests, community reviewers, and our [**generous donors**](/donate), we're happy to announce the **Bevy 0.15** release on [crates.io](https://crates.io/crates/bevy)!
+
+For those who don't know, Bevy is a refreshingly simple data-driven game engine built in Rust. You can check out our [Quick Start Guide](/learn/quick-start) to try it today. It's free and open source forever! You can grab the full [source code](https://github.com/bevyengine/bevy) on GitHub. Check out [Bevy Assets](https://bevyengine.org/assets) for a collection of community-developed plugins, games, and learning resources.
+
+To update an existing Bevy App or Plugin to **Bevy 0.15**, check out our [0.14 to 0.15 Migration Guide](/learn/migration-guides/0-14-to-0-15/).
+
+Since our last release a few months ago we've added a _ton_ of new features, bug fixes, and quality of life tweaks, but here are some of the highlights:
+
+- TODO
+
+As is now tradition, Bevy 0.15 was prepared using a **release candidate** process to help ensure that you can upgrade right away with peace of mind.
+We've worked closely with both plugin authors and ordinary users to catch critical bugs, round the rough corners off our new features, and refine the migration guide.
+As we prepared fixes, we've [shipped new release candidates on crates.io](https://crates.io/crates/bevy/versions?sort=date), letting core ecosystem crates update and listening closely for show-stopping problems.
+Thank you so much to [everyone who helped out](https://discord.com/channels/691052431525675048/1295069829740499015): these efforts are a vital step towards making Bevy something that teams large and small can trust to work reliably.
+
+<!-- more -->
+
+{{ release_notes(version="0.15") }}
+
+## What's Next?
+
+The features above may be great, but what else does Bevy have in flight?
+Peering deep into the mists of time (predictions are _extra_ hard when your team is almost all volunteers!), we can see some exciting work taking shape:
+
+- TODO
+
+{{ support_bevy() }}
+{{ contributors(version="0.15") }}
+{{ changelog(version="0.15")}}


### PR DESCRIPTION
Apparently this stub didn't exist yet! I needed this for #1730, and it's cleaner to ship this as its own PR.

When reviewing, please be *very* sure that I didn't screw up the draft status of the post.

Sections marked TODO are, you know, still to be done. I've used a consistent symbol so we can easily double check before publication.