### PR TITLE
Hide assets/examples filters to non-JS users

### DIFF
--- a/static/assets.js
+++ b/static/assets.js
@@ -142,6 +142,8 @@ if (versionsSelect) {
 
 }
 
+document.querySelector('[data-assets-filters]').classList.remove('hidden');
+
 document
     .querySelector('#assets-filter')
     .addEventListener("change", (item) => {

--- a/templates/assets.html
+++ b/templates/assets.html
@@ -6,17 +6,19 @@
 {% block page_content %}
   <div class="assets">
     {{ assets_macros::init_svg() }}
-    <div class="assets-search">
-      <input class="assets-search__input"
-              type="text"
-              id="assets-search"
-              placeholder="Search (ie: 0.11 MIT)">
-    </div>
-    <div class="assets-filters">
-      <label>Bevy last supported version</label>
-      <select class="asset-version-select" id="assets-filter">
-        <option value="all_versions">All</option>
-      </select>
+    <div class="hidden" data-assets-filters>
+      <div class="assets-search">
+        <input class="assets-search__input"
+                type="text"
+                id="assets-search"
+                placeholder="Search (ie: 0.15 MIT)">
+      </div>
+      <div class="assets-filters">
+        <label>Bevy last supported version</label>
+        <select class="asset-version-select" id="assets-filter">
+          <option value="all_versions">All</option>
+        </select>
+      </div>
     </div>
     <div class="assets-intro media-content">
       A collection of third-party Bevy assets, plugins, learning resources, and apps made by the community. If you

--- a/templates/layouts/examples.html
+++ b/templates/layouts/examples.html
@@ -8,7 +8,7 @@
     <div class="assets-intro media-content">
       {% block intro %}{% endblock intro %}
     </div>
-    <div class="assets-search">
+    <div class="assets-search hidden" data-assets-filters>
       <input class="assets-search__input"
               type="text"
               id="assets-search"
@@ -30,5 +30,5 @@
       {% endif %}
     {% endfor %}
   </div>
-  <script type="module">import '/assets.js'</script>
+  <script type="module">import '/assets.js';</script>
 {% endblock page_content %}


### PR DESCRIPTION
Since the beginning the website has favored non-JS solutions when possible. But there are features than can only be implemented with JS. For those users that have JS disabled in their browser we shouldn't show these features.

**This PR hides assets/examples filters to non-JS users.**

To try this in Firefox:
- Go to: `about:config`
- Set `javascript.enabled` to `false`
- Navigate to assets/examples, you shouldn't see the filters

<img width="600" alt="image" src="https://github.com/user-attachments/assets/1043b5b0-5dad-4b96-8c71-f79b90611a85">

<img width="600" alt="image" src="https://github.com/user-attachments/assets/7b5b2381-13b4-4023-9758-41aecc47c060">
