### PR TITLE
Cull, organize and sort release notes for 0.16

### DIFF
--- a/release-content/0.16/release-notes/14780_Link_iOS_example_with_rustc_and_avoid_C_trampoline.md
+++ b/release-content/0.16/release-notes/14780_Link_iOS_example_with_rustc_and_avoid_C_trampoline.md
@@ -1,4 +1,0 @@
-<!-- Link iOS example with `rustc`, and avoid C trampoline -->
-<!-- https://github.com/bevyengine/bevy/pull/14780 -->
-
-<!-- TODO -->

--- a/release-content/0.16/release-notes/15607_Track_callsite_for_observers__hooks.md
+++ b/release-content/0.16/release-notes/15607_Track_callsite_for_observers__hooks.md
@@ -1,4 +1,0 @@
-<!-- Track callsite for observers & hooks -->
-<!-- https://github.com/bevyengine/bevy/pull/15607 -->
-
-<!-- TODO -->

--- a/release-content/0.16/release-notes/15858_Introduce_methods_on_QueryState_to_obtain_a_Query.md
+++ b/release-content/0.16/release-notes/15858_Introduce_methods_on_QueryState_to_obtain_a_Query.md
@@ -1,4 +1,0 @@
-<!-- Introduce methods on QueryState to obtain a Query -->
-<!-- https://github.com/bevyengine/bevy/pull/15858 -->
-
-<!-- TODO -->

--- a/release-content/0.16/release-notes/16047_track_change_detection_Also_track_spawnsdespawns.md
+++ b/release-content/0.16/release-notes/16047_track_change_detection_Also_track_spawnsdespawns.md
@@ -1,4 +1,0 @@
-<!-- track_change_detection: Also track spawns/despawns -->
-<!-- https://github.com/bevyengine/bevy/pull/16047 -->
-
-<!-- TODO -->

--- a/release-content/0.16/release-notes/16434_Getting_QueryState_from_immutable_World_reference.md
+++ b/release-content/0.16/release-notes/16434_Getting_QueryState_from_immutable_World_reference.md
@@ -1,4 +1,0 @@
-<!-- Getting `QueryState` from immutable `World` reference -->
-<!-- https://github.com/bevyengine/bevy/pull/16434 -->
-
-<!-- TODO -->

--- a/release-content/0.16/release-notes/16575_Move_required_components_doc_to_type_doc.md
+++ b/release-content/0.16/release-notes/16575_Move_required_components_doc_to_type_doc.md
@@ -1,4 +1,0 @@
-<!-- Move required components doc to type doc -->
-<!-- https://github.com/bevyengine/bevy/pull/16575 -->
-
-<!-- TODO -->

--- a/release-content/0.16/release-notes/16758_Add_no_std_support_to_bevy_ecs.md
+++ b/release-content/0.16/release-notes/16758_Add_no_std_support_to_bevy_ecs.md
@@ -1,4 +1,0 @@
-<!-- Add `no_std` support to `bevy_ecs` -->
-<!-- https://github.com/bevyengine/bevy/pull/16758 -->
-
-<!-- TODO -->

--- a/release-content/0.16/release-notes/16795_Tab_navigation_framework_for_bevy_input_focus.md
+++ b/release-content/0.16/release-notes/16795_Tab_navigation_framework_for_bevy_input_focus.md
@@ -1,4 +1,0 @@
-<!-- Tab navigation framework for bevy_input_focus. -->
-<!-- https://github.com/bevyengine/bevy/pull/16795 -->
-
-<!-- TODO -->

--- a/release-content/0.16/release-notes/16826_Extend_cloning_functionality_and_add_convenience_methods_t.md
+++ b/release-content/0.16/release-notes/16826_Extend_cloning_functionality_and_add_convenience_methods_t.md
@@ -1,4 +1,0 @@
-<!-- Extend cloning functionality and add convenience methods to `EntityWorldMut` and `EntityCommands` -->
-<!-- https://github.com/bevyengine/bevy/pull/16826 -->
-
-<!-- TODO -->

--- a/release-content/0.16/release-notes/16874_Add_no_std_support_to_bevy_app.md
+++ b/release-content/0.16/release-notes/16874_Add_no_std_support_to_bevy_app.md
@@ -1,4 +1,0 @@
-<!-- Add `no_std` support to `bevy_app` -->
-<!-- https://github.com/bevyengine/bevy/pull/16874 -->
-
-<!-- TODO -->

--- a/release-content/0.16/release-notes/17043_Add_Result_handling_to_Commands_and_EntityCommands.md
+++ b/release-content/0.16/release-notes/17043_Add_Result_handling_to_Commands_and_EntityCommands.md
@@ -1,4 +1,0 @@
-<!-- Add `Result` handling to `Commands` and `EntityCommands` -->
-<!-- https://github.com/bevyengine/bevy/pull/17043 -->
-
-<!-- TODO -->

--- a/release-content/0.16/release-notes/17258_Proportional_scaling_for_the_sprites_texture.md
+++ b/release-content/0.16/release-notes/17258_Proportional_scaling_for_the_sprites_texture.md
@@ -1,4 +1,0 @@
-<!-- Proportional scaling for the sprite's texture. -->
-<!-- https://github.com/bevyengine/bevy/pull/17258 -->
-
-<!-- TODO -->

--- a/release-content/0.16/release-notes/17423_BRP_resource_methods.md
+++ b/release-content/0.16/release-notes/17423_BRP_resource_methods.md
@@ -1,4 +1,0 @@
-<!-- BRP resource methods -->
-<!-- https://github.com/bevyengine/bevy/pull/17423 -->
-
-<!-- TODO -->

--- a/release-content/0.16/release-notes/17482_Replace_Ambient_Lights_with_Environment_Map_Lights.md
+++ b/release-content/0.16/release-notes/17482_Replace_Ambient_Lights_with_Environment_Map_Lights.md
@@ -1,4 +1,0 @@
-<!-- Replace Ambient Lights with Environment Map Lights -->
-<!-- https://github.com/bevyengine/bevy/pull/17482 -->
-
-<!-- TODO -->

