### PR TITLE
Fix light-mode table colors

### DIFF
--- a/sass/_vars.scss
+++ b/sass/_vars.scss
@@ -321,7 +321,8 @@ $border-radius: 10px;
 
   --table-border-color: var(--color-neutral-60b);
   --table-border-radius: 4px;
-  --table-header-color: var(--color-neutral-13);
+  --table-header-bg-color: var(--color-neutral-13);
+  --table-header-color: var(--color-neutral-82);
 
   --tabs-bg-color: var(--color-white);
   --tabs-highlight-color: var(--color-blue-link);
@@ -448,6 +449,10 @@ $border-radius: 10px;
     --on-this-page-active-color: var(--color-black);
 
     --scrollbar-thumb-color: #{unquote('rgb(from var(--color-black) r g b / 0.2)')};
+
+    --table-border-color: var(--color-neutral-75);
+    --table-header-bg-color: var(--color-neutral-82);
+    --table-header-color: var(--color-neutral-22);
 
     --todo-bg-color: rgba(191, 170, 64, 0.3);
     --todo-border-color: rgba(223, 191, 32, 0.5);

--- a/sass/elements/_table.scss
+++ b/sass/elements/_table.scss
@@ -2,10 +2,12 @@ table {
   border-spacing: 0;
   border: 2px solid var(--table-border-color);
   border-radius: var(--table-border-radius);
+  margin-block: 16px;
 }
 
 thead {
-  background-color: var(--table-header-color);
+  background-color: var(--table-header-bg-color);
+  color: var(--table-header-color)
 }
 
 tr td {


### PR DESCRIPTION
Fix light-mode table header colors.

**[Before](https://bevyengine.org/learn/migration-guides/0-15-to-0-16/#utils):**
<img width="403" alt="image" src="https://github.com/user-attachments/assets/82ca2fc6-1dac-46d6-8e7a-18143b46e38e" />

**After:**

https://github.com/user-attachments/assets/a6354399-575f-4b44-9bc1-7b90b9ae0aff

