### PR TITLE
Hide heading anchors by default

### DIFF
--- a/sass/_utils.scss
+++ b/sass/_utils.scss
@@ -48,6 +48,19 @@ body:not(.show_drafts) .public_draft:not(.active_draft) {
   color: #737373;
   text-shadow: none;
   font-weight: 500;
+  opacity: 0;
+  transition: opacity $duration;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  &:hover .anchor-link {
+    opacity: 1;
+  }
 }
 
 .public_draft>div>a {


### PR DESCRIPTION
Hide heading anchors (`#`) by default to reduce noise:

https://github.com/user-attachments/assets/c1b080a6-c53b-429d-9675-b7b94afa6db4