--- a/release-content/0.16/release-notes/17753_featecs_configurable_error_handling_for_fallible_systems.md
+++ b/release-content/0.16/release-notes/17753_featecs_configurable_error_handling_for_fallible_systems.md
@@ -1,4 +1,0 @@
-<!-- feat(ecs): configurable error handling for fallible systems -->
-<!-- https://github.com/bevyengine/bevy/pull/17753 -->
-
-<!-- TODO -->

--- a/release-content/0.16/release-notes/17967_Upgrade_to_Rust_Edition_2024.md
+++ b/release-content/0.16/release-notes/17967_Upgrade_to_Rust_Edition_2024.md
@@ -1,4 +1,0 @@
-<!-- Upgrade to Rust Edition 2024 -->
-<!-- https://github.com/bevyengine/bevy/pull/17967 -->
-
-<!-- TODO -->

--- a/release-content/0.16/release-notes/18017_allow_Call_and_Closure_expressions_in_hook_macro_attribute.md
+++ b/release-content/0.16/release-notes/18017_allow_Call_and_Closure_expressions_in_hook_macro_attribute.md
@@ -1,4 +1,0 @@
-<!-- allow `Call` and `Closure` expressions in hook macro attributes -->
-<!-- https://github.com/bevyengine/bevy/pull/18017 -->
-
-<!-- TODO -->

--- a/release-content/0.16/release-notes/18093_Transform_Propagation_Optimization_Static_Subtree_Marking.md
+++ b/release-content/0.16/release-notes/18093_Transform_Propagation_Optimization_Static_Subtree_Marking.md
@@ -1,4 +1,0 @@
-<!-- Transform Propagation Optimization: Static Subtree Marking -->
-<!-- https://github.com/bevyengine/bevy/pull/18093 -->
-
-<!-- TODO -->

--- a/release-content/0.16/release-notes/_release-notes.toml
+++ b/release-content/0.16/release-notes/_release-notes.toml
@@ -62,10 +62,10 @@ prs = [16589, 17043, 17753, 18144, 18454]
 file_name = "16589_Fallible_systems.md"
 
 [[release_notes]]
-title = "Use multidraw for opaque meshes when GPU culling is in use."
+title = "GPU-driven rendering"
 authors = ["@pcwalton"]
 contributors = []
-prs = [16427]
+prs = [16427]                                                                     # TODO: there are way more that need to be included here
 file_name = "16427_Use_multidraw_for_opaque_meshes_when_GPU_culling_is_in_use.md"
 
 [[release_notes]]

--- a/release-content/0.16/release-notes/_release-notes.toml
+++ b/release-content/0.16/release-notes/_release-notes.toml
@@ -237,13 +237,6 @@ prs = [17840]
 file_name = "17840_Parallel_Transform_Propagation.md"
 
 [[release_notes]]
-title = "Upgrade to Rust Edition 2024"
-authors = ["@bushrat011899"]
-contributors = ["@mockersf"]
-prs = [17967]
-file_name = "17967_Upgrade_to_Rust_Edition_2024.md"
-
-[[release_notes]]
 title = "BRP resource methods"
 authors = ["@mweatherley"]
 contributors = []

--- a/release-content/0.16/release-notes/_release-notes.toml
+++ b/release-content/0.16/release-notes/_release-notes.toml
@@ -1,336 +1,335 @@
 [[release_notes]]
 title = "Getting `QueryState` from immutable `World` reference"
-authors = ["@vil-mo",]
+authors = ["@vil-mo"]
 contributors = []
 prs = [16434]
 file_name = "16434_Getting_QueryState_from_immutable_World_reference.md"
 
 [[release_notes]]
 title = "Multiple box shadow support"
-authors = ["@ickshonpe",]
+authors = ["@ickshonpe"]
 contributors = ["@alice-i-cecile"]
 prs = [16502]
 file_name = "16502_Multiple_box_shadow_support.md"
 
 [[release_notes]]
 title = "Entity cloning"
-authors = ["@eugineerd",]
+authors = ["@eugineerd"]
 contributors = []
 prs = [16132]
 file_name = "16132_Entity_cloning.md"
 
 [[release_notes]]
 title = "Add a bindless mode to `AsBindGroup`."
-authors = ["@pcwalton",]
+authors = ["@pcwalton"]
 contributors = []
 prs = [16368]
 file_name = "16368_Add_a_bindless_mode_to_AsBindGroup.md"
 
 [[release_notes]]
 title = "Add optional transparency passthrough for sprite backend with bevy_picking"
-authors = ["@vandie",]
+authors = ["@vandie"]
 contributors = ["@andriyDev"]
 prs = [16388]
 file_name = "16388_Add_optional_transparency_passthrough_for_sprite_backend_w.md"
 
 [[release_notes]]
 title = "Move required components doc to type doc"
-authors = ["@SpecificProtagonist",]
+authors = ["@SpecificProtagonist"]
 contributors = ["@alice-i-cecile", "@JMS55"]
 prs = [16575]
 file_name = "16575_Move_required_components_doc_to_type_doc.md"
 
 [[release_notes]]
 title = "Retained `Gizmo`s"
-authors = ["@tim-blackbird",]
+authors = ["@tim-blackbird"]
 contributors = []
 prs = [15473]
 file_name = "15473_Retained_Gizmos.md"
 
 [[release_notes]]
 title = "Add Immutable `Component` Support"
-authors = ["@bushrat011899",]
+authors = ["@bushrat011899"]
 contributors = ["@nakedible", "@MrGVSV", "@BenjaminBrienen", "@alice-i-cecile"]
 prs = [16372]
 file_name = "16372_Add_Immutable_Component_Support.md"
 
 [[release_notes]]
 title = "Add \"bevy_input_focus\" crate."
