### PR TITLE
Combine and  refine `bevy_core`  migrations

### DIFF
--- a/release-content/0.16/migration-guides/16894_Move_Name_out_of_bevy_core.md
+++ b/release-content/0.16/migration-guides/16894_Move_Name_out_of_bevy_core.md
@@ -1,1 +1,0 @@
-If you were importing `Name` or `NameOrEntity` from `bevy_core`, instead import from `bevy_ecs::name`.

--- a/release-content/0.16/migration-guides/16897_Remove_bevy_core.md
+++ b/release-content/0.16/migration-guides/16897_Remove_bevy_core.md
@@ -1,3 +1,0 @@
-- `TypeRegistryPlugin` no longer exists. If you can’t use a default `App` but still need `Name` registered, do so manually with `app.register_type::<Name>()`.
-- References to `TaskPoolPlugin` and associated types will need to import it from `bevy_app` instead of `bevy_core`
-- References to `FrameCountPlugin` and associated types will need to import it from `bevy_diagnostic` instead of `bevy_core`

--- a/release-content/0.16/migration-guides/_guides.toml
+++ b/release-content/0.16/migration-guides/_guides.toml
@@ -281,12 +281,6 @@ areas = ["ECS"]
 file_name = "17679_Move_Item_and_fetch_to_QueryData_from_WorldQuery.md"
 
 [[guides]]
-title = "Move `Name` out of `bevy_core`"
-prs = [16894]
-areas = ["ECS"]
-file_name = "16894_Move_Name_out_of_bevy_core.md"
-
-[[guides]]
 title = "Move `Resource` trait to its own file"
 prs = [17469]
 areas = ["ECS"]
@@ -1117,9 +1111,9 @@ file_name = "16257_Remove_accesskit_reexport_from_bevy_a11y.md"
 
 [[guides]]
 title = "Remove `bevy_core`"
-prs = [16897]
+prs = [16894, 16897]
 areas = []
-file_name = "16897_Remove_bevy_core.md"
+file_name = "bevy_core_removed.md"
 
 [[guides]]
 title = "Rename `trigger.entity()` to `trigger.target()`"

--- a/release-content/0.16/migration-guides/bevy_core_removed.md
+++ b/release-content/0.16/migration-guides/bevy_core_removed.md
@@ -1,0 +1,35 @@
+`bevy_core` has been removed and its items moved into more appropriate locations.
+Below are some tables showing where items have been moved to
+
+**Structs**
+
+| Item                             | 0.15 Path   | 0.16 Path         |
+| -------------------------------- | ----------- | ----------------- |
+| `FrameCount`                     | `bevy_core` | `bevy_diagnostic` |
+| `FrameCountPlugin`               | `bevy_core` | `bevy_diagnostic` |
+| `Name`                           | `bevy_core` | `bevy_ecs::name`  |
+| `NameOrEntity`                   | `bevy_core` | `bevy_ecs::name`  |
+| `NameOrEntityItem`               | `bevy_core` | `bevy_ecs::name`  |
+| `NonSendMarker`                  | `bevy_core` | `bevy_app`        |
+| `TaskPoolOptions`                | `bevy_core` | `bevy_app`        |
+| `TaskPoolPlugin`                 | `bevy_core` | `bevy_app`        |
+| `TaskPoolThreadAssignmentPolicy` | `bevy_core` | `bevy_app`        |
+| `TypeRegistrationPlugin`         | `bevy_core` | _Removed_         |
+
+**Functions**
+
+| Item                             | 0.15 Path   | 0.16 Path         |
+| -------------------------------- | ----------- | ----------------- |
+| `update_frame_count`             | `bevy_core` | `bevy_diagnostic` |
+
+**Removed**
+
+- `TypeRegistrationPlugin` no longer exists. If you can’t use a default `App` but still need `Name` registered, do so manually.
+  
+  ```rust
+  // Before
+  app.add_plugins(TypeRegistrationPlugin);
+
+  // After
+  app.register_type::<Name>();
+  ```.


### PR DESCRIPTION
# Objective

`bevy_core` was entirely removed during the 0.16 development cycle, but its items were moved during several PRs. To aid in migration, these PRs should be combined.

## Solution

- Combined the migration guides for PRs 16894 and 16897
- Directly compared `bevy_core@0.15.3` to `bevy@0.16.0-rc.2` using `docs.rs`