### PR TITLE
0.15 migration: Fix up guide for 16163

### DIFF
--- a/release-content/0.15/migration-guides/16163_Dont_reëxport_bevy_image_from_bevy_render.md
+++ b/release-content/0.15/migration-guides/16163_Dont_reëxport_bevy_image_from_bevy_render.md
@@ -1,1 +1,10 @@
-Use `bevy_image` instead of `bevy_render::texture` items.
+Various types and traits are no longer re-exported from `bevy_image` in `bevy::render::texture`. Import them directly from `bevy::image` instead.
+
+```rust
+// 0.14
+use bevy::render::texture::BevyDefault;
+// 0.15
+use bevy::image::BevyDefault;
+```
+
+This is an incomprehensive list of other types may be affected for searchability: `CompressedImageFormats`, `ExrTextureLoader`, `HdrTextureLoader`, `Image`, `ImageAddressMode`, `ImageFilterMode`, `ImageLoader`, `ImageLoaderSettings`, `ImageSampler`, `ImageSamplerDescriptor`, `ImageType`, `TextureError`, `TextureFormatPixelInfo`.

--- a/release-content/0.15/migration-guides/16163_Dont_reëxport_bevy_image_from_bevy_render.md
+++ b/release-content/0.15/migration-guides/16163_Dont_reëxport_bevy_image_from_bevy_render.md
@@ -7,4 +7,4 @@ use bevy::render::texture::BevyDefault;
 use bevy::image::BevyDefault;
 ```
 
-This is an incomprehensive list of other types may be affected for searchability: `CompressedImageFormats`, `ExrTextureLoader`, `HdrTextureLoader`, `Image`, `ImageAddressMode`, `ImageFilterMode`, `ImageLoader`, `ImageLoaderSettings`, `ImageSampler`, `ImageSamplerDescriptor`, `ImageType`, `TextureError`, `TextureFormatPixelInfo`.
+For searchability, this is a non-comprehensive list of other types may be affected: `CompressedImageFormats`, `ExrTextureLoader`, `HdrTextureLoader`, `Image`, `ImageAddressMode`, `ImageFilterMode`, `ImageLoader`, `ImageLoaderSettings`, `ImageSampler`, `ImageSamplerDescriptor`, `ImageType`, `TextureError`, `TextureFormatPixelInfo`.

--- a/release-content/0.15/migration-guides/_guides.toml
+++ b/release-content/0.15/migration-guides/_guides.toml
@@ -221,7 +221,7 @@ areas = ["Cross-Cutting", "Math"]
 file_name = "15239_Fix_floating_point_math.md"
 
 [[guides]]
-title = "Don't reëxport `bevy_image` from `bevy_render`"
+title = "Don't re-export `bevy_image` from `bevy_render`"
 prs = [16163]
 areas = ["Cross-Cutting", "Rendering"]
 file_name = "16163_Dont_reëxport_bevy_image_from_bevy_render.md"


### PR DESCRIPTION
This change resulted in some pretty weird-looking breakage and deserves a bit of love. Some of Bevy's examples used these re-exports, so they are likely to be in other codebases.

The list of types was gleaned from changes to Bevy code / examples from the original PR.