### PR TITLE
Fix contributors guide page header message using wrong path

### DIFF
--- a/templates/macros/base.html
+++ b/templates/macros/base.html
@@ -12,7 +12,7 @@
       Quick Start
     {% elif section_or_page.path is starting_with("/learn/advanced-examples") %}
       Advanced Examples
-    {% elif section_or_page.path is starting_with("/contribute/") %}
+    {% elif section_or_page.path is starting_with("/learn/contribute/") %}
       Contribute
     {% elif section_or_page.path is starting_with("/news/") %}
       News


### PR DESCRIPTION
The page name macro was still expecting the Contributors Guide section to be under "/contribute" and not "/learn/contribute" so the Guide had no page name, and thus no name in the mobile nav menu switches, nor in the page headers by the logo.

<details>
<summary>Before:</summary>

![website on computer screen](https://github.com/user-attachments/assets/975e158b-6539-4424-a0f0-38e7656db769)

![website on mobile screen](https://github.com/user-attachments/assets/b4605fc2-7fa0-4670-9f5d-7db6fbe9ca8d)
</details>
<details>
<summary>After:</summary>

![website on computer screen](https://github.com/user-attachments/assets/dc8bda64-afbe-4655-b9ad-fd748fe64e5b)

![website on mobile screen](https://github.com/user-attachments/assets/5de9df60-09f0-4d02-8fc7-22c91afcb40d)

</details>