### PR TITLE
Use `<hr>` instead of `border-top` in Migration headings

### DIFF
--- a/sass/pages/_migration_guide.scss
+++ b/sass/pages/_migration_guide.scss
@@ -19,9 +19,18 @@
   }
 
   h3 {
-    margin-block: 2rem .5rem;
-    padding-top: 2rem;
-    border-top: solid rgba(#fff, 0.05) 1px;
+    margin-block: 2rem 0.5rem;
+  }
+
+  hr {
+    $color: rgba(#fff, 0.05);
+
+    height: 1px;
+    color: $color;
+    background: $color;
+    font-size: 0;
+    border: 0;
+    margin-block: 2rem;
   }
 }
 

--- a/templates/shortcodes/migration_guides.md
+++ b/templates/shortcodes/migration_guides.md
@@ -23,6 +23,8 @@
 ## {{ area_name }}
 {% endif %}
 
+{% if not area_changed %}<hr>{% endif %}
+
 ### {{ guide.title }}
 
 <ul class="migration-guide-meta">
@@ -37,4 +39,5 @@
 {{ guide_body }}
 
 {% endfor %}
+
 </div>


### PR DESCRIPTION
Fixes a minor detail 😅. Right now Migration guides H3 headings have the `border-top` set. The problem is that when the user clicks on the sidebar links (or `#`) the scrolls aligns with the horizontal line because that's part of the heading.

The solution is to remove the `border-top` from the H3 heading and use `<hr>` instead, this way the scroll aligns with the text instead of the horizontal line.

Demo:
- First old behaviour
- Then this PR behaviour

https://github.com/user-attachments/assets/380a8c4d-6e74-4dee-bb06-0dcd0d07e563
