### PR TITLE
Revise and condense retained rendering migration guide

### DIFF
--- a/release-content/0.15/migration-guides/15320_Retained_Rendering.md
+++ b/release-content/0.15/migration-guides/15320_Retained_Rendering.md
@@ -4,7 +4,7 @@
 <!-- https://github.com/bevyengine/bevy/pull/15582 Synchronized Removed Components -->
 <!-- https://github.com/bevyengine/bevy/pull/15756 Type Safe Retained Render World -->
 
-With the advent of the retained render world, entities are no longer despawned at the end of every frame.
+With the advent of the retained render world, entities are no longer despawned at the end of every frame in the render world.
 Extracted entities with the `TemporaryRenderEntity` component will be despawned at the end of every frame like before.
 
 In order to make this possible, the `Entity` identifiers in the main and the extracted version in render world are no longer guaranteed to line up. As a result:

--- a/release-content/0.15/migration-guides/15320_Retained_Rendering.md
+++ b/release-content/0.15/migration-guides/15320_Retained_Rendering.md
@@ -3,15 +3,21 @@
 <!-- https://github.com/bevyengine/bevy/pull/15320 Adopted PR -->
 <!-- https://github.com/bevyengine/bevy/pull/15582 Synchronized Removed Components -->
 <!-- https://github.com/bevyengine/bevy/pull/15756 Type Safe Retained Render World -->
-With the advent of the retained render world, collections that contain references to `Entity` that are extracted into the render world have been changed to contain `MainEntity` in order to prevent errors where a render world entity id is used to look up an item by accident. Custom rendering code may need to be changed to query for `&MainEntity` in order to look up the correct item from such a collection. Additionally, users who implement their own extraction logic for collections of main world entity should strongly consider extracting into a different collection that uses `MainEntity` as a key.
 
-Additionally, render phases now require specifying both the `Entity` and `MainEntity` for a given `PhaseItem`. Custom render phases should ensure `MainEntity` is available when queuing a phase item.
+With the advent of the retained render world, entities are no longer despawned at the end of every frame.
+Extracted entities with the `TemporaryRenderEntity` component will be despawned at the end of every frame like before.
+
+In order to make this possible, the `Entity` identifiers in the main and the extracted version in render world are no longer guaranteed to line up. As a result:
+
+- all tools to spawn entities with a precise `Entity` id are in the process of being deprecated and will be removed
+- collections that contain references to `Entity` that are extracted into the render world have been changed to contain `MainEntity` in order to prevent errors where a render world entity id is used to look up an item by accident. Custom rendering code may need to be changed to query for `&MainEntity` in order to look up the correct item from such a collection
+  - users who implement their own extraction logic for collections of main world entity should strongly consider extracting into a different collection that uses `MainEntity` as a key.
+- render phases now require specifying both the `Entity` and `MainEntity` for a given `PhaseItem`. Custom render phases should ensure `MainEntity` is available when queuing a phase item
 
 Renderers can now check `RenderVisibleEntities` to avoid rendering items that are not visible from a view. `RenderVisibleMeshEntities`, `RenderCubemapVisibleEntities`, and `RenderCascadeVisibleEntities` are also available for more fine-grained control.
 
-The retained render world is a complex change: migrating might take one of a few different forms depending on the patterns you're using.
-
-For every example, we specify in which world the code is run. Most of the changes affect render world code, so for the average Bevy user who's using Bevy's high-level rendering APIs, these changes are unlikely to affect your code.
+To guide you further, let's take a look at a few common patterns.
+For every example, we specify in which world the code is run.
 
 ### Spawning entities in the render world
 

--- a/release-content/0.15/migration-guides/15320_Retained_Rendering.md
+++ b/release-content/0.15/migration-guides/15320_Retained_Rendering.md
@@ -3,6 +3,12 @@
 <!-- https://github.com/bevyengine/bevy/pull/15320 Adopted PR -->
 <!-- https://github.com/bevyengine/bevy/pull/15582 Synchronized Removed Components -->
 <!-- https://github.com/bevyengine/bevy/pull/15756 Type Safe Retained Render World -->
