### PR TITLE
Improve release note styling

### DIFF
--- a/release-content/0.15/release-notes/14920_Add_cached_run_system_API.md
+++ b/release-content/0.15/release-notes/14920_Add_cached_run_system_API.md
@@ -31,10 +31,10 @@ let id2 = world.register_system_cached(quux);
 assert!(id1 == id2);
 ```
 
-## Comparison to `run_system_once`
+### Comparison to `run_system_once`
 
 There were two ways to run one-shot systems, and now there are three. The approach taken by `run_system_once` is to set up a system, run it once, and then tear it down. This means that `run_system_once` _does_ avoid the memory leak problem. However, any system parameters like `Local` and `EventReader` that rely on persistent state between runs will be broken; and any system parameters like `Query` that rely on cached computations to improve performance will have to rebuild their cache each time, which can be costly. As a consequence, `run_system_once` is only recommended for diagnostic use (e.g. unit tests), and `run_system` or `run_system_cached` should be preferred for "real" code.
 
-## Limitations
+### Limitations
 
 The cached API can only work if it can guarantee that different systems are never cached under the same `CachedSystemId<S>`. In other words, there should be no more than 1 distinct system of type `S`. This is true when `size_of::<S>() == 0`, which is almost always true in practice. Thus, to enforce correctness, the new API will give you a compile-time error if you try to use a non-zero-sized function (like a function pointer or a capturing closure).

--- a/release-content/0.15/release-notes/15276_Reduce_runtime_panics_through_SystemParam_validation.md
+++ b/release-content/0.15/release-notes/15276_Reduce_runtime_panics_through_SystemParam_validation.md
@@ -39,7 +39,7 @@ Additionally, few new system params were introduced to simplify existing code:
 - `Option<Single<D, F>>` - Works like `Query<D, F>::single`, fails if query contains more than 1 match,
 - [`Populated<D, F>`] - Works like a `Query<D, F>`, fails if query contains no matches.
 
-## Warnings
+### Warnings
 
 Fallible system params come with a primitive warning mechanic.
 Currently, systems can behave in one of two ways:

--- a/release-content/0.15/release-notes/15800_Add_mesh_picking_backend_and_MeshRayCast_system_parameter.md
+++ b/release-content/0.15/release-notes/15800_Add_mesh_picking_backend_and_MeshRayCast_system_parameter.md
@@ -26,7 +26,7 @@ In Bevy 0.15, we're shipping three first-party picking backends for UI, sprites,
 
 We expect both [`bevy_rapier`] and [`avian`] (the two most popular ecosystem physics crates for Bevy) to add their own accelerated collider picking backends to work with the newly upstreamed API. Unless you're debugging, building an editor or really care about the exact triangles of raw meshes, you should use one of those crates for efficient mesh picking.
 
-## Usage
+### Usage
 
 If you haven't used `bevy_picking`'s predecessor, there are two important and straightforward ways to get started with the API.
 

--- a/sass/pages/_news.scss
+++ b/sass/pages/_news.scss
@@ -41,16 +41,25 @@
 }
 
 .release-feature-authors {
-  margin-top: -0.5rem !important;
+  margin-top: -0.8rem !important;
   font-style: italic;
   color: $subtitle-color;
 }
 
 .release-feature-meta {
   @extend .release-feature-authors;
+  display: flex;
+  gap: 5px;
+  font-size: 1.0rem;
+  flex-wrap: wrap;
+}
 
-  padding: 0 !important;
-  list-style: none;
+.release-feature-meta-item {
+  color: #b8b8b8 !important;
+}
+
+.release-feature-meta-title {
+  margin-right: 4px;
 }
 
 .news-image-subtitle {

--- a/templates/shortcodes/release_notes.md
+++ b/templates/shortcodes/release_notes.md
@@ -5,14 +5,20 @@
 {% for release_note in release_notes_data.release_notes %}
 {% set release_note_body = load_data(path=macros::path_join(path_a=base_path, path_b=release_note.file_name)) %}
 
-### {{ release_note.title }}
+## {{ release_note.title }}
 
-<ul class="release-feature-meta">
-  <li>Authors: {{ release_note.authors | join(sep=", ")}}</li>
-  {% for pr in release_note.prs %}
-  <li><a href="https://github.com/bevyengine/bevy/pull/{{ pr }}">PR #{{ pr }}</a></li>
-  {% endfor %}
-</ul>
+<div class="release-feature-meta">
+  <div>
+    <span class="release-feature-meta-title">Authors:</span>
+    {% for author in release_note.authors %}{% if author is starting_with("@") %}<a href="https://github.com/{{ author | trim_start_matches(pat="@") }}" class="release-feature-meta-item">{{ author }}</a>{% else %}<span class="release-feature-meta-item">{{ author }}</span>{% endif %}{% if not loop.last %},{% endif %}
+    {% endfor %}
+  </div>
+  <div>
+    <span class="release-feature-meta-title">PRs:</span>
+    {% for pr in release_note.prs %}<a class="release-feature-meta-item" href="https://github.com/bevyengine/bevy/pull/{{ pr }}">#{{ pr }}</a>{% if not loop.last %},{% endif %}
+    {% endfor %}
+  </div>
+</div>
 
 {{ release_note_body | replace(from='POST_PATH', to=page.colocated_path) | markdown }}
 


### PR DESCRIPTION
This improves release note style and functionality in a number of ways:

1. We now link to author github profiles when in the form `@X` 
1. Prefers single-line formatting. This was particularly heinous with new lines for each PR
2. Harmonize "pr" and "author" formatting
2. Group prs under a single "PRs" section, rather than labeling each one `PR #1, PR #2, etc`
3. When breaking lines to run out of room, break by PR/Author section first
4. Makes section headings `##` instead of `###`. They were "too small" in their current form / the wrong section level
5. Reduces prominence of PR / Author sections by reducing font size and replacing blue link color with white
6. Reduced the space between the section heading and the author/pr section. This helps logically group them together / helps the reader easily distinguish between "header" information and content. This is the same approach used for the main title + authors.
7. Fixed a number of "over prominent" subheaders in 0.15 articles

### Before
![image](https://github.com/user-attachments/assets/7a0fb7ca-7861-4acb-b07f-58ca24da3509)

### After
![image](https://github.com/user-attachments/assets/8bba4b9d-3115-45a9-b891-ff1fb5d799cf)
