### PR TITLE
0.15 Editorial Pass 2

### DIFF
--- a/release-content/0.15/release-notes/15013_Implement_animation_masks_allowing_fine_control_of_the_tar.md
+++ b/release-content/0.15/release-notes/15013_Implement_animation_masks_allowing_fine_control_of_the_tar.md
@@ -4,7 +4,7 @@
 Animations now support masking out animation targets (joints).
 This is implemented at the level of animation blend graphs (`AnimationGraph`)
 and can be used to play different animations on separate parts of the
-same model without interfering with one another. This may come up, for example, 
-if you need a character to play separate animations on its upper and lower body.
+same model without interfering with one another. For example, you can play separate animations on a character's upper and lower body.
 
+In this video, the fox's head and legs are playing two separate animations, thanks to animation masks:
 <video controls><source src="masked-animation.mp4" type="video/mp4"/></video>

--- a/release-content/0.15/release-notes/15282_Allow_animation_clips_to_animate_arbitrary_properties.md
+++ b/release-content/0.15/release-notes/15282_Allow_animation_clips_to_animate_arbitrary_properties.md
@@ -1,12 +1,12 @@
 <!-- Allow animation clips to animate arbitrary properties. -->
 <!-- https://github.com/bevyengine/bevy/pull/15282 -->
-Animation clips can now be used to animate component properties with arbitrary curves.
+[`AnimationClip`] can now be used to animate component fields with arbitrary curves.
 
 ```rust
 animation_clip.add_curve_to_target(
     animation_target_id,
     AnimatableCurve::new(
-        AnimatedProperty::new(|font: &mut TextFont| &mut font.font_size),
+        animated_field!(TextFont::font_size),
         // Oscillate the font size during the length of the animation.
         FunctionCurve::new(
             Interval::UNIT, 
@@ -16,26 +16,31 @@ animation_clip.add_curve_to_target(
 );
 ```
 
-This uses the new `Curve` API, which supports arbitrary curve types.
-
 <video controls><source src="animated-font-size.mp4" type="video/mp4"/></video>
 
-Similarly, animations of `Transform` components and morph weights may also be
-specified using arbitrary curves; for example, the type `TranslationCurve` wraps
-a `Curve<Vec3>` and uses it to animate the `translation` part of the target's
-`Transform`.
+This works for any named field and uses the new `Curve` API, which supports arbitrary curve types.
+Animating `Transform` fields will likely be the most common use case:
 
 ```rust
-// Construct a `Curve<Vec3>`` using a built-in easing curve constructor.
-let translation_curve = EasingCurve::new(
-    vec3(-10., 2., 0.),
-    vec3(6., 2., 0.),
-    EaseFunction::CubicInOut,
-);
-
-// Use this `Curve<Vec3>` to animate the `translation` part of `Transform`.
 animation_clip.add_curve_to_target(
     animation_target_id,
-    TranslationCurve(translation_curve)
+    AnimatableCurve::new(
+        animated_field!(Transform::translation),
+        // Construct a `Curve<Vec3>`` using a built-in easing curve constructor.
+        EasingCurve::new(
+            vec3(-10., 2., 0.),
+            vec3(6., 2., 0.),
+            EaseFunction::CubicInOut,
+        )
+    )
 );
 ```
+
+Bevy's internal animation handling for things like GLTF animations uses the same API!
+
+If you need more complicated logic than "animate a specific component field", you can implement [`AnimatableProperty`], which can be used in
+[`AnimatableCurve`] in place of [`animated_field!`].
+
+[`AnimationClip`]: https://dev-docs.bevyengine.org/bevy/animation/struct.AnimationClip.html
+[`AnimatableProperty`]: https://dev-docs.bevyengine.org/bevy/animation/animation_curves/trait.AnimatableProperty.html
+[`AnimatableCurve`]: https://dev-docs.bevyengine.org/bevy/animation/animation_curves/struct.AnimatableCurve.html

--- a/release-content/0.15/release-notes/15800_Add_mesh_picking_backend_and_MeshRayCast_system_parameter.md
+++ b/release-content/0.15/release-notes/15800_Add_mesh_picking_backend_and_MeshRayCast_system_parameter.md
@@ -22,7 +22,7 @@ In Bevy 0.15, we're shipping three first-party picking backends for UI, sprites,
 
 - UI: both the legacy [`Interaction`] and new [`PickingInteraction`] components exist [for now](https://github.com/bevyengine/bevy/issues/15550), with subtle behavioral differences.
 - Sprites: picking always uses the full rectangle, and [alpha transparency is not taken into account](https://github.com/bevyengine/bevy/issues/14929).
-- Mesh: this is a naive raycast against the full mesh. If you run into performance problems here, you should use simplified meshes and an acceleration data structure like a BVH to speed this up. As a result, this functionality is currently disabled by default.
+- Mesh: this is a naive raycast against the full mesh. If you run into performance problems here, you should use simplified meshes and an acceleration data structure like a BVH to speed this up. As a result, this functionality is currently disabled by default. It can be enabled by enabling the [`MeshPickingPlugin`].
 
 We expect both [`bevy_rapier`] and [`avian`] (the two most popular ecosystem physics crates for Bevy) to add their own accelerated collider picking backends to work with the newly upstreamed API. Unless you're debugging, building an editor or really care about the exact triangles of raw meshes, you should use one of those crates for efficient mesh picking.
 
@@ -36,38 +36,18 @@ Secondly, you might want to respond dynamically to various pointer-powered event
 Here, we're spawning a simple text node and responding to pointer events.
 
 ```rust
