### PR TITLE
Tidy up "past sponsors" markup

### DIFF
--- a/templates/sponsors.html
+++ b/templates/sponsors.html
@@ -96,7 +96,8 @@
         <h2 class="past-donors-title">Past Donors</h2>
         <div class="past-donor">
         {% for donor in past_donors %}
-            {% if loop.last %}{{ donor.name }}{% else %}{{ donor.name }},{% endif %}
+            {% set name = donor.name | escape | replace(from=" ", to="&nbsp;") %}
+            {% if loop.last %}{{ name | safe }}{% else %}{{ name | safe }},{% endif %}
         {% endfor %}
         </div>
     {% endif %}

--- a/templates/sponsors.html
+++ b/templates/sponsors.html
@@ -96,8 +96,7 @@
         <h2 class="past-donors-title">Past Donors</h2>
         <div class="past-donor">
         {% for donor in past_donors %}
-            {% set name = donor.name | escape | replace(from=" ", to="&nbsp;") %}
-            {% if loop.last %}{{ name | safe }}{% else %}{{ name | safe }},{% endif %}
+            {{ donor.name | escape | replace(from=" ", to="&nbsp;") | safe }}{% if not loop.last %},{% endif %}
         {% endfor %}
         </div>
     {% endif %}

--- a/templates/sponsors.html
+++ b/templates/sponsors.html
@@ -91,28 +91,12 @@
 {% endfor %}
 
 {% if donors.donor %}
-    {% set_global first = true %}
-    {% set sorted_donors = donors.donor | sort(attribute="amount") | reverse %}
-    {% set_global past_donor_exists = false %}
-    {% for donor in sorted_donors %}
-        {% if donor.past %}
-            {% set_global past_donor_exists = true %}
-        {% endif %}
-    {% endfor %}
-    {% if past_donor_exists %}
+    {% set past_donors = donors.donor | filter(attribute="past", value=true) | filter(attribute="name") | sort(attribute="amount") | reverse %}
+    {% if past_donors %}
         <h2 class="past-donors-title">Past Donors</h2>
         <div class="past-donor">
-        {% for donor in sorted_donors %}
-            {% if not donor.past %}
-                {% continue %}
-            {% endif %}
-            {% if not donor.name %}
-                {% continue %}
-            {% endif %}
-            {% if first %}{{ donor.name }}{% else %} , {{ donor.name }}{% endif %}
-            {% if first %}
-                {% set_global first = false %}
-            {% endif %}
+        {% for donor in past_donors %}
+            {% if loop.last %}{{ donor.name }}{% else %}{{ donor.name }},{% endif %}
         {% endfor %}
         </div>
     {% endif %}


### PR DESCRIPTION
# Objective

Tidy up this section of the tera template.

The output should be identical, except without the space between names and the following comma.

## Solution

- Replace manual array filtering with `filter` filter
- Replace manual array index tracking with `loop`
- Get rid of pesky space between names and comma
- Replace spaces in names with non-breaking spaces so they don't get split onto two lines.

## Before
<img width="1276" alt="Screenshot 2025-02-18 at 7 02 21 AM" src="https://github.com/user-attachments/assets/189c6be1-f2a8-4aa0-8fa0-d9ea61114777" />

## After

<img width="1276" alt="Screenshot 2025-02-18 at 7 01 32 AM" src="https://github.com/user-attachments/assets/f63586e5-f2fe-4e4a-9879-f8d34a2811a5" />