+With the advent of the retained render world, collections that contain references to `Entity` that are extracted into the render world have been changed to contain `MainEntity` in order to prevent errors where a render world entity id is used to look up an item by accident. Custom rendering code may need to be changed to query for `&MainEntity` in order to look up the correct item from such a collection. Additionally, users who implement their own extraction logic for collections of main world entity should strongly consider extracting into a different collection that uses `MainEntity` as a key.
+
+Additionally, render phases now require specifying both the `Entity` and `MainEntity` for a given `PhaseItem`. Custom render phases should ensure `MainEntity` is available when queuing a phase item.
+
+Renderers can now check `RenderVisibleEntities` to avoid rendering items that are not visible from a view. `RenderVisibleMeshEntities`, `RenderCubemapVisibleEntities`, and `RenderCascadeVisibleEntities` are also available for more fine-grained control.
+
 The retained render world is a complex change: migrating might take one of a few different forms depending on the patterns you're using.
 
 For every example, we specify in which world the code is run. Most of the changes affect render world code, so for the average Bevy user who's using Bevy's high-level rendering APIs, these changes are unlikely to affect your code.
@@ -13,7 +19,7 @@ Previously, if you spawned an entity with `world.spawn(...)`, `commands.spawn(..
 
 ### Extract components with `ExtractComponentPlugin`
 
-```
+```rust
 // main world
 app.add_plugins(ExtractComponentPlugin::<ComponentToExtract>::default());
 ```
@@ -34,6 +40,7 @@ pub fn extract_clusters(
     }
 }
 ```
+
 An extract query in the render world queries for entities and components in the main world. Here `entity` is a main world entity and `get_or_spawn(main_world_entity).insert(...)` potentially inserts components on the wrong entity. Remember, there is no longer a one-to-one correspondence between the main and render world entities. Moreover `get_or_spawn` has been deprecated.
 
 In 0.15, you should use `RenderEntity` in place of `Entity` to get the correct entity in the render world. For entities to have a `RenderEntity` they need to be synced first. This can be done either via `WorldSyncPlugin` or adding the `SyncToRenderWorld` to the main world entity.
@@ -93,4 +100,3 @@ pub(crate) render_lightmaps: EntityHashMap<RenderLightmap>,
 // render world 0.15
 pub(crate) render_lightmaps: MainEntityHashMap<RenderLightmap>,
 ```
-

--- a/release-content/0.15/migration-guides/15756_Type_safe_retained_render_world.md
+++ b/release-content/0.15/migration-guides/15756_Type_safe_retained_render_world.md
@@ -1,5 +1,0 @@
-With the advent of the retained render world, collections that contain references to `Entity` that are extracted into the render world have been changed to contain `MainEntity` in order to prevent errors where a render world entity id is used to look up an item by accident. Custom rendering code may need to be changed to query for `&MainEntity` in order to look up the correct item from such a collection. Additionally, users who implement their own extraction logic for collections of main world entity should strongly consider extracting into a different collection that uses `MainEntity` as a key.
-
-Additionally, render phases now require specifying both the `Entity` and `MainEntity` for a given `PhaseItem`. Custom render phases should ensure `MainEntity` is available when queuing a phase item.
-
-Renderers can now check `RenderVisibleEntities` to avoid rendering items that are not visible from a view. `RenderVisibleMeshEntities`, `RenderCubemapVisibleEntities`, and `RenderCascadeVisibleEntities` are also available for more fine-grained control.

--- a/release-content/0.15/migration-guides/_guides.toml
+++ b/release-content/0.15/migration-guides/_guides.toml
@@ -822,12 +822,6 @@ areas = ["Rendering"]
 file_name = "15489_Migrate_bevy_sprite_to_required_components.md"
 
 [[guides]]
-title = "Type safe retained render world"
-prs = [15756]
-areas = ["Rendering"]
-file_name = "15756_Type_safe_retained_render_world.md"
-
-[[guides]]
 title = "Move `ImageLoader` and `CompressedImageSaver` to `bevy_image`."
 prs = [15812]
 areas = ["Rendering"]


### PR DESCRIPTION
Prompted by #1794, I noticed that we had two distinct sections for the migration guide that cover retained rendering. I've condensed those, and then done an editing pass.