### PR TITLE
Clean up migration guides without an area

### DIFF
--- a/release-content/0.15/migration-guides/15812_Move_ImageLoader_and_CompressedImageSaver_to_bevy_image.md
+++ b/release-content/0.15/migration-guides/15812_Move_ImageLoader_and_CompressedImageSaver_to_bevy_image.md
@@ -1,1 +1,8 @@
 - `ImageLoader` can no longer be initialized directly through `init_asset_loader`. Now you must use `app.register_asset_loader(ImageLoader::new(supported_compressed_formats))` (check out the implementation of `bevy_render::ImagePlugin`). This only affects you if you are initializing the loader manually and does not affect users of `bevy_render::ImagePlugin`.
+- The asset loader name must be updated in `.meta` files for images.
+Change: `loader: "bevy_render::texture::image_loader::ImageLoader",`
+to: `loader: "bevy_image::image_loader::ImageLoader",`
+
+This will fix the following error:
+
+> `no `AssetLoader` found with the name 'bevy_render::texture::image_loader::ImageLoader`

--- a/release-content/0.15/migration-guides/15945_Fix_asset_settings_example_regression.md
+++ b/release-content/0.15/migration-guides/15945_Fix_asset_settings_example_regression.md
@@ -1,6 +1,0 @@
-This PR obviously requires no migration guide as this is just a bug-fix, but I believe that #15812 should mention that meta files needs updating. Proposal:
-
-- Asset loader name must be updated in `.meta` files for images.
-Change: `loader: "bevy_render::texture::image_loader::ImageLoader",`
-to: `loader: "bevy_image::image_loader::ImageLoader",`
-It will fix the following error: `no `AssetLoader` found with the name 'bevy_render::texture::image_loader::ImageLoader`

--- a/release-content/0.15/migration-guides/_guides.toml
+++ b/release-content/0.15/migration-guides/_guides.toml
@@ -6,12 +6,6 @@ prs = [14449, 15320, 15582, 15756]
 file_name = "15320_Retained_Rendering.md"
 
 [[guides]]
-title = "Fix asset_settings example regression"
-prs = [15945]
-areas = []
-file_name = "15945_Fix_asset_settings_example_regression.md"
-
-[[guides]]
 title = "Remove AVIF feature"
 prs = [15973]
 areas = ["Rendering"]


### PR DESCRIPTION
One of these was genuinely unlabeled, while the other was a weird PR that had a migration guide but not for the changes in the PR itself.

Spotted by examining https://bevyengine.org/learn/migration-guides/0-14-to-0-15/