### PR TITLE
#18555: Release notes and migration guide

### DIFF
--- a/release-content/0.16/migration-guides/18555_Improved_require_syntax.md
+++ b/release-content/0.16/migration-guides/18555_Improved_require_syntax.md
@@ -1,0 +1,41 @@
+Custom-constructor requires should use the new expression-style syntax:
+
+```rust
+// before
+#[derive(Component)]
+#[require(A(returns_a))]
+struct Foo;
+
+// after
+#[derive(Component)]
+#[require(A = returns_a())]
+struct Foo;
+```
+
+Inline-closure-constructor requires should use the inline value syntax where possible:
+
+```rust
+// before
+#[derive(Component)]
+#[require(A(|| A(10))]
+struct Foo;
+
+// after
+#[derive(Component)]
+#[require(A(10)]
+struct Foo;
+```
+
+In cases where that is not possible, use the expression-style syntax:
+
+```rust
+// before
+#[derive(Component)]
+#[require(A(|| A(10))]
+struct Foo;
+
+// after
+#[derive(Component)]
+#[require(A = A(10)]
+struct Foo;
+```

--- a/release-content/0.16/migration-guides/_guides.toml
+++ b/release-content/0.16/migration-guides/_guides.toml
@@ -143,6 +143,12 @@ areas = ["Diagnostics", "ECS"]
 file_name = "16778_Event_source_location_tracking.md"
 
 [[guides]]
+title = "Improved Required Component Syntax"
+prs = [18555]
+areas = ["ECS"]
+file_name = "18555_Improved_require_syntax.md"
+
+[[guides]]
 title = "Add `EntityDoesNotExistError`, replace cases of `Entity` as an error, do some easy Resultification"
 prs = [17855]
 areas = ["ECS"]

--- a/release-content/0.16/release-notes/18555_Improved_require_syntax.md
+++ b/release-content/0.16/release-notes/18555_Improved_require_syntax.md
@@ -1,0 +1,41 @@
+**Bevy 0.15** introduced [Required Components](/news/bevy-0-15/#required-components), which enabled components to "require" other components when they are inserted. A component's required components are automatically inserted alongside them (with some configured default value).
+
+**Bevy 0.15** supported the following syntax for defining Required Components:
+
+```rust
+#[derive(Component)]
+#[require(
+    A, // Default: this will use A::default()
+    B(some_b), // Function: this will use some_b to create B
+    C(|| C { value: 1 }), // Inline Closure: will use the given closure
+)]
+struct Foo;
+
+fn some_b() -> B {
+    B(1)
+}
+```
+
+This worked pretty well, but it had some downsides:
+
+1. Defining custom values involved more boilerplate than necessary. You either had to define a whole standalone function to return the value, or use clunky closure syntax (where you repeat the component name).
+2. Defining custom values wasn't aligned with Rust syntax or common derive macro conventions.
+
+In **Bevy 0.16** we reworked and expanded Required Component syntax to support inline values and a more natural and idiomatic "expression" syntax.
+
+```rust
+#[derive(Component)]
+#[require(
+    A, // this will use A::default()
+    B(1), // inline tuple-struct value
+    C { value: 1 }, // inline named-struct value
+    D::Variant, // inline enum variant
+    E::SOME_CONST, // inline associated const
+    F::new(1), // inline constructor
+    G = returns_g(), // an expression that returns G
+    H = SomethingElse::new(), // expression returns SomethingElse, where SomethingElse: Into<H> 
+)]
+struct Foo;
+```
+
+Much better!

--- a/release-content/0.16/release-notes/_release-notes.toml
+++ b/release-content/0.16/release-notes/_release-notes.toml
@@ -49,6 +49,13 @@ contributors = ["@alice-i-cecile", "Freya Pines", "@pin3-free", "@mweatherley"]
 prs = [15607, 16047, 16778]
 file_name = "16778_Event_source_location_tracking.md"
 
+[[release_notes]]
+title = "Improved Require Syntax"
+authors = ["@cart"]
+contributors = []
+prs = [18555]
+file_name = "18555_Improved_require_syntax.md"
+
 # Rendering
 
 [[release_notes]]


### PR DESCRIPTION
Release notes and migration guide for https://github.com/bevyengine/bevy/pull/18555

Fixes #2026.