### PR TITLE
Fix migration guides issues

### DIFF
--- a/release-content/0.15/migration-guides/15482_bevy_reflect_Add_ReflectDeserializerProcessor.md
+++ b/release-content/0.15/migration-guides/15482_bevy_reflect_Add_ReflectDeserializerProcessor.md
@@ -49,3 +49,4 @@ fn deserialize(&mut self, r: &TypeRegistration, d: &mut dyn erased_serde::Deseri
 ```
 
 A similar processor system should also be added to the serialization side, but that’s for another PR. Ideally, both PRs will be in the same release, since one isn’t very useful without the other.
+</details>

--- a/release-content/0.15/migration-guides/15591_Text_rework.md
+++ b/release-content/0.15/migration-guides/15591_Text_rework.md
@@ -5,7 +5,7 @@ There are several major changes to consider:
 - each text section is now stored as a distinct entity within the standard hierarchy, rather than as a `Vec<TextSection>` on the `Text` component. Children of `Text`/`Text2d` entities with `TextSpan` components will act as additional text sections.
 - like other aspects of Bevy's API, required components have replaced bundles
 
-## `TextBundle` and text styling
+#### `TextBundle` and text styling
 
 `TextBundle` has been removed.
 Add the `Text` component to set the string displayed.
@@ -18,7 +18,7 @@ Like elsewhere in Bevy, there is no style inheritance. Consider [writing your ow
 
 To control the layout of a `Text` section, modify the properties of its `Node`.
 
-## Accessing text spans by index
+#### Accessing text spans by index
 
 Previously, text sections were elements of a vector stored within `Text`.
 Now, they are stored as distinct entities under the same `Parent`.
@@ -48,7 +48,7 @@ fn refresh_text(
 
 2D equivalents (`Text2dReader` and `Text2dWriter`) also exist.
 
-## Internal layout information
+#### Internal layout information
 
 `TextBundle` additional fields have been moved into the `TextNodeFlags` component,
 while `Text2dBundle`'s additional fields turned into the `TextBounds` and `Anchor` components.

--- a/release-content/0.15/migration-guides/15898_Migrate_UI_bundles_to_required_components.md
+++ b/release-content/0.15/migration-guides/15898_Migrate_UI_bundles_to_required_components.md
@@ -3,7 +3,7 @@ Simultaneously, the fields and behavior of `Style` have been moved to `Node`, an
 
 It will be easiest to migrate if you replace `Node` with `ComputedNode` first, then `Style` with `Node`, and finally `NodeBundle` with `Node`.
 
-## `Node` -> `ComputedNode`
+#### `Node` -> `ComputedNode`
 
 For any usage of the “computed node properties” that used to live on `Node`, use `ComputedNode` instead.
 This is a trivial find-and-replace rename.
@@ -30,7 +30,7 @@ fn system(computed_nodes: Query<&ComputedNode>) {
 }
 ```
 
-## `Style` -> `Node`
+#### `Style` -> `Node`
 
 All of the values of `Style` now live on `Node`. This is a find-and-replace rename.
 
@@ -52,7 +52,7 @@ Node {
 }
 ```
 
-## `NodeBundle` -> `Node`
+#### `NodeBundle` -> `Node`
 
 Finally, replace all uses of `NodeBundle` with `Node`.
 All other components in `NodeBundle` are now added implicitly via required components.

--- a/release-content/0.15/migration-guides/_guides.toml
+++ b/release-content/0.15/migration-guides/_guides.toml
@@ -5,6 +5,12 @@ areas = ["Accessibility", "UI"]
 file_name = "14091_Bump_accesskit_to_016.md"
 
 [[guides]]
+title = "Remove `accesskit` re-export from `bevy_a11y`"
+prs = [16257]
+areas = ["Accessibility"]
+file_name = "16257_Remove_accesskit_reexport_from_bevy_a11y.md"
+
+[[guides]]
 title = "Deprecate `is_playing_animation`"
 prs = [14387]
 areas = ["Animation"]
@@ -135,6 +141,18 @@ title = "bevy_asset: Improve `NestedLoader` API"
 prs = [15509]
 areas = ["Assets"]
 file_name = "15509_bevy_asset_Improve_NestedLoader_API.md"
+
+[[guides]]
+title = "Deprecate `LoadAndSave` Asset Processor"
+prs = [15090]
+areas = ["Assets"]
+file_name = "15090_Deprecate_LoadAndSave_Asset_Processor.md"
+
+[[guides]]
+title = "`AssetReader::read` now returns an opaque type"
+prs = [14082]
+areas = ["Assets"]
+file_name = "14082_AssetReader_read_now_returns_an_opaque_type.md"
 
 [[guides]]
 title = "Make gLTF node children Handle instead of objects"
@@ -1269,21 +1287,3 @@ title = "Add Display implementation to DebugName."
 prs = [13760]
 areas = []
 file_name = "13760_Add_Display_implementation_to_DebugName.md"
-
-[[guides]]
-title = "Remove `accesskit` re-export from `bevy_a11y`"
-prs = [16257]
-areas = ["Accessibility"]
-file_name = "16257_Remove_accesskit_reexport_from_bevy_a11y.md"
-
-[[guides]]
-title = "Deprecate `LoadAndSave` Asset Processor"
-prs = [15090]
-areas = ["Asset"]
-file_name = "15090_Deprecate_LoadAndSave_Asset_Processor.md"
-
-[[guides]]
-title = "`AssetReader::read` now returns an opaque type"
-prs = [14082]
-areas = ["Asset"]
-file_name = "14082_AssetReader_read_now_returns_an_opaque_type.md"

--- a/sass/pages/_content.scss
+++ b/sass/pages/_content.scss
@@ -30,7 +30,12 @@ $content-font-size: 1.22rem;
   }
 
   h4 {
-    margin-bottom: 1rem;
+    font-size: 1.3rem;
+    margin-bottom: 1.5rem;
+
+    code {
+      font-size: inherit;
+    }
   }
 
   pre {


### PR DESCRIPTION
- Move migrations that were at the bottom to their respective areas
- Add missing `</details>`
- Change some migration headings to `<h4>`
- Improve `<h4>` styling so it's more prominent than regular text