### PR TITLE
Update bluesky link to new handle

### DIFF
--- a/content/community/links.toml
+++ b/content/community/links.toml
@@ -39,7 +39,7 @@ description = "A community to discuss Bevy, Rust, and game development"
 [[links]]
 title = "Bluesky"
 subtitle = "bevy.bsky.social"
-url = "https://bsky.app/profile/bevy.bsky.social"
+url = "https://bsky.app/profile/bevyengine.org"
 image = "/assets/bluesky.svg"
 image_alt = "Bluesky logo"
 description = "Quick updates and shared Bevy content from the community"


### PR DESCRIPTION
Link wasn't updated to the new handle so it linked to the old one.