### PR TITLE
Fix missing links in 0.15 release notes

### DIFF
--- a/release-content/0.15/release-notes/13991_Minimal_Bubbling_Observers.md
+++ b/release-content/0.15/release-notes/13991_Minimal_Bubbling_Observers.md
@@ -27,4 +27,5 @@ Let us know what you cook up: user feedback is indispensable for building a bett
 [`Pointer<E>`]: https://docs.rs/bevy/0.15.0/bevy/picking/events/struct.Pointer.html
 [`Trigger::propagate(false)`]: https://docs.rs/bevy/0.15.0/bevy/ecs/prelude/struct.Trigger.html#method.propagate
 [`Parent`]: https://docs.rs/bevy/0.15.0/bevy/hierarchy/struct.Parent.html
+[`Traversal`]: https://docs.rs/bevy/0.15.0/bevy/ecs/traversal/trait.Traversal.html
 [proto-relations]: https://github.com/bevyengine/bevy/issues/3742

--- a/release-content/0.15/release-notes/14099_Allow_volumetric_fog_to_be_localized_to_specific_optionally.md
+++ b/release-content/0.15/release-notes/14099_Allow_volumetric_fog_to_be_localized_to_specific_optionally.md
@@ -10,3 +10,6 @@ A camera with the [`VolumetricFog`] component will render any [`FogVolume`] enti
 [`FogVolume`] has a `density_texture_offset`, which allows the 3D texture to be "scrolled". This allows effects such as clouds "passing through" the volume:
 
 <video controls><source src="scrolling_fog.mp4" type="video/mp4"/></video>
+
+[`FogVolume`]: https://docs.rs/bevy/0.15.0/bevy/pbr/struct.FogVolume.html
+[`VolumetricFog`]: https://docs.rs/bevy/0.15.0/bevy/pbr/struct.VolumetricFog.html


### PR DESCRIPTION
Noticed a couple of missing links in the 0.15 release notes that showed up like this:

![image](https://github.com/user-attachments/assets/a7a2dea0-ce27-43e1-9a7b-ba122bba19b0)

This PR adds all the missing links.