### PR TITLE
Give Proper Credit for `no_std` Support

### DIFF
--- a/release-content/0.16/release-notes/_release-notes.toml
+++ b/release-content/0.16/release-notes/_release-notes.toml
@@ -215,6 +215,6 @@ file_name = "17840_Parallel_Transform_Propagation.md"
 [[release_notes]]
 title = "Add `no_std` support to `bevy`"
 authors = ["@bushrat011899"]
-contributors = ["@alice-i-cecile"]
-prs = [17955]
+contributors = ["@alice-i-cecile", "@BD103", "@BenjaminBrienen", "@hymm", "@Jondolf", "@MrGVSV", "@mweatherley", "@Victoronz"]
+prs = [15281, 15463, 15464, 15465, 15528, 15810, 16256, 16633, 16758, 16874, 16995, 16998, 17027, 17028, 17030, 17031, 17086, 17470, 17490, 17491, 17505, 17507, 17955, 18061, 18333]
 file_name = "17955_Add_no_std_support_to_bevy.md"


### PR DESCRIPTION
While I led the `no_std` effort and authored all the relevant PRs, many other contributors were involved in the process. I've updated the release notes metadata to link to all the various PRs that (combined) added `no_std` support to `bevy`, and included all the contributors to those PRs (sorted alphabetically). I think that also better conveys the magnitude of the changes involved in getting `no_std` Bevy across the line.