### PR TITLE
Add domain verification file for Bluesky/AT Proto

### DIFF
--- a/static/.well-known/atproto-did
+++ b/static/.well-known/atproto-did
@@ -1,0 +1,1 @@
+did:plc:rurf32i2ytudjhvyytliz7ct


### PR DESCRIPTION
This should allow changing the handle from `@bevy.bsky.social` to `@bevyengine.org`, matching the official website domain. Assuming that GitHub pages doesn't mess up the deploy/serving of `.well-known`.