### PR TITLE
Generate stub root pages for release notes and migration guides for Bevy 0.16

### DIFF
--- a/content/learn/migration-guides/0.15-to-0.16.md
+++ b/content/learn/migration-guides/0.15-to-0.16.md
@@ -1,0 +1,9 @@
++++
+title = "0.15 to 0.16"
+insert_anchor_links = "right"
+[extra]
+weight = 11
+long_title = "Migration Guide: 0.15 to 0.16"
++++
+
+{{ migration_guides(version="0.16") }}

--- a/content/news/2025-XX-XX-bevy-0.16/index.md
+++ b/content/news/2025-XX-XX-bevy-0.16/index.md
@@ -7,6 +7,7 @@ show_image = true
 image_subtitle = "TODO"
 image_subtitle_link = "https://todo.example.com"
 public_draft = 2008
+status = 'hidden'
 +++
 
 Thanks to **??** contributors, **???** pull requests, community reviewers, and our [**generous donors**](/donate), we're happy to announce the **Bevy 0.16** release on [crates.io](https://crates.io/crates/bevy)!

--- a/content/news/2025-XX-XX-bevy-0.16/index.md
+++ b/content/news/2025-XX-XX-bevy-0.16/index.md
@@ -32,5 +32,5 @@ Peering deep into the mists of time (predictions are _extra_ hard when your team
 - TODO
 
 {{ support_bevy() }}
-{{ contributors(version="0.16") }}
-{{ changelog(version="0.16")}}
+TODO: add  contributors
+TODO: add changelog

--- a/content/news/2025-XX-XX-bevy-0.16/index.md
+++ b/content/news/2025-XX-XX-bevy-0.16/index.md
@@ -1,0 +1,35 @@
++++
+title = "Bevy 0.16"
+date = 2024-12-31 # TODO: fix date
+[extra]
+image = "cover.png"
+show_image = true
+image_subtitle = "TODO"
+image_subtitle_link = "https://todo.example.com"
+public_draft = 2008
++++
+
+Thanks to **??** contributors, **???** pull requests, community reviewers, and our [**generous donors**](/donate), we're happy to announce the **Bevy 0.16** release on [crates.io](https://crates.io/crates/bevy)!
+
+For those who don't know, Bevy is a refreshingly simple data-driven game engine built in Rust. You can check out our [Quick Start Guide](/learn/quick-start) to try it today. It's free and open source forever! You can grab the full [source code](https://github.com/bevyengine/bevy) on GitHub. Check out [Bevy Assets](https://bevyengine.org/assets) for a collection of community-developed plugins, games, and learning resources.
+
+To update an existing Bevy App or Plugin to **Bevy 0.16**, check out our [0.15 to 0.16 Migration Guide](/learn/migration-guides/0-15-to-0-16/).
+
+Since our last release a few months ago we've added a _ton_ of new features, bug fixes, and quality of life tweaks, but here are some of the highlights:
+
+- TODO
+
+<!-- more -->
+
+{{ release_notes(version="0.16") }}
+
+## What's Next?
+
+The features above may be great, but what else does Bevy have in flight?
+Peering deep into the mists of time (predictions are _extra_ hard when your team is almost all volunteers!), we can see some exciting work taking shape:
+
+- TODO
+
+{{ support_bevy() }}
+{{ contributors(version="0.16") }}
+{{ changelog(version="0.16")}}


### PR DESCRIPTION
The critical thing to double-check is that I got public_draft usage right for the release note page.