### PR TITLE
Update methods in pre-relations hierarchy-related migration guide

### DIFF
--- a/release-content/0.16/migration-guides/17029_Refactor_hierarchyrelated_commands_to_remove_structs.md
+++ b/release-content/0.16/migration-guides/17029_Refactor_hierarchyrelated_commands_to_remove_structs.md
@@ -1,16 +1,21 @@
-If you were queuing the structs of hierarchy-related commands or `SendEvent` directly, you will need to change them to the methods implemented on `EntityCommands` (or `Commands` for `SendEvent`):
+If you were queuing the structs of hierarchy-related commands directly, you will need to change them to methods implemented on `EntityCommands`:
 
-Struct|Method
-------|------
-`commands.queue(AddChild { child, parent });`|`commands.entity(parent).add_child(child);` OR `commands.entity(child).set_parent(parent);`
-`commands.queue(AddChildren { children, parent });`|`commands.entity(parent).add_children(children);`
-`commands.queue(InsertChildren { children, parent });`|`commands.entity(parent).insert_children(children);`
-`commands.queue(RemoveChildren { children, parent });`|`commands.entity(parent).remove_children(children);`
-`commands.queue(ReplaceChildren { children, parent });`|`commands.entity(parent).replace_children(children);`
-`commands.queue(ClearChildren { parent });`|`commands.entity(parent).clear_children();`
-`commands.queue(RemoveParent { child });`|`commands.entity(child).remove_parent()`
-`commands.queue(DespawnRecursive { entity, warn: true });`|`commands.entity(entity).despawn_recursive();`
-`commands.queue(DespawnRecursive { entity, warn: false });`|`commands.entity(entity).try_despawn_recursive();`
-`commands.queue(DespawnChildrenRecursive { entity, warn: true });`|`commands.entity(entity).despawn_descendants();`
-`commands.queue(DespawnChildrenRecursive { entity, warn: false});`|`commands.entity(entity).try_despawn_descendants();`
-`commands.queue(SendEvent { event });`|`commands.send_event(event);`
+| Struct                                                       | Method                                                                                         |
+|--------------------------------------------------------------|------------------------------------------------------------------------------------------------|
+| `commands.queue(AddChild { child, parent })`                 | `commands.entity(parent).add_child(child)` OR `commands.entity(child).insert(ChildOf(parent))` |
+| `commands.queue(AddChildren { children, parent })`           | `commands.entity(parent).add_children(children)`                                               |
+| `commands.queue(InsertChildren { children, parent, index })` | `commands.entity(parent).insert_children(index, children)`                                     |
+| `commands.queue(RemoveChildren { children, parent })`        | `commands.entity(parent).remove_children(children)`                                            |
+| `commands.queue(ReplaceChildren { children, parent })`       | `commands.entity(parent).replace_children(children)`                                           |
+| `commands.queue(ClearChildren { parent })`                   | `commands.entity(parent).remove::<Children>()`                                                 |
+| `commands.queue(RemoveParent { child })`                     | `commands.entity(child).remove::<ChildOf>()`                                                   |
+| `commands.queue(DespawnRecursive { entity, warn: true })`    | `commands.entity(entity).despawn()`                                                            |
+| `commands.queue(DespawnRecursive { entity, warn: false })`   | `commands.entity(entity).try_despawn()`                                                        |
+| `commands.queue(DespawnChildrenRecursive { entity, warn })`  | `commands.entity(entity).despawn_related::<Children>()`                                        |
+
+If you were queuing the structs of event-related commands directly, you will need to change them to methods implemented on `Commands`:
+
+| Struct                                            | Method                                     |
+|---------------------------------------------------|--------------------------------------------|
+| `commands.queue(SendEvent { event })`             | `commands.send_event(event)`               |
+| `commands.queue(TriggerEvent { event, targets })` | `commands.trigger_targets(event, targets)` |

--- a/release-content/0.16/migration-guides/_guides.toml
+++ b/release-content/0.16/migration-guides/_guides.toml
@@ -263,8 +263,8 @@ areas = ["ECS"]
 file_name = "18173_Queued_component_registration.md"
 
 [[guides]]
-title = "Refactor hierarchy-related commands to remove structs"
-prs = [17029]
+title = "Refactor various commands to remove structs"
+prs = [16999, 17029]
 areas = ["ECS"]
 file_name = "17029_Refactor_hierarchyrelated_commands_to_remove_structs.md"
 


### PR DESCRIPTION
bevyengine/bevy#17029 removed hierarchy-related struct-commands and recommended equivalent methods, and some of those methods were later changed by the big relations stuff. This updates them (and also adds a bit of another PR (bevyengine/bevy#16999) that didn't get a migration guide but seemed relevant).

~(EntityCommands doesn't actually have insert_children on main, but will with https://github.com/bevyengine/bevy/pull/18675)~ (It does now)