### PR TITLE
Process shortcodes in migration guides

### DIFF
--- a/templates/shortcodes/callout.html
+++ b/templates/shortcodes/callout.html
@@ -1,3 +1,3 @@
 <aside class="callout callout--{{ type | default(value="info") }}">
-  {{ body | markdown | safe }}
+  {{ body | safe }}
 </aside>

--- a/templates/shortcodes/migration_guides.md
+++ b/templates/shortcodes/migration_guides.md
@@ -33,8 +33,7 @@
 <li class="migration-guide-meta__area">{{ area }}</li>
 {% endfor %}
 </ul>
-
-{{ guide_body }}
+{{ guide_body | markdown }}
 
 {% endfor %}
 </div>


### PR DESCRIPTION
Makes a similar change to #1448, but for migration guides.

I am not totally sure this is correct, but it seems to work.

(See http://localhost:1111/learn/migration-guides/0-14-to-0-15/#replace-the-wgpu-trace-feature-with-a-field-in-bevy-render-settings-wgpusettings) after building the site locally.

Also not making any particular judgment here about whether we want this particular `callout` in the migration guide or if we want those in the migration guides in general.