-authors = ["@viridia",]
+authors = ["@viridia"]
 contributors = []
 prs = [15611]
 file_name = "15611_Add_bevy_input_focus_crate.md"
 
 [[release_notes]]
 title = "Add optional transparency passthrough for sprite backend with bevy_picking"
-authors = ["@vandie",]
+authors = ["@vandie"]
 contributors = ["@andriyDev"]
 prs = [16388]
 file_name = "16388_Add_optional_transparency_passthrough_for_sprite_backend_w.md"
 
 [[release_notes]]
 title = "Fallible systems"
-authors = ["@NthTensor",]
+authors = ["@NthTensor"]
 contributors = ["@bushrat011899"]
 prs = [16589]
 file_name = "16589_Fallible_systems.md"
 
 [[release_notes]]
 title = "Use multidraw for opaque meshes when GPU culling is in use."
-authors = ["@pcwalton",]
+authors = ["@pcwalton"]
 contributors = []
 prs = [16427]
 file_name = "16427_Use_multidraw_for_opaque_meshes_when_GPU_culling_is_in_use.md"
 
 [[release_notes]]
 title = "bevy_reflect: Function Overloading (Generic & Variadic Functions)"
-authors = ["@MrGVSV",]
+authors = ["@MrGVSV"]
 contributors = []
 prs = [15074]
 file_name = "15074_bevy_reflect_Function_Overloading_Generic__Variadic_Functi.md"
 
 [[release_notes]]
 title = "Derivative access patterns for curves"
-authors = ["@mweatherley",]
+authors = ["@mweatherley"]
 contributors = ["@alice-i-cecile"]
 prs = [16503]
 file_name = "16503_Derivative_access_patterns_for_curves.md"
 
 [[release_notes]]
 title = "Event source location tracking"
-authors = ["@SpecificProtagonist",]
+authors = ["@SpecificProtagonist"]
 contributors = ["@alice-i-cecile"]
 prs = [16778]
 file_name = "16778_Event_source_location_tracking.md"
 
 [[release_notes]]
 title = "Extend cloning functionality and add convenience methods to `EntityWorldMut` and `EntityCommands`"
-authors = ["@JaySpruce",]
+authors = ["@JaySpruce"]
 contributors = []
 prs = [16826]
 file_name = "16826_Extend_cloning_functionality_and_add_convenience_methods_t.md"
 
 [[release_notes]]
 title = "Tab navigation framework for bevy_input_focus."
-authors = ["@viridia",]
+authors = ["@viridia"]
 contributors = ["@alice-i-cecile"]
 prs = [16795]
 file_name = "16795_Tab_navigation_framework_for_bevy_input_focus.md"
 
 [[release_notes]]
 title = "track_change_detection: Also track spawns/despawns"
-authors = ["@SpecificProtagonist",]
+authors = ["@SpecificProtagonist"]
 contributors = ["Freya Pines", "@pin3-free", "@mweatherley"]
 prs = [16047]
 file_name = "16047_track_change_detection_Also_track_spawnsdespawns.md"
 
 [[release_notes]]
 title = "Add `AssetChanged` query filter"
-authors = ["@tychedelia",]
+authors = ["@tychedelia"]
 contributors = ["@chescock", "@pcwalton", "@alice-i-cecile", "@nicopap"]
 prs = [16810]
 file_name = "16810_Add_AssetChanged_query_filter.md"
 
 [[release_notes]]
 title = "Add `no_std` support to `bevy_ecs`"
-authors = ["@bushrat011899",]
+authors = ["@bushrat011899"]
 contributors = ["@alice-i-cecile", "@Victoronz"]
 prs = [16758]
 file_name = "16758_Add_no_std_support_to_bevy_ecs.md"
 
 [[release_notes]]
 title = "Add `no_std` support to `bevy_app`"
-authors = ["@bushrat011899",]
+authors = ["@bushrat011899"]
 contributors = ["@alice-i-cecile"]
 prs = [16874]
 file_name = "16874_Add_no_std_support_to_bevy_app.md"
 
 [[release_notes]]
 title = "Anamorphic Bloom"
-authors = ["@aevyrie",]
+authors = ["@aevyrie"]
 contributors = []
 prs = [17096]
 file_name = "17096_Anamorphic_Bloom.md"
 
 [[release_notes]]
 title = "Add `Result` handling to `Commands` and `EntityCommands`"
-authors = ["@JaySpruce",]
+authors = ["@JaySpruce"]
 contributors = []
 prs = [17043]
 file_name = "17043_Add_Result_handling_to_Commands_and_EntityCommands.md"
 
 [[release_notes]]
 title = "Forward decals (port of bevy_contact_projective_decals)"
-authors = ["@JMS55",]
+authors = ["@JMS55"]
 contributors = ["@IceSentry"]
 prs = [16600]
 file_name = "16600_Forward_decals_port_of_bevy_contact_projective_decals.md"
 
 [[release_notes]]
 title = "Relationships (non-fragmenting, one-to-many)"
-authors = ["@cart",]
+authors = ["@cart"]
 contributors = ["@alice-i-cecile"]
 prs = [17398]
 file_name = "17398_Relationships_nonfragmenting_onetomany.md"
 
 [[release_notes]]
 title = "Add DefaultQueryFilters"
-authors = ["@NiseVoid",]
+authors = ["@NiseVoid"]
 contributors = []
 prs = [13120]
 file_name = "13120_Add_DefaultQueryFilters.md"
 
 [[release_notes]]
 title = "Track callsite for observers & hooks"
-authors = ["@SpecificProtagonist",]
+authors = ["@SpecificProtagonist"]
 contributors = ["@alice-i-cecile"]
 prs = [15607]
 file_name = "15607_Track_callsite_for_observers__hooks.md"
 
 [[release_notes]]
 title = "Procedural atmospheric scattering"
