### PR TITLE
add slash to route

### DIFF
--- a/templates/macros/header.html
+++ b/templates/macros/header.html
@@ -2,9 +2,9 @@
   {% set lower_current_path = current_path | lower %}
   {% set home = "/" %}
   {% if path == "" %}
-    {% set route = "/"~name %}
+    {% set route = "/"~name~"/" %}
   {% else %}
-    {% set route = path %}
+    {% set route = path~"/" %}
   {% endif %}
   {% set currently_home = path == home and lower_current_path == home %}
   {% set is_active = lower_current_path is starting_with("/"~name | lower) or currently_home %}

--- a/templates/macros/header.html
+++ b/templates/macros/header.html
@@ -2,9 +2,9 @@
   {% set lower_current_path = current_path | lower %}
   {% set home = "/" %}
   {% if path == "" %}
-    {% set route = "/"~name~"/" %}
+    {% set route = "/"~name %}
   {% else %}
-    {% set route = path~"/" %}
+    {% set route = path %}
   {% endif %}
   {% set currently_home = path == home and lower_current_path == home %}
   {% set is_active = lower_current_path is starting_with("/"~name | lower) or currently_home %}
@@ -13,7 +13,7 @@
     {% set class = class~" main-menu__link--active" %}
   {% endif %}
   <li class="main-menu__entry {{ extra_class }}">
-    <a href="{{ route | lower }}" class="{{ class }}">
+    <a href="{{ route | lower }}/" class="{{ class }}">
       <span>{{ name }}</span>
     </a>
   </li>


### PR DESCRIPTION
I added a trailing slash to the URL to avoid GitHub Pages' automatic redirect from slashless URLs.
The redirection process incurs an additional HTTP request on each menu load, marginally impacting the page load time.

![image](https://github.com/user-attachments/assets/e1f43079-2d63-4650-b535-24222dc25996)
