### PR TITLE
Fix sorting of patch version numbers in crates.io metadata retrieval

### DIFF
--- a/generate-assets/src/lib.rs
+++ b/generate-assets/src/lib.rs
@@ -728,7 +728,7 @@ pub fn get_metadata_from_cratesio_statement(
         FROM ( \
             SELECT version_id, license, major, \
                 CAST(SUBSTR(minor_and_patch,0,second_point) AS INTEGER) minor, \
-                SUBSTR(minor_and_patch,second_point+1) patch \
+                CAST(SUBSTR(minor_and_patch,second_point+1) AS INTEGER) patch \
             FROM ( \
                 SELECT version_id, license, major, minor_and_patch, \
                     INSTR(minor_and_patch, '.') second_point \


### PR DESCRIPTION
Originally reported by @ChristopherBiscardi over on [discord](https://discord.com/channels/691052431525675048/745355529777315850/1312992286795370519).

`bevy_renet` is currently showing that it depends on Bevy 0.11, despite having recent releases depending on more recent versions of Bevy.

<img width="313" alt="image" src="https://github.com/user-attachments/assets/6e720aa3-9a1a-4225-bc3c-6027427a4731">

This seems to be due to a bug in the way we parse and sort version numbers in sql. The `patch` portion of the version number is being treated and sorted as a string. Here's the output of the relevant subquery for `bevy_renet` with the `LIMIT 1` removed, showing the incorrect sorting.

```
850228|MIT OR Apache-2.0|0|0|9
803802|MIT OR Apache-2.0|0|0|8
747658|MIT OR Apache-2.0|0|0|7
666460|MIT OR Apache-2.0|0|0|6
594323|MIT OR Apache-2.0|0|0|5
590568|MIT OR Apache-2.0|0|0|4
573573|MIT OR Apache-2.0|0|0|3
548673|MIT OR Apache-2.0|0|0|2
1209414|MIT OR Apache-2.0|0|0|12
1059556|MIT OR Apache-2.0|0|0|11
952880|MIT OR Apache-2.0|0|0|10
541835|MIT OR Apache-2.0|0|0|1
```

So the metadata for `bevy_renet` version 0.0.9 is being retrieved, which depends on Bevy 0.11.

After this PR, the same query returns a correct sorting.

```
1209414|MIT OR Apache-2.0|0|0|12
1059556|MIT OR Apache-2.0|0|0|11
952880|MIT OR Apache-2.0|0|0|10
850228|MIT OR Apache-2.0|0|0|9
803802|MIT OR Apache-2.0|0|0|8
747658|MIT OR Apache-2.0|0|0|7
666460|MIT OR Apache-2.0|0|0|6
594323|MIT OR Apache-2.0|0|0|5
590568|MIT OR Apache-2.0|0|0|4
573573|MIT OR Apache-2.0|0|0|3
548673|MIT OR Apache-2.0|0|0|2
541835|MIT OR Apache-2.0|0|0|1
```

Which correctly lists the latest version first. And we seem to get the correct result after rebuilding assets:

<img width="313" alt="image" src="https://github.com/user-attachments/assets/97bb824b-fbf4-4854-a7bc-54458b64dccc">