-authors = ["@ecoskey",]
+authors = ["@ecoskey"]
 contributors = ["@mate-h", "@atlv24", "@JMS55"]
 prs = [16314]
 file_name = "16314_Procedural_atmospheric_scattering.md"
 
 [[release_notes]]
 title = "Proportional scaling for the sprite's texture."
-authors = ["@silvestrpredko",]
+authors = ["@silvestrpredko"]
 contributors = []
 prs = [17258]
 file_name = "17258_Proportional_scaling_for_the_sprites_texture.md"
 
 [[release_notes]]
 title = "Implement basic clustered decal projectors."
-authors = ["@pcwalton",]
+authors = ["@pcwalton"]
 contributors = []
 prs = [17315]
 file_name = "17315_Implement_basic_clustered_decal_projectors.md"
 
 [[release_notes]]
 title = "Add support for specular tints and maps per the `KHR_materials_specular` glTF extension."
-authors = ["@pcwalton",]
+authors = ["@pcwalton"]
 contributors = []
 prs = [14069]
 file_name = "14069_Add_support_for_specular_tints_and_maps_per_the_KHR_materi.md"
 
 [[release_notes]]
 title = "Implement experimental GPU two-phase occlusion culling for the standard 3D mesh pipeline."
-authors = ["@pcwalton",]
+authors = ["@pcwalton"]
 contributors = []
 prs = [17413]
 file_name = "17413_Implement_experimental_GPU_twophase_occlusion_culling_for_.md"
 
 [[release_notes]]
 title = "Cold Specialization"
-authors = ["@tychedelia",]
+authors = ["@tychedelia"]
 contributors = ["@pcwalton"]
 prs = [17567]
 file_name = "17567_Cold_Specialization.md"
 
 [[release_notes]]
 title = "Introduce methods on QueryState to obtain a Query"
-authors = ["@chescock",]
+authors = ["@chescock"]
 contributors = []
 prs = [15858]
 file_name = "15858_Introduce_methods_on_QueryState_to_obtain_a_Query.md"
 
 [[release_notes]]
 title = "Basic UI text shadows"
-authors = ["@ickshonpe",]
+authors = ["@ickshonpe"]
 contributors = []
 prs = [17559]
 file_name = "17559_Basic_UI_text_shadows.md"
 
 [[release_notes]]
 title = "Improved Spawn APIs and Bundle Effects"
-authors = ["@cart",]
+authors = ["@cart"]
 contributors = ["@alice-i-cecile", "@MrGVSV", "@ecoskey"]
 prs = [17521]
 file_name = "17521_Improved_Spawn_APIs_and_Bundle_Effects.md"
 
 [[release_notes]]
 title = "feat(ecs): configurable error handling for fallible systems"
-authors = ["@JeanMertz",]
+authors = ["@JeanMertz"]
 contributors = []
 prs = [17753]
 file_name = "17753_featecs_configurable_error_handling_for_fallible_systems.md"
 
 [[release_notes]]
 title = "Trait tags on docs.rs"
-authors = ["@SpecificProtagonist",]
+authors = ["@SpecificProtagonist"]
 contributors = ["@Jondolf", "@Carter0"]
 prs = [17758]
 file_name = "17758_Trait_tags_on_docsrs.md"
 
 [[release_notes]]
 title = "Parallel Transform Propagation"
-authors = ["@aevyrie",]
+authors = ["@aevyrie"]
 contributors = ["@alice-i-cecile", "@mockersf"]
 prs = [17840]
 file_name = "17840_Parallel_Transform_Propagation.md"
 
 [[release_notes]]
 title = "Upgrade to Rust Edition 2024"
-authors = ["@bushrat011899",]
+authors = ["@bushrat011899"]
 contributors = ["@mockersf"]
 prs = [17967]
 file_name = "17967_Upgrade_to_Rust_Edition_2024.md"
 
 [[release_notes]]
 title = "BRP resource methods"
-authors = ["@mweatherley",]
+authors = ["@mweatherley"]
 contributors = []
 prs = [17423]
 file_name = "17423_BRP_resource_methods.md"
 
 [[release_notes]]
 title = "Replace Ambient Lights with Environment Map Lights"
-authors = ["@SparkyPotato",]
+authors = ["@SparkyPotato"]
 contributors = []
 prs = [17482]
 file_name = "17482_Replace_Ambient_Lights_with_Environment_Map_Lights.md"
 
 [[release_notes]]
 title = "allow `Call` and `Closure` expressions in hook macro attributes"
-authors = ["@RobWalt",]
+authors = ["@RobWalt"]
 contributors = []
 prs = [18017]
 file_name = "18017_allow_Call_and_Closure_expressions_in_hook_macro_attribute.md"
 
 [[release_notes]]
 title = "Stop automatically generating meta files for assets while using asset processing."
-authors = ["@andriyDev",]
+authors = ["@andriyDev"]
 contributors = []
 prs = [17216]
 file_name = "17216_Stop_automatically_generating_meta_files_for_assets_while_.md"
 
 [[release_notes]]
 title = "Add `no_std` support to `bevy`"
-authors = ["@bushrat011899",]
+authors = ["@bushrat011899"]
 contributors = ["@alice-i-cecile"]
 prs = [17955]
 file_name = "17955_Add_no_std_support_to_bevy.md"
 
 [[release_notes]]
 title = "Add support for experimental WESL shader source"
-authors = ["@tychedelia",]
+authors = ["@tychedelia"]
 contributors = []
 prs = [17953]
 file_name = "17953_Add_support_for_experimental_WESL_shader_source.md"
 
 [[release_notes]]
 title = "Transform Propagation Optimization: Static Subtree Marking"
-authors = ["@aevyrie",]
+authors = ["@aevyrie"]
 contributors = []
 prs = [18093]
 file_name = "18093_Transform_Propagation_Optimization_Static_Subtree_Marking.md"
 
 [[release_notes]]
 title = "Link iOS example with `rustc`, and avoid C trampoline"
