### PR TITLE
Behead Headless Plugins release notes

### DIFF
--- a/release-content/0.15/release-notes/15260_Added_HeadlessPlugins_15203.md
+++ b/release-content/0.15/release-notes/15260_Added_HeadlessPlugins_15203.md
@@ -1,4 +1,0 @@
-<!-- Added `HeadlessPlugins` (#15203) -->
-<!-- https://github.com/bevyengine/bevy/pull/15260 -->
-
-<!-- TODO -->

--- a/release-content/0.15/release-notes/_release-notes.toml
+++ b/release-content/0.15/release-notes/_release-notes.toml
@@ -202,13 +202,6 @@ prs = [5772]
 file_name = "5772_bevy_reflect_Add_Reflectable_trait.md"
 
 [[release_notes]]
-title = "Added `HeadlessPlugins` (#15203)"
-authors = ["@Wcubed"]
-contributors = []
-prs = [15260]
-file_name = "15260_Added_HeadlessPlugins_15203.md"
-
-[[release_notes]]
 title = "Add cached `run_system` API"
 authors = ["@benfrankel"]
 contributors = []


### PR DESCRIPTION
This was tackled a different way in https://github.com/bevyengine/bevy/pull/16401, and probably doesn't warrant a release note in its current form.

Closes #1689.