### PR TITLE
Various migration guide fixes

### DIFF
--- a/release-content/0.15/migration-guides/13859_Change_SceneInstanceReady_to_trigger_an_observer.md
+++ b/release-content/0.15/migration-guides/13859_Change_SceneInstanceReady_to_trigger_an_observer.md
@@ -1,16 +1,16 @@
-If you have a system which read `SceneInstanceReady` events:
+If you have a system which reads `SceneInstanceReady` events, it must be rewritten as an observer or entity observer.
 
-> 
-`fn ready_system(ready_events: EventReader<'_, '_, SceneInstanceReady>) {`
+```rust
+// 0.14
+fn ready_system(ready_events: EventReader<'_, '_, SceneInstanceReady>) {
+    // ...
+}
 
-
-It must be rewritten as an observer:
-
-> 
-`commands.observe(|trigger: Trigger<SceneInstanceReady>| {`
-
-
-Or, if you were expecting the event in relation to a specific entity or entities, as an entity observer:
-
-> 
-`commands.entity(entity).observe(|trigger: Trigger<SceneInstanceReady>| {`
+// 0.15
+commands.observe(|trigger: Trigger<SceneInstanceReady>| {
+    // ...
+});
+commands.entity(entity).observe(|trigger: Trigger<SceneInstanceReady>| {
+    // ...
+});
+```

--- a/release-content/0.15/migration-guides/14416_feat_Add_Worldget_reflect_and_Worldget_reflect_mut.md
+++ b/release-content/0.15/migration-guides/14416_feat_Add_Worldget_reflect_and_Worldget_reflect_mut.md
@@ -1,1 +1,0 @@
-No breaking changes, but users can use the new methods if they did it manually before.

--- a/release-content/0.15/migration-guides/14842_Replace_the_wgpu_trace_feature_with_a_field_in_bevy_render.md
+++ b/release-content/0.15/migration-guides/14842_Replace_the_wgpu_trace_feature_with_a_field_in_bevy_render.md
@@ -1,10 +1,8 @@
 The `bevy/wgpu_trace` and `bevy_render/wgpu_trace` features have been removed, as WGPU tracing is now enabled during the creation of `bevy_render::RenderPlugin`.
 
-{% callout(type="info") %}
-At the time of writing, WGPU has not reimplemented tracing support, so WGPU tracing will not currently work. However, once WGPU has reimplemented tracing support, the steps below should be sufficient to continue generating WGPU traces.
+Note: At the time of writing, WGPU has not reimplemented tracing support, so WGPU tracing will not currently work. However, once WGPU has reimplemented tracing support, the steps below should be sufficient to continue generating WGPU traces.
 
 You can track the progress of WGPU tracing being reimplemented at [gfx-rs/wgpu#5974](https://github.com/gfx-rs/wgpu/issues/5974).
-{% end %}
 
 To continue generating WGPU traces:
 

--- a/release-content/0.15/migration-guides/15281_Add_core_and_alloc_over_std_Lints.md
+++ b/release-content/0.15/migration-guides/15281_Add_core_and_alloc_over_std_Lints.md
@@ -1,1 +1,0 @@
-The MSRV is now 1.81. Please update to this version or higher.

--- a/release-content/0.15/migration-guides/15666_Split_out_bevy_mesh_from_bevy_render.md
+++ b/release-content/0.15/migration-guides/15666_Split_out_bevy_mesh_from_bevy_render.md
@@ -1,3 +1,7 @@
-`bevy_render::mesh::morph::inherit_weights` is now `bevy_render::mesh::inherit_weights`
+`bevy_render::mesh::morph::inherit_weights` has been moved to `bevy_render::mesh::inherit_weights`.
 
-if you were using `Mesh::compute_aabb`, you will need to `use bevy_render::mesh::MeshAabb;` now
+`Mesh::compute_aabb` has been moved to the new `MeshAabb` trait. You may need to import it.
+
+```rust
+use bevy::render::mesh::MeshAabb;
+```

--- a/release-content/0.15/migration-guides/_guides.toml
+++ b/release-content/0.15/migration-guides/_guides.toml
@@ -209,12 +209,6 @@ areas = ["Core", "Editor"]
 file_name = "14211_Rename_bevy_corenameDebugName_to_bevy_corenameNameOrEntity.md"
 
 [[guides]]
-title = "Add `core` and `alloc` over `std` Lints"
-prs = [15281]
-areas = ["Cross-Cutting"]
-file_name = "15281_Add_core_and_alloc_over_std_Lints.md"
-
-[[guides]]
 title = "Remove the `Component` trait implementation from `Handle`"
 prs = [15796]
 areas = ["Cross-Cutting"]
@@ -489,12 +483,6 @@ title = "`ReflectBundle::remove` improvement"
 prs = [16139]
 areas = ["ECS", "Reflection"]
 file_name = "16139_ReflectBundleremove_improvement.md"
-
-[[guides]]
-title = "feat: Add `World::get_reflect()` and `World::get_reflect_mut()`"
-prs = [14416]
-areas = ["ECS", "Reflection"]
-file_name = "14416_feat_Add_Worldget_reflect_and_Worldget_reflect_mut.md"
 
 [[guides]]
 title = "Use crate: `disqualified`"


### PR DESCRIPTION
This is just barely scratching the surface to fix some low hanging fruit.

- 13859: The formatting in this one was really messed up
- 14416: No breaking changes, removed.
- 14842: Used callout shortcode that doesn't work here
- 15281: I think this is outdated, and is covered by general warning at top of page, removed.
- 15666: `bevy_render` -> `bevy::render` for user code. Hopefully a little less confusing now too