-authors = ["@madsmtm",]
+authors = ["@madsmtm"]
 contributors = ["@mockersf"]
 prs = [14780]
 file_name = "14780_Link_iOS_example_with_rustc_and_avoid_C_trampoline.md"
-

--- a/release-content/0.16/release-notes/_release-notes.toml
+++ b/release-content/0.16/release-notes/_release-notes.toml
@@ -188,13 +188,6 @@ prs = [17840]
 file_name = "17840_Parallel_Transform_Propagation.md"
 
 [[release_notes]]
-title = "BRP resource methods"
-authors = ["@mweatherley"]
-contributors = []
-prs = [17423]
-file_name = "17423_BRP_resource_methods.md"
-
-[[release_notes]]
 title = "Stop automatically generating meta files for assets while using asset processing."
 authors = ["@andriyDev"]
 contributors = []

--- a/release-content/0.16/release-notes/_release-notes.toml
+++ b/release-content/0.16/release-notes/_release-notes.toml
@@ -83,18 +83,11 @@ prs = [16503]
 file_name = "16503_Derivative_access_patterns_for_curves.md"
 
 [[release_notes]]
-title = "Event source location tracking"
+title = "Better location tracking"
 authors = ["@SpecificProtagonist"]
-contributors = ["@alice-i-cecile"]
-prs = [16778]
+contributors = ["@alice-i-cecile", "Freya Pines", "@pin3-free", "@mweatherley"]
+prs = [15607, 16047, 16778]
 file_name = "16778_Event_source_location_tracking.md"
-
-[[release_notes]]
-title = "track_change_detection: Also track spawns/despawns"
-authors = ["@SpecificProtagonist"]
-contributors = ["Freya Pines", "@pin3-free", "@mweatherley"]
-prs = [16047]
-file_name = "16047_track_change_detection_Also_track_spawnsdespawns.md"
 
 [[release_notes]]
 title = "Add `AssetChanged` query filter"
@@ -130,13 +123,6 @@ authors = ["@NiseVoid"]
 contributors = []
 prs = [13120]
 file_name = "13120_Add_DefaultQueryFilters.md"
-
-[[release_notes]]
-title = "Track callsite for observers & hooks"
-authors = ["@SpecificProtagonist"]
-contributors = ["@alice-i-cecile"]
-prs = [15607]
-file_name = "15607_Track_callsite_for_observers__hooks.md"
 
 [[release_notes]]
 title = "Procedural atmospheric scattering"

--- a/release-content/0.16/release-notes/_release-notes.toml
+++ b/release-content/0.16/release-notes/_release-notes.toml
@@ -118,20 +118,6 @@ prs = [16810]
 file_name = "16810_Add_AssetChanged_query_filter.md"
 
 [[release_notes]]
-title = "Add `no_std` support to `bevy_ecs`"
-authors = ["@bushrat011899"]
-contributors = ["@alice-i-cecile", "@Victoronz"]
-prs = [16758]
-file_name = "16758_Add_no_std_support_to_bevy_ecs.md"
-
-[[release_notes]]
-title = "Add `no_std` support to `bevy_app`"
-authors = ["@bushrat011899"]
-contributors = ["@alice-i-cecile"]
-prs = [16874]
-file_name = "16874_Add_no_std_support_to_bevy_app.md"
-
-[[release_notes]]
 title = "Anamorphic Bloom"
 authors = ["@aevyrie"]
 contributors = []

--- a/release-content/0.16/release-notes/_release-notes.toml
+++ b/release-content/0.16/release-notes/_release-notes.toml
@@ -1,37 +1,4 @@
-[[release_notes]]
-title = "Multiple box shadow support"
-authors = ["@ickshonpe"]
-contributors = ["@alice-i-cecile"]
-prs = [16502]
-file_name = "16502_Multiple_box_shadow_support.md"
-
-[[release_notes]]
-title = "Entity cloning"
-authors = ["@eugineerd", "@JaySpruce"]
-contributors = []
-prs = [16132, 16826]
-file_name = "16132_Entity_cloning.md"
-
-[[release_notes]]
-title = "Add a bindless mode to `AsBindGroup`."
-authors = ["@pcwalton"]
-contributors = []
-prs = [16368]
-file_name = "16368_Add_a_bindless_mode_to_AsBindGroup.md"
-
-[[release_notes]]
-title = "Add optional transparency passthrough for sprite backend with bevy_picking"
-authors = ["@vandie"]
-contributors = ["@andriyDev"]
-prs = [16388]
-file_name = "16388_Add_optional_transparency_passthrough_for_sprite_backend_w.md"
-
-[[release_notes]]
-title = "Retained `Gizmo`s"
-authors = ["@tim-blackbird"]
-contributors = []
-prs = [15473]
-file_name = "15473_Retained_Gizmos.md"
+# ECS
 
 [[release_notes]]
 title = "Add Immutable `Component` Support"
@@ -41,18 +8,32 @@ prs = [16372]
 file_name = "16372_Add_Immutable_Component_Support.md"
 
 [[release_notes]]
-title = "Add \"bevy_input_focus\" crate."
-authors = ["@viridia", "@alice-i-cecile"]
-contributors = []
-prs = [15611, 16795]
-file_name = "15611_Add_bevy_input_focus_crate.md"
+title = "Relationships (non-fragmenting, one-to-many)"
+authors = ["@cart"]
+contributors = ["@alice-i-cecile"]
+prs = [17398]
+file_name = "17398_Relationships_nonfragmenting_onetomany.md"
 
 [[release_notes]]
