### PR TITLE
Revert to old content font color

### DIFF
--- a/sass/pages/_content.scss
+++ b/sass/pages/_content.scss
@@ -5,7 +5,7 @@ $content-font-size: 1.22rem;
   font-size: $content-font-size;
   font-weight: 400;
   line-height: 1.43;
-  color: #bbb;
+  color: #d2d2d2;
   font-style: normal;
   text-decoration: none;
   word-break: break-word;


### PR DESCRIPTION
#1743 changed the default content font color in a way that significantly reduced contrast. The old color was a better default content color.