### PR TITLE
Fix missing code fence in 0.16 migration guide

### DIFF
--- a/release-content/0.16/migration-guides/17826_Fix_unsoundness_in_QueryItersort_by.md
+++ b/release-content/0.16/migration-guides/17826_Fix_unsoundness_in_QueryItersort_by.md
@@ -11,4 +11,5 @@ query.iter().sort_by::<&C>(comparer);
 // now fails with "error: implementation of `FnMut` is not general enough"
 fn comparer(left: &&'w C, right: &&'w C) -> Ordering { /* ... */ }
 // After: Accepts any lifetime using inferred lifetime parameter
-fn comparer(left: &&C, right: &&C) -> Ordering { /* ... */ }```
+fn comparer(left: &&C, right: &&C) -> Ordering { /* ... */ }
+```


### PR DESCRIPTION
While scrolling through the migration guide, I noticed weird output starting at https://bevyengine.org/learn/migration-guides/0-15-to-0-16/#fix-unsoundness-in-queryiter-sort-by

It looks like the code fence was missing a newline and wasn't considered closed.  

Looking at the original ticket, https://github.com/bevyengine/bevy/pull/17826, it was missing the final ` ``` ` entirely.  Sorry!  