### PR TITLE
Use single quotes in TOML for contributors

### DIFF
--- a/generate-release/src/contributors.rs
+++ b/generate-release/src/contributors.rs
@@ -49,7 +49,7 @@ pub fn generate_contributors(
         writeln!(
             output,
             r#"[[contributors]]
-name = "{name}"
+name = '{name}'
 "#
         )?;
     }


### PR DESCRIPTION
Per doup's suggestion to avoid escaping issues with WX\\shixi contributor name. I did a couple check runs, output looks pretty sensible.

Closes #1728.