### PR TITLE
Remove periods from release highlight bullet points

### DIFF
--- a/content/news/2024-XX-XX-bevy-0.15/index.md
+++ b/content/news/2024-XX-XX-bevy-0.15/index.md
@@ -25,11 +25,11 @@ Since our last release a few months ago we've added a _ton_ of new features, bug
 - **Bevy Remote Protocol (BRP)**: A new protocol that allows external clients (such as editors) to interact with running Bevy games
 - **Visibility Bitmask Ambient Occlusion (VBAO)**: An improved GTAO algorithm that improves ambient occlusion quality
 - **Chromatic Aberration**: A new post processing effect that simulates lenses that fail to focus light to a single point
-- **Volumetric Fog Improvements**: Support for "fog volumes" that define where volumetric fog is rendered (and what form it takes). We also added volumetric fog support for Point Lights and Spotlights.
-- **Order Independent Transparency**: A new opt-in transparency algorithm that improves the stability / quality of transparent objects as their distance from the camera changes.
-- **Improved Text Rendering**: We've switched to Cosmic Text for our text rendering, which significantly improves our ability to render text, especially for non-Latin-based languages that require font shaping and bidirectional text.
-- **Gamepads as Entities**: Gamepads are now represented as entities, making them much easier to interact with.
-- **UI Box Shadows**: Bevy UI nodes can now render configurable box shadows.
+- **Volumetric Fog Improvements**: "Fog volumes" that define where volumetric fog is rendered (and what form it takes), along with Point Lights and Spotlight compatibility
+- **Order Independent Transparency**: A new opt-in transparency algorithm that improves the stability / quality of transparent objects as their distance from the camera changes
+- **Improved Text Rendering**: We've switched to Cosmic Text for our text rendering, which significantly improves our ability to render text, especially for non-Latin-based languages that require font shaping and bidirectional text
+- **Gamepads as Entities**: Gamepads are now represented as entities, making them much easier to interact with
+- **UI Box Shadows**: Bevy UI nodes can now render configurable box shadows
 
 Bevy 0.15 was prepared using our new **release candidate** process to help ensure that you can upgrade right away with peace of mind. We worked closely with both plugin authors and ordinary users to catch critical bugs, polish new features, and refine the migration guide. For each release candidate, we prepared fixes, [shipped a new release candidate on crates.io](https://crates.io/crates/bevy/versions?sort=date), let core ecosystem crates update, and listened closely for show-stopping problems. A huge thanks to [everyone who helped out](https://discord.com/channels/691052431525675048/1295069829740499015)! These efforts are a vital step towards making Bevy something that teams large and small can trust to work reliably.
 


### PR DESCRIPTION
I noticed that these were inconsistent. I don't really care about which style we use, just that it's consistent. So I checked the 0.14 release notes and copied them.

I also reworded one bullet point about volumetric fog into one sentence for consistency and to reduce punctuation weirdness.