-use bevy::prelude::*;
+// UI text that prints a message when clicked:
+commands
+    .spawn(Text::new("Click Me!"))
+    .observe(on_click_print_hello);
 
-fn main() {
-    App::new()
-        .add_plugins((DefaultPlugins, MeshPickingPlugin))
-        .add_systems(Startup, setup_scene)
-        .run();
-}
-
-fn setup_scene(
-    mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
-    mut materials: ResMut<Assets<StandardMaterial>>,
-) {
-    // UI text that prints a message when clicked:
-    commands
-        .spawn(Text::new("Click Me!"))
-        .observe(on_click_print_hello);
-
-    // A cube that spins when dragged:
-    commands
-        .spawn((
-            Mesh3d(meshes.add(Cuboid::default())),
-            MeshMaterial3d(materials.add(Color::WHITE)),
-        ))
-        // Picking observers work with *any* entity that has a picking backend running.
-        // Try adding this `on_drag_spin` observer to the UI text! :)
-        .observe(on_drag_spin);
-
-    // Light and camera
-    commands.spawn((PointLight::default(), Transform::from_xyz(4.0, 8.0, 4.0)));
-    commands.spawn((Camera3d::default(), Transform::from_xyz(0.0, 2.0, 9.0)));
+// A cube that spins when dragged:
+commands
+    .spawn((
+        Mesh3d(meshes.add(Cuboid::default())),
+        MeshMaterial3d(materials.add(Color::WHITE)),
+    ))
+    .observe(on_drag_spin);
 }
 
 fn on_click_print_hello(click: Trigger<Pointer<Click>>) {
@@ -94,3 +74,4 @@ If you want to override how an entity interacts with picking, add the [`PickingB
 [`bevy_rapier`]: https://crates.io/crates/bevy_rapier3d
 [`avian`]: https://crates.io/crates/avian3d
 [`PickingBehavior`]: https://docs.rs/bevy/0.15.0/bevy/picking/struct.PickingBehavior.html
+[`MeshPickingPlugin`]: https://docs.rs/bevy/0.15.0/bevy/picking/mesh_picking/struct.MeshPickingPlugin.html

--- a/release-content/0.15/release-notes/15800_Add_mesh_picking_backend_and_MeshRayCast_system_parameter.md
+++ b/release-content/0.15/release-notes/15800_Add_mesh_picking_backend_and_MeshRayCast_system_parameter.md
@@ -22,7 +22,7 @@ In Bevy 0.15, we're shipping three first-party picking backends for UI, sprites,
 
 - UI: both the legacy [`Interaction`] and new [`PickingInteraction`] components exist [for now](https://github.com/bevyengine/bevy/issues/15550), with subtle behavioral differences.
 - Sprites: picking always uses the full rectangle, and [alpha transparency is not taken into account](https://github.com/bevyengine/bevy/issues/14929).
-- Mesh: this is a naive raycast against the full mesh. If you run into performance problems here, you should use simplified meshes and an acceleration data structure like a BVH to speed this up. As a result, this functionality is currently disabled by default. It can be enabled by enabling the [`MeshPickingPlugin`].
+- Mesh: this is a naive raycast against the full mesh. If you run into performance problems here, you should use simplified meshes and an acceleration data structure like a [BVH](https://en.wikipedia.org/wiki/Bounding_volume_hierarchy) to speed this up. As a result, this functionality is currently disabled by default. It can be enabled by enabling the [`MeshPickingPlugin`].
 
 We expect both [`bevy_rapier`] and [`avian`] (the two most popular ecosystem physics crates for Bevy) to add their own accelerated collider picking backends to work with the newly upstreamed API. Unless you're debugging, building an editor or really care about the exact triangles of raw meshes, you should use one of those crates for efficient mesh picking.
 


### PR DESCRIPTION
* Pares down the picking example to its bare essentials
* Adapts property animation to use the changes in https://github.com/bevyengine/bevy/pull/16484
* Adds some clarity to the animation mask section