### PR TITLE
Remove #18421 Migration Guide

### DIFF
--- a/release-content/0.16/migration-guides/18421_Add_more_methods_to_RelationshipSourceCollection.md
+++ b/release-content/0.16/migration-guides/18421_Add_more_methods_to_RelationshipSourceCollection.md
@@ -1,1 +1,0 @@
-Any type implementing `RelationshipSourceCollection` now needs to also implement `new`, `reserve` and `shrink_to_fit`. `reserve` and `shrink_to_fit` can be made no-ops if they conceptually mean nothing to a collection.

--- a/release-content/0.16/migration-guides/_guides.toml
+++ b/release-content/0.16/migration-guides/_guides.toml
@@ -155,12 +155,6 @@ areas = ["ECS"]
 file_name = "17855_Add_EntityDoesNotExistError_replace_cases_of_Entity_as_an_.md"
 
 [[guides]]
-title = "Add more methods to `RelationshipSourceCollection`"
-prs = [18421]
-areas = ["ECS"]
-file_name = "18421_Add_more_methods_to_RelationshipSourceCollection.md"
-
-[[guides]]
 title = "Cache systems by `S` instead of `S::System`"
 prs = [16694]
 areas = ["ECS"]


### PR DESCRIPTION
# Objective

The migration guide for #18421 does not apply for `bevy@0.15.3` to `bevy@0.16.0`, since it is for new methods in the trait `RelationshipSourceCollection`, which was added after 0.15.3.

## Solution

Remove the unnecessary migration guide.