### PR TITLE
TextUiWriter rename

### DIFF
--- a/release-content/0.15/migration-guides/15591_Text_rework.md
+++ b/release-content/0.15/migration-guides/15591_Text_rework.md
@@ -38,7 +38,7 @@ After:
 ```rust
 fn refresh_text(
     query: Query<Entity, With<TimeText>>,
-    mut writer: UiTextWriter,
+    mut writer: TextUiWriter,
     time: Res<Time>
 ) {
     let entity = query.single();


### PR DESCRIPTION
The data type appears to have been renamed since the guide was written