### PR TITLE
Add Bluesky link in footer and tweak styling

### DIFF
--- a/content/community/links.toml
+++ b/content/community/links.toml
@@ -2,9 +2,10 @@
 title = "GitHub"
 subtitle = "bevyengine"
 url = "https://github.com/bevyengine/bevy"
-image = "/assets/github.svg"
+image = "/assets/github-mark-white.svg"
 image_alt = "GitHub logo"
 description = "Interact with Bevy's source code, report issues, and suggest changes"
+show_in_footer = true
 
 [[links]]
 title = "Bevy People"
@@ -35,6 +36,7 @@ url = "https://discord.gg/bevy"
 image = "/assets/discord.svg"
 image_alt = "Discord logo"
 description = "A community to discuss Bevy, Rust, and game development"
+show_in_footer = true
 
 [[links]]
 title = "Bluesky"
@@ -43,6 +45,7 @@ url = "https://bsky.app/profile/bevyengine.org"
 image = "/assets/bluesky.svg"
 image_alt = "Bluesky logo"
 description = "Quick updates and shared Bevy content from the community"
+show_in_footer = true
 
 [[links]]
 title = "Twitter"
@@ -51,6 +54,7 @@ url = "https://twitter.com/BevyEngine"
 image = "/assets/twitter.svg"
 image_alt = "Twitter logo"
 description = "Quick updates and shared Bevy content from the community"
+show_in_footer = true
 
 [[links]]
 title = "Reddit"
@@ -59,6 +63,7 @@ url = "https://www.reddit.com/r/bevy/"
 image = "/assets/reddit.svg"
 image_alt = "Reddit logo"
 description = "Stay up to date on Bevy news, share your games or plugins, and discuss Bevy."
+show_in_footer = true
 
 [[links]]
 title = "itch.io"
@@ -67,6 +72,7 @@ url = "https://itch.io/games/tag-bevy"
 image = "/assets/itchio-textless.svg"
 image_alt = "itch.io logo"
 description = 'Games tagged with "bevy" on itch.io.'
+show_in_footer = true
 
 [[links]]
 title = "Mastodon"
@@ -75,3 +81,4 @@ url = "https://mastodon.social/@bevy"
 image = "/assets/mastodon-logo-purple.svg"
 image_alt = "Mastodon logo"
 description = "News, boosted community creations and chatter on the short-form Fediverse network."
+show_in_footer = true

--- a/sass/components/_footer.scss
+++ b/sass/components/_footer.scss
@@ -3,15 +3,23 @@
     display: flex;
     flex-direction: row;
     justify-content: center;
-    gap: 25px;
-    padding: 20px;
+    flex-wrap: wrap;
+    padding: 32px 16px;
   }
 
   &__social {
+    padding: 12px;
+
     img {
       filter: grayscale(1) brightness(800%);
-      &:hover {
+      transition: scale $duration, opacity $duration;
+      opacity: 0.65;
+    }
+
+    &:hover {
+      img {
         scale: 110%;
+        opacity: 1;
       }
     }
   }

--- a/templates/layouts/base.html
+++ b/templates/layouts/base.html
@@ -192,41 +192,22 @@
       <footer class="print:hidden">
         {% block footer_extensions %}{% endblock footer_extensions %}
         <div class="footer__social-container">
-          <a class="footer__social" href="https://github.com/bevyengine/bevy">
-            <img src="/assets/github-mark-white.svg"
-                  alt="Bevy engine's GitHub repo"
-                  width="32"
-                  height="32" />
-          </a>
-          <a class="footer__social" href="https://discord.gg/bevy">
-            <img src="/assets/discord.svg"
-                  alt="Bevy Discord server"
-                  width="32"
-                  height="32" />
-          </a>
-          <a class="footer__social" href="https://mastodon.social/@bevy">
-            <img src="/assets/mastodon-logo-purple.svg"
-                  alt="Bevy Mastodon account"
-                  width="32"
-                  height="32" />
-          </a>
-          <a class="footer__social" href="https://twitter.com/BevyEngine">
-            <img src="/assets/twitter.svg"
-                  alt="Bevy Twitter account"
-                  width="32"
-                  height="32" />
-          </a>
-          <a class="footer__social" href="https://www.reddit.com/r/bevy/">
-            <img src="/assets/reddit.svg"
-                  alt="Bevy subreddit"
-                  width="32"
-                  height="32" />
-          </a>
-          <a class="footer__social" href="/atom.xml">
+          {% set community_links = load_data(path="content/community/links.toml") %}
+          {% for link in community_links.links %}
+            {% if link.show_in_footer %}
+              <a class="footer__social" href="{{ link.url }}" title="{{ link.title }}">
+                <img src="{{ link.image }}"
+                      alt="{{ link.image_alt }}"
+                      width="24"
+                      height="24" />
+              </a>
+            {% endif %}
+          {% endfor %}
+          <a class="footer__social" href="/atom.xml" title="Bevy news feed">
             <img src="/assets/feed.svg"
                   alt="Bevy news feed"
-                  width="32"
-                  height="32" />
+                  width="24"
+                  height="24" />
           </a>
         </div>
       </footer>


### PR DESCRIPTION
Links now come from `links.toml` so it's easier to maintain the footer list.

Styling changes:
- Smaller icons
- Change color of icons to grey (opacity 0.65); white on hover
- Replace gap with link padding so there isn't any "non-interactive gaps" between icons and increases icon link "hit-area"
- Increased footer vertical padding
- Added CSS transition to scale/opacity

https://github.com/user-attachments/assets/dfd5f513-7228-48d8-813a-6475f5f6d007

Fixes #1867. Fixes #1866.