### PR TITLE
Add S-Ready-For-Implementation to triage docs

### DIFF
--- a/content/learn/contribute/reference/triage.md
+++ b/content/learn/contribute/reference/triage.md
@@ -30,6 +30,7 @@ Labels are our primary tool for organizing work. You can find a complete list wi
 - **P**: Priority (e.g. P-Critical, P-High, ...).
   - Most work is not explicitly categorized by priority; volunteer work mostly occurs on an ad hoc basis depending on contributor interests.
 - **S**: Status. The most common include:
+  - `S-Ready-For-Implementation`: this issue is ready for someone to pick it up and open a PR!
   - `S-Needs-Triage`: this issue needs to be labeled.
   - `S-Adopt-Me`: the original PR author has no intent to complete the PR, and it should be adopted by another contributor. This PR should be closed, and have an issue linked to track its adoption.
   - `S-Blocked`: cannot move forward until something else changes.


### PR DESCRIPTION
While adding the S-Nominated-To-Close tag in another PR, I noticed that S-Ready-For-Implementation was one of the most common labels.  While it's probably pretty straightforward without explanation, I felt this might be a good call to action (which is why I added it to the top of the list).