### PR TITLE
can use CI to check if building all examples to wasm works before updating latest

### DIFF
--- a/.github/workflows/build-wasm-examples.yml
+++ b/.github/workflows/build-wasm-examples.yml
@@ -2,6 +2,18 @@ name: Build WASM Examples
 
 on:
   workflow_dispatch:
+    inputs:
+      ref:
+        required: true
+        type: string
+        default: "latest"
+        description: "Bevy ref to use"
+      publish:
+        required: true
+        type: boolean
+        default: false
+        description: "Publish to cloudflare"
+
 
 env:
   PER_PAGE: 50
@@ -17,14 +29,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 'bevyengine/bevy'
-          ref: 'latest'
+          ref: ${{ inputs.ref }}
       - name: Get Pages
         id: pages
         run: |
           example_count=`cat Cargo.toml | grep 'wasm = true' | wc -l`
           page_count=$((example_count / ${{ env.PER_PAGE }} + 1))
           echo "pages=`jq -n -c \"[range($page_count)]\"`" >> $GITHUB_OUTPUT
- 
+
   wasm-examples:
     name: Build WASM Examples
     needs: prepare-pages
@@ -39,7 +51,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 'bevyengine/bevy'
-          ref: 'latest'
+          ref: ${{ inputs.ref }}
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -67,11 +79,12 @@ jobs:
       name: Upload to Cloudflare
       runs-on: ubuntu-latest
       needs: wasm-examples
+      if: ${{ inputs.publish }}
       strategy:
         matrix:
-          api: [webgl2, webgpu]  
+          api: [webgl2, webgpu]
       steps:
-        
+
         - name: Download all artifacts
           uses: actions/download-artifact@v4
 


### PR DESCRIPTION
- I want to be able to confirm building all examples in wasm work before updating the `latest` tag
- CI is updated to be able to target other tags/branches of the Bevy repo, and to publish to cloudflare only when needed