-title = "Add optional transparency passthrough for sprite backend with bevy_picking"
-authors = ["@vandie"]
-contributors = ["@andriyDev"]
-prs = [16388]
-file_name = "16388_Add_optional_transparency_passthrough_for_sprite_backend_w.md"
+title = "Improved Spawn APIs and Bundle Effects"
+authors = ["@cart"]
+contributors = ["@alice-i-cecile", "@MrGVSV", "@ecoskey"]
+prs = [17521]
+file_name = "17521_Improved_Spawn_APIs_and_Bundle_Effects.md"
+
+[[release_notes]]
+title = "Entity cloning"
+authors = ["@eugineerd", "@JaySpruce"]
+contributors = []
+prs = [16132, 16826]
+file_name = "16132_Entity_cloning.md"
+
+[[release_notes]]
+title = "Add DefaultQueryFilters"
+authors = ["@NiseVoid"]
+contributors = []
+prs = [13120]
+file_name = "13120_Add_DefaultQueryFilters.md"
 
 [[release_notes]]
 title = "Unified ECS error handling"
@@ -62,39 +43,27 @@ prs = [16589, 17043, 17753, 18144, 18454]
 file_name = "16589_Fallible_systems.md"
 
 [[release_notes]]
-title = "GPU-driven rendering"
-authors = ["@pcwalton"]
-contributors = []
-prs = [16427]                                                                     # TODO: there are way more that need to be included here
-file_name = "16427_Use_multidraw_for_opaque_meshes_when_GPU_culling_is_in_use.md"
-
-[[release_notes]]
-title = "bevy_reflect: Function Overloading (Generic & Variadic Functions)"
-authors = ["@MrGVSV"]
-contributors = []
-prs = [15074]
-file_name = "15074_bevy_reflect_Function_Overloading_Generic__Variadic_Functi.md"
-
-[[release_notes]]
-title = "Derivative access patterns for curves"
-authors = ["@mweatherley"]
-contributors = ["@alice-i-cecile"]
-prs = [16503]
-file_name = "16503_Derivative_access_patterns_for_curves.md"
-
-[[release_notes]]
 title = "Better location tracking"
 authors = ["@SpecificProtagonist"]
 contributors = ["@alice-i-cecile", "Freya Pines", "@pin3-free", "@mweatherley"]
 prs = [15607, 16047, 16778]
 file_name = "16778_Event_source_location_tracking.md"
 
+# Rendering
+
 [[release_notes]]
-title = "Add `AssetChanged` query filter"
-authors = ["@tychedelia"]
-contributors = ["@chescock", "@pcwalton", "@alice-i-cecile", "@nicopap"]
-prs = [16810]
-file_name = "16810_Add_AssetChanged_query_filter.md"
+title = "GPU-driven rendering"
+authors = ["@pcwalton"]
+contributors = []
+prs = [16427]
+file_name = "16427_Use_multidraw_for_opaque_meshes_when_GPU_culling_is_in_use.md"
+
+[[release_notes]]
+title = "Add a bindless mode to `AsBindGroup`."
+authors = ["@pcwalton"]
+contributors = []
+prs = [16368]
+file_name = "16368_Add_a_bindless_mode_to_AsBindGroup.md"
 
 [[release_notes]]
 title = "Anamorphic Bloom"
@@ -109,20 +78,6 @@ authors = ["@JMS55"]
 contributors = ["@IceSentry"]
 prs = [16600]
 file_name = "16600_Forward_decals_port_of_bevy_contact_projective_decals.md"
-
-[[release_notes]]
-title = "Relationships (non-fragmenting, one-to-many)"
-authors = ["@cart"]
-contributors = ["@alice-i-cecile"]
-prs = [17398]
-file_name = "17398_Relationships_nonfragmenting_onetomany.md"
-
-[[release_notes]]
-title = "Add DefaultQueryFilters"
-authors = ["@NiseVoid"]
-contributors = []
-prs = [13120]
-file_name = "13120_Add_DefaultQueryFilters.md"
 
 [[release_notes]]
 title = "Procedural atmospheric scattering"
@@ -153,11 +108,13 @@ prs = [17413]
 file_name = "17413_Implement_experimental_GPU_twophase_occlusion_culling_for_.md"
 
 [[release_notes]]
-title = "Cold Specialization"
+title = "Add support for experimental WESL shader source"
 authors = ["@tychedelia"]
-contributors = ["@pcwalton"]
-prs = [17567]
-file_name = "17567_Cold_Specialization.md"
+contributors = []
+prs = [17953]
+file_name = "17953_Add_support_for_experimental_WESL_shader_source.md"
+
+# UI
 
 [[release_notes]]
 title = "Basic UI text shadows"
@@ -167,11 +124,72 @@ prs = [17559]
 file_name = "17559_Basic_UI_text_shadows.md"
 
 [[release_notes]]
-title = "Improved Spawn APIs and Bundle Effects"
-authors = ["@cart"]
-contributors = ["@alice-i-cecile", "@MrGVSV", "@ecoskey"]
-prs = [17521]
-file_name = "17521_Improved_Spawn_APIs_and_Bundle_Effects.md"
+title = "Multiple box shadow support"
+authors = ["@ickshonpe"]
+contributors = ["@alice-i-cecile"]
+prs = [16502]
+file_name = "16502_Multiple_box_shadow_support.md"
+
+[[release_notes]]
+title = "Add \"bevy_input_focus\" crate."
+authors = ["@viridia", "@alice-i-cecile"]
+contributors = []
+prs = [15611, 16795]
+file_name = "15611_Add_bevy_input_focus_crate.md"
+
+# Gizmos
+
+[[release_notes]]
+title = "Retained `Gizmo`s"
+authors = ["@tim-blackbird"]
+contributors = []
+prs = [15473]
+file_name = "15473_Retained_Gizmos.md"
+
+# Picking
+
+[[release_notes]]
+title = "Add optional transparency passthrough for sprite backend with bevy_picking"
+authors = ["@vandie"]
+contributors = ["@andriyDev"]
+prs = [16388]
+file_name = "16388_Add_optional_transparency_passthrough_for_sprite_backend_w.md"
+
+# Reflection
+
+[[release_notes]]
+title = "bevy_reflect: Function Overloading (Generic & Variadic Functions)"
+authors = ["@MrGVSV"]
+contributors = []
+prs = [15074]
+file_name = "15074_bevy_reflect_Function_Overloading_Generic__Variadic_Functi.md"
+
+# Math
+
+[[release_notes]]
+title = "Derivative access patterns for curves"
+authors = ["@mweatherley"]
+contributors = ["@alice-i-cecile"]
+prs = [16503]
+file_name = "16503_Derivative_access_patterns_for_curves.md"
+
+# Assets
+
+[[release_notes]]
+title = "Add `AssetChanged` query filter"
+authors = ["@tychedelia"]
+contributors = ["@chescock", "@pcwalton", "@alice-i-cecile", "@nicopap"]
+prs = [16810]
+file_name = "16810_Add_AssetChanged_query_filter.md"
+
+[[release_notes]]
+title = "Stop automatically generating meta files for assets while using asset processing."
+authors = ["@andriyDev"]
+contributors = []
+prs = [17216]
+file_name = "17216_Stop_automatically_generating_meta_files_for_assets_while_.md"
+
+# Grab bag
 
 [[release_notes]]
 title = "Trait tags on docs.rs"
