### PR TITLE
Remove migration guides for 15481 and 18013 which have both been reverted.

### DIFF
--- a/release-content/0.16/migration-guides/15481_Remove_labeled_assets_from_LoadedAsset_and_ErasedLoadedAss.md
+++ b/release-content/0.16/migration-guides/15481_Remove_labeled_assets_from_LoadedAsset_and_ErasedLoadedAss.md
@@ -1,1 +1,0 @@
-- Most uses of `LoadedAsset` and `ErasedLoadedAsset` should be replaced with `CompleteLoadedAsset` and `CompleteErasedLoadedAsset` respectively.

--- a/release-content/0.16/migration-guides/18013_Make_adding_a_subasset_label_return_a_result_for_if_there_.md
+++ b/release-content/0.16/migration-guides/18013_Make_adding_a_subasset_label_return_a_result_for_if_there_.md
@@ -1,1 +1,0 @@
-- `AssetLoader`s must now handle the case of a duplicate subasset label when using `LoadContext::add_labeled_asset` and its variants. If you know your subasset labels are unique by construction (e.g., they include an index number), you can simply unwrap this result.

--- a/release-content/0.16/migration-guides/_guides.toml
+++ b/release-content/0.16/migration-guides/_guides.toml
@@ -29,18 +29,6 @@ areas = ["App"]
 file_name = "16401_Headless_by_features.md"
 
 [[guides]]
-title = "Make adding a subasset label return a result for if there is a duplicate label."
-prs = [18013]
-areas = ["Assets"]
-file_name = "18013_Make_adding_a_subasset_label_return_a_result_for_if_there_.md"
-
-[[guides]]
-title = "Remove `labeled_assets` from `LoadedAsset` and `ErasedLoadedAsset`"
-prs = [15481]
-areas = ["Assets"]
-file_name = "15481_Remove_labeled_assets_from_LoadedAsset_and_ErasedLoadedAss.md"
-
-[[guides]]
 title = "Remove the `meta` field from `LoadedAsset` and `ErasedLoadedAsset`."
 prs = [15487]
 areas = ["Assets"]


### PR DESCRIPTION
These were reverted in https://github.com/bevyengine/bevy/pull/18567.