### PR TITLE
Update MSVC build tools link

### DIFF
--- a/content/learn/quick-start/getting-started/setup.md
+++ b/content/learn/quick-start/getting-started/setup.md
@@ -38,7 +38,7 @@ Once this is done, you should have the ```rustc``` compiler and the ```cargo``` 
   #### Windows
   </summary>
 
-  * Run the [Visual Studio 2019 build tools installer](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=16)
+  * Run the [Microsoft C++ Build Tools installer](https://visualstudio.microsoft.com/visual-cpp-build-tools/)
   * For easy setup, select the ```Desktop development with C++``` workload in the installer.
   * For a minimal setup, follow these steps:
       1. In the installer, navigate to `Individual components`

--- a/content/learn/quick-start/getting-started/setup.md
+++ b/content/learn/quick-start/getting-started/setup.md
@@ -38,7 +38,7 @@ Once this is done, you should have the ```rustc``` compiler and the ```cargo``` 
   #### Windows
   </summary>
 
-  * Run the [Microsoft C++ Build Tools installer](https://visualstudio.microsoft.com/visual-cpp-build-tools/)
+  * Run the [Visual Studio C++ Build Tools installer](https://visualstudio.microsoft.com/visual-cpp-build-tools/)
   * For easy setup, select the ```Desktop development with C++``` workload in the installer.
   * For a minimal setup, follow these steps:
       1. In the installer, navigate to `Individual components`


### PR DESCRIPTION
The previous link was redirecting to a page that has quite a lot of options (which only install Visual Studio IDE as far as I can see) but not an option to get the build tools installer. I'm changing this to the link provided in Rust's [getting started](https://www.rust-lang.org/learn/get-started) guide.