@@ -188,22 +206,8 @@ prs = [17840]
 file_name = "17840_Parallel_Transform_Propagation.md"
 
 [[release_notes]]
-title = "Stop automatically generating meta files for assets while using asset processing."
-authors = ["@andriyDev"]
-contributors = []
-prs = [17216]
-file_name = "17216_Stop_automatically_generating_meta_files_for_assets_while_.md"
-
-[[release_notes]]
 title = "Add `no_std` support to `bevy`"
 authors = ["@bushrat011899"]
 contributors = ["@alice-i-cecile"]
 prs = [17955]
 file_name = "17955_Add_no_std_support_to_bevy.md"
-
-[[release_notes]]
-title = "Add support for experimental WESL shader source"
-authors = ["@tychedelia"]
-contributors = []
-prs = [17953]
-file_name = "17953_Add_support_for_experimental_WESL_shader_source.md"

--- a/release-content/0.16/release-notes/_release-notes.toml
+++ b/release-content/0.16/release-notes/_release-notes.toml
@@ -272,13 +272,6 @@ prs = [17953]
 file_name = "17953_Add_support_for_experimental_WESL_shader_source.md"
 
 [[release_notes]]
-title = "Transform Propagation Optimization: Static Subtree Marking"
-authors = ["@aevyrie"]
-contributors = []
-prs = [18093]
-file_name = "18093_Transform_Propagation_Optimization_Static_Subtree_Marking.md"
-
-[[release_notes]]
 title = "Link iOS example with `rustc`, and avoid C trampoline"
 authors = ["@madsmtm"]
 contributors = ["@mockersf"]

--- a/release-content/0.16/release-notes/_release-notes.toml
+++ b/release-content/0.16/release-notes/_release-notes.toml
@@ -195,13 +195,6 @@ prs = [17423]
 file_name = "17423_BRP_resource_methods.md"
 
 [[release_notes]]
-title = "Replace Ambient Lights with Environment Map Lights"
-authors = ["@SparkyPotato"]
-contributors = []
-prs = [17482]
-file_name = "17482_Replace_Ambient_Lights_with_Environment_Map_Lights.md"
-
-[[release_notes]]
 title = "Stop automatically generating meta files for assets while using asset processing."
 authors = ["@andriyDev"]
 contributors = []

--- a/release-content/0.16/release-notes/_release-notes.toml
+++ b/release-content/0.16/release-notes/_release-notes.toml
@@ -195,13 +195,6 @@ prs = [17567]
 file_name = "17567_Cold_Specialization.md"
 
 [[release_notes]]
-title = "Introduce methods on QueryState to obtain a Query"
-authors = ["@chescock"]
-contributors = []
-prs = [15858]
-file_name = "15858_Introduce_methods_on_QueryState_to_obtain_a_Query.md"
-
-[[release_notes]]
 title = "Basic UI text shadows"
 authors = ["@ickshonpe"]
 contributors = []

--- a/release-content/0.16/release-notes/_release-notes.toml
+++ b/release-content/0.16/release-notes/_release-notes.toml
@@ -1,11 +1,4 @@
 [[release_notes]]
-title = "Getting `QueryState` from immutable `World` reference"
-authors = ["@vil-mo"]
-contributors = []
-prs = [16434]
-file_name = "16434_Getting_QueryState_from_immutable_World_reference.md"
-
-[[release_notes]]
 title = "Multiple box shadow support"
 authors = ["@ickshonpe"]
 contributors = ["@alice-i-cecile"]

--- a/release-content/0.16/release-notes/_release-notes.toml
+++ b/release-content/0.16/release-notes/_release-notes.toml
@@ -55,10 +55,10 @@ prs = [16388]
 file_name = "16388_Add_optional_transparency_passthrough_for_sprite_backend_w.md"
 
 [[release_notes]]
-title = "Fallible systems"
-authors = ["@NthTensor"]
+title = "Unified ECS error handling"
+authors = ["@NthTensor", "@JeanMertz", "@JaySpruce", "@cart", "@alice-i-cecile"]
 contributors = ["@bushrat011899"]
-prs = [16589]
+prs = [16589, 17043, 17753, 18144, 18454]
 file_name = "16589_Fallible_systems.md"
 
 [[release_notes]]
@@ -116,13 +116,6 @@ authors = ["@aevyrie"]
 contributors = []
 prs = [17096]
 file_name = "17096_Anamorphic_Bloom.md"
-
-[[release_notes]]
-title = "Add `Result` handling to `Commands` and `EntityCommands`"
-authors = ["@JaySpruce"]
-contributors = []
-prs = [17043]
-file_name = "17043_Add_Result_handling_to_Commands_and_EntityCommands.md"
 
 [[release_notes]]
 title = "Forward decals (port of bevy_contact_projective_decals)"
