### PR TITLE
Fix sidebar section highlighter

### DIFF
--- a/static/on-this-page.js
+++ b/static/on-this-page.js
@@ -18,13 +18,8 @@ let otp_state = new Map();
  * @param {string | HTMLElement} id_or_node 
  */
 function otp_set_active(id_or_node){
-  let id = "";
-  if(typeof id_or_node == "object"){
-    id = id_or_node.getAttribute("id");
-  } else {
-    id = id_or_node;
-  }
-  id = "#" + id;
+  let id = `#${id_or_node instanceof HTMLElement ? id_or_node.getAttribute("id") : id_or_node}`;
+
   document.querySelectorAll(".on-this-page a").forEach(a => {
     a.setAttribute("data-active", a.getAttribute("href") == id);
   });
@@ -39,10 +34,13 @@ let otp_observer =  new IntersectionObserver(
     entries.forEach(entry => {
       otp_state.set(entry.target, entry.isIntersecting);
     });
+
     let intersecting = Array.from(otp_state)
       .filter(([_el, inter]) => inter)
       .map(([el, _inter]) => el);
-    intersecting.sort((element) => -element.getBoundingClientRect().y);
+
+    intersecting.sort((a, b) => a.getBoundingClientRect().y - b.getBoundingClientRect().y);
+
     if (intersecting.length > 0) {
       otp_set_active(intersecting[0]);
     }

--- a/static/on-this-page.js
+++ b/static/on-this-page.js
@@ -30,6 +30,10 @@ function otp_set_active(id_or_node){
   });
 }
 
+let headerHeight = getComputedStyle(document.body).getPropertyValue(
+  "--header-height"
+);
+
 let otp_observer =  new IntersectionObserver(
   entries => {
     entries.forEach(entry => {
@@ -43,7 +47,7 @@ let otp_observer =  new IntersectionObserver(
       otp_set_active(intersecting[0]);
     }
   }, {
-    rootMargin: "0px 0px 20% 0px",
+    rootMargin: `-${headerHeight} 0px 20% 0px`,
     threshold: 1.0,
   });
 


### PR DESCRIPTION
Apply the header offset to `on-this-page.js` intersection observer. This way the sidebar will highlight the next section as soon as the old section gets below the header. [Previously it waited until exiting the viewport](https://github.com/bevyengine/bevy-website/pull/1907#issuecomment-2520945939).

Fixes #1908.

New behavior (header opacity reduced to 0.5 and yellow header **just for visualization**)

https://github.com/user-attachments/assets/e5b597e3-d13c-4609-a16f-82daa216aeb6