### PR TITLE
Write migration guide for 18451

### DIFF
--- a/release-content/0.16/migration-guides/18451_Get_names_of_queued_components.md
+++ b/release-content/0.16/migration-guides/18451_Get_names_of_queued_components.md
@@ -1,0 +1,3 @@
+`Components::get_name` now returns `Option<Cow<'_, str>` instead of `Option<&str>`. This is because it now returns results for queued components. If that behavior is not desired, or you know the component is not queued, you can use `components.get_info().map(ComponentInfo::name)` instead.
+
+Similarly, `ScheduleGraph::conflicts_to_string` now returns `impl Iterator<Item = (String, String, Vec<Cow<str>>)>` instead of `impl Iterator<Item = (String, String, Vec<&str>)>`. Because `Cow<str>` derefs to `&str`, most use cases can remain unchanged.

--- a/release-content/0.16/migration-guides/18451_Get_names_of_queued_components.md
+++ b/release-content/0.16/migration-guides/18451_Get_names_of_queued_components.md
@@ -1,3 +1,5 @@
-`Components::get_name` now returns `Option<Cow<'_, str>` instead of `Option<&str>`. This is because it now returns results for queued components. If that behavior is not desired, or you know the component is not queued, you can use `components.get_info().map(ComponentInfo::name)` instead.
+Bevy now supports queueing components to be registered with read only world access, as opposed to registering them directly with mutable access. For now, that's an implementation detail, but it opens up some exciting possibilities for the future. Today, however, it causes a breaking change.
 
-Similarly, `ScheduleGraph::conflicts_to_string` now returns `impl Iterator<Item = (String, String, Vec<Cow<str>>)>` instead of `impl Iterator<Item = (String, String, Vec<&str>)>`. Because `Cow<str>` derefs to `&str`, most use cases can remain unchanged.
+In order to support getting the names of components that are queued but not registered (important for debugging), `Components::get_name` now returns `Option<Cow<'_, str>` instead of `Option<&str>`. If that behavior is not desired, or you know the component is not queued, you can use `components.get_info().map(ComponentInfo::name)` instead. Similarly, `ScheduleGraph::conflicts_to_string` now returns `impl Iterator<Item = (String, String, Vec<Cow<str>>)>` instead of `impl Iterator<Item = (String, String, Vec<&str>)>`.
+
+Because `Cow<str>` derefs to `&str`, most use cases can remain unchanged. If you're curious about queued registration, check out the original pr [here](https://github.com/bevyengine/bevy/pull/18173).

--- a/release-content/0.16/migration-guides/_guides.toml
+++ b/release-content/0.16/migration-guides/_guides.toml
@@ -41,6 +41,12 @@ areas = ["Assets"]
 file_name = "17695_Weak_handle_migration.md"
 
 [[guides]]
+title = "Get names of queued components"
+prs = [18451]
+areas = ["ECS"]
+file_name = "18451_Get_names_of_queued_components.md"
+
+[[guides]]
 title = "Add `AssetChanged` query filter"
 prs = [16810]
 areas = ["Assets", "ECS"]


### PR DESCRIPTION
[18451](https://github.com/bevyengine/bevy/pull/18451) was (hopefully) the last breaking change of 0.16!

It was created after most migration guides were auto-generated, but this PR adds the migration guide for it.