### PR TITLE
Hide example progress bar by default

### DIFF
--- a/sass/components/_bevy-instance.scss
+++ b/sass/components/_bevy-instance.scss
@@ -9,6 +9,7 @@
     left: 50%;
     width: 250px;
     transform: translateX(-50%);
+    display: none;
 
     &:empty {
       display: none;


### PR DESCRIPTION
Before this PR the behavior was:
- the progress bar HTML is visible by default
- the progress bar JS shows the progress bar when it starts loading an asset and hides the progress bar when it finishes the loading

The problem is that some examples don't have any asset so they don't run the JS script, hence the progress bar stays visible. This PR changes the default style for the progress bar to `hidden` to avoid this issue.

Fixes #1795.