### PR TITLE
Add release notes for multidraw.

### DIFF
--- a/release-content/0.16/release-notes/16427_Use_multidraw_for_opaque_meshes_when_GPU_culling_is_in_use.md
+++ b/release-content/0.16/release-notes/16427_Use_multidraw_for_opaque_meshes_when_GPU_culling_is_in_use.md
@@ -1,4 +1,11 @@
 <!-- Use multidraw for opaque meshes when GPU culling is in use. -->
 <!-- https://github.com/bevyengine/bevy/pull/16427 -->
 
-<!-- TODO -->
+We've now added support for *multidraw*. This is a feature that allows multiple meshes to be drawn
+in a single draw call, which can be a significant performance improvement by reducing the number of
+draw culls as well as the number of rebindings. As a side-effect, GPU culling has now been enabled
+by default!
+
+One caveat with multidraw is that it currently only works on Vulkan. We believe we can close this
+gap in future Bevy versions. Another caveat is that multidraw currently does not apply to non-opaque
+meshes or 2D meshes.


### PR DESCRIPTION
Fixes #1968.

It looks like the original PR is "stale". We've since merged https://github.com/bevyengine/bevy/pull/16692 and https://github.com/bevyengine/bevy/pull/16757 which allows multidraw for shadows and enables GPU culling by default (which also implicitly enables multidraw by default). Hopefully I'm not missing related improvements to this space.