### PR TITLE
Rewrite the migration guide for PR 14842

### DIFF
--- a/release-content/0.15/migration-guides/14842_Replace_the_wgpu_trace_feature_with_a_field_in_bevy_render.md
+++ b/release-content/0.15/migration-guides/14842_Replace_the_wgpu_trace_feature_with_a_field_in_bevy_render.md
@@ -1,6 +1,12 @@
-- The `bevy/wgpu_trace`, `bevy_render/wgpu_trace`, and `bevy_internal/wgpu_trace` features no longer exist. Remove them from your `Cargo.toml`, CI, tooling, and what-not.
-- Follow the instructions in the updated `docs/debugging.md` file in the repository, under the WGPU Tracing section.
+The `bevy/wgpu_trace` and `bevy_render/wgpu_trace` features have been removed, as WGPU tracing is now enabled during the creation of `bevy_render::RenderPlugin`.
 
-Because of the changes made, you can now generate traces to any path, rather than the hardcoded `%WorkspaceRoot%/wgpu_trace` (where `%WorkspaceRoot%` is… the root of your crate’s workspace) folder.
+{% callout(type="info") %}
+At the time of writing, WGPU has not reimplemented tracing support, so WGPU tracing will not currently work. However, once WGPU has reimplemented tracing support, the steps below should be sufficient to continue generating WGPU traces.
 
-(If WGPU hasn’t restored tracing functionality…) Do note that WGPU has not yet restored tracing functionality. However, once it does, the above should be sufficient to generate new traces.
+You can track the progress of WGPU tracing being reimplemented at [gfx-rs/wgpu#5974](https://github.com/gfx-rs/wgpu/issues/5974).
+{% end %}
+
+To continue generating WGPU traces:
+
+1. Remove any instance of `bevy/wgpu_trace` or `bevy_render/wgpu_trace` you may have from any `Cargo.toml` files.
+2. Follow the instructions in `docs/debugging.md` file in the repository, under the WGPU Tracing section.

--- a/release-content/0.15/migration-guides/14842_Replace_the_wgpu_trace_feature_with_a_field_in_bevy_render.md
+++ b/release-content/0.15/migration-guides/14842_Replace_the_wgpu_trace_feature_with_a_field_in_bevy_render.md
@@ -8,5 +8,5 @@ You can track the progress of WGPU tracing being reimplemented at [gfx-rs/wgpu#5
 
 To continue generating WGPU traces:
 
-1. Remove any instance of `bevy/wgpu_trace` or `bevy_render/wgpu_trace` you may have from any `Cargo.toml` files.
+1. Remove any instance of the `bevy/wgpu_trace` or `bevy_render/wgpu_trace` features you may have in any of your `Cargo.toml` files.
 2. Follow the instructions in `docs/debugging.md` file in the repository, under the WGPU Tracing section.

--- a/release-content/0.15/migration-guides/14842_Replace_the_wgpu_trace_feature_with_a_field_in_bevy_render.md
+++ b/release-content/0.15/migration-guides/14842_Replace_the_wgpu_trace_feature_with_a_field_in_bevy_render.md
@@ -9,4 +9,4 @@ You can track the progress of WGPU tracing being reimplemented at [gfx-rs/wgpu#5
 To continue generating WGPU traces:
 
 1. Remove any instance of the `bevy/wgpu_trace` or `bevy_render/wgpu_trace` features you may have in any of your `Cargo.toml` files.
-2. Follow the instructions in `docs/debugging.md` file in the repository, under the WGPU Tracing section.
+2. Follow the instructions in [`docs/debugging.md`, under the WGPU Tracing section](https://github.com/bevyengine/bevy/blob/release-0.15.0/docs/debugging.md#wgpu-tracing).


### PR DESCRIPTION
When I initially wrote the migration guide for https://github.com/bevyengine/bevy/pull/14842, I was under the impression that it would be read and rewritten to better suit the migration guide.

However, I wasn't aware that there were tools being used to create the migration guides, much less that they would copy my migration guide verbatim.

Realizing this, I decided to rewrite this migration guide. I'm much happier with the result - though any feedback is welcome!

P.S. Thanks to @TrialDragon for teaching me how to make a note callout!