@@ -200,13 +193,6 @@ authors = ["@cart"]
 contributors = ["@alice-i-cecile", "@MrGVSV", "@ecoskey"]
 prs = [17521]
 file_name = "17521_Improved_Spawn_APIs_and_Bundle_Effects.md"
-
-[[release_notes]]
-title = "feat(ecs): configurable error handling for fallible systems"
-authors = ["@JeanMertz"]
-contributors = []
-prs = [17753]
-file_name = "17753_featecs_configurable_error_handling_for_fallible_systems.md"
 
 [[release_notes]]
 title = "Trait tags on docs.rs"

--- a/release-content/0.16/release-notes/_release-notes.toml
+++ b/release-content/0.16/release-notes/_release-notes.toml
@@ -167,13 +167,6 @@ prs = [16314]
 file_name = "16314_Procedural_atmospheric_scattering.md"
 
 [[release_notes]]
-title = "Proportional scaling for the sprite's texture."
-authors = ["@silvestrpredko"]
-contributors = []
-prs = [17258]
-file_name = "17258_Proportional_scaling_for_the_sprites_texture.md"
-
-[[release_notes]]
 title = "Implement basic clustered decal projectors."
 authors = ["@pcwalton"]
 contributors = []

--- a/release-content/0.16/release-notes/_release-notes.toml
+++ b/release-content/0.16/release-notes/_release-notes.toml
@@ -270,10 +270,3 @@ authors = ["@tychedelia"]
 contributors = []
 prs = [17953]
 file_name = "17953_Add_support_for_experimental_WESL_shader_source.md"
-
-[[release_notes]]
-title = "Link iOS example with `rustc`, and avoid C trampoline"
-authors = ["@madsmtm"]
-contributors = ["@mockersf"]
-prs = [14780]
-file_name = "14780_Link_iOS_example_with_rustc_and_avoid_C_trampoline.md"

--- a/release-content/0.16/release-notes/_release-notes.toml
+++ b/release-content/0.16/release-notes/_release-notes.toml
@@ -202,13 +202,6 @@ prs = [17482]
 file_name = "17482_Replace_Ambient_Lights_with_Environment_Map_Lights.md"
 
 [[release_notes]]
-title = "allow `Call` and `Closure` expressions in hook macro attributes"
-authors = ["@RobWalt"]
-contributors = []
-prs = [18017]
-file_name = "18017_allow_Call_and_Closure_expressions_in_hook_macro_attribute.md"
-
-[[release_notes]]
 title = "Stop automatically generating meta files for assets while using asset processing."
 authors = ["@andriyDev"]
 contributors = []

--- a/release-content/0.16/release-notes/_release-notes.toml
+++ b/release-content/0.16/release-notes/_release-notes.toml
@@ -27,13 +27,6 @@ prs = [16388]
 file_name = "16388_Add_optional_transparency_passthrough_for_sprite_backend_w.md"
 
 [[release_notes]]
-title = "Move required components doc to type doc"
-authors = ["@SpecificProtagonist"]
-contributors = ["@alice-i-cecile", "@JMS55"]
-prs = [16575]
-file_name = "16575_Move_required_components_doc_to_type_doc.md"
-
-[[release_notes]]
 title = "Retained `Gizmo`s"
 authors = ["@tim-blackbird"]
 contributors = []

--- a/release-content/0.16/release-notes/_release-notes.toml
+++ b/release-content/0.16/release-notes/_release-notes.toml
@@ -42,9 +42,9 @@ file_name = "16372_Add_Immutable_Component_Support.md"
 
 [[release_notes]]
 title = "Add \"bevy_input_focus\" crate."
-authors = ["@viridia"]
+authors = ["@viridia", "@alice-i-cecile"]
 contributors = []
-prs = [15611]
+prs = [15611, 16795]
 file_name = "15611_Add_bevy_input_focus_crate.md"
 
 [[release_notes]]
@@ -95,13 +95,6 @@ authors = ["@JaySpruce"]
 contributors = []
 prs = [16826]
 file_name = "16826_Extend_cloning_functionality_and_add_convenience_methods_t.md"
-
-[[release_notes]]
-title = "Tab navigation framework for bevy_input_focus."
-authors = ["@viridia"]
-contributors = ["@alice-i-cecile"]
-prs = [16795]
-file_name = "16795_Tab_navigation_framework_for_bevy_input_focus.md"
 
 [[release_notes]]
 title = "track_change_detection: Also track spawns/despawns"

--- a/release-content/0.16/release-notes/_release-notes.toml
+++ b/release-content/0.16/release-notes/_release-notes.toml
@@ -7,9 +7,9 @@ file_name = "16502_Multiple_box_shadow_support.md"
 
 [[release_notes]]
 title = "Entity cloning"
-authors = ["@eugineerd"]
+authors = ["@eugineerd", "@JaySpruce"]
 contributors = []
-prs = [16132]
+prs = [16132, 16826]
 file_name = "16132_Entity_cloning.md"
 
 [[release_notes]]
@@ -88,13 +88,6 @@ authors = ["@SpecificProtagonist"]
 contributors = ["@alice-i-cecile"]
 prs = [16778]
 file_name = "16778_Event_source_location_tracking.md"
-
-[[release_notes]]
-title = "Extend cloning functionality and add convenience methods to `EntityWorldMut` and `EntityCommands`"
-authors = ["@JaySpruce"]
-contributors = []
-prs = [16826]
-file_name = "16826_Extend_cloning_functionality_and_add_convenience_methods_t.md"
 
 [[release_notes]]
 title = "track_change_detection: Also track spawns/despawns"


### PR DESCRIPTION
This is the first crucial editing pass on the generated release notes. It's best reviewed commit-by-commit, as I've gone and done an organization pass by area at the very end to make it easier to find segments for now. Once the content is written we can do a proper editorial organization pass.

If you think one of the PRs that was cut is vital to talk about, make your case and I'll revert that commit if I agree.

