### PR TITLE
Add release candidate warning to `0.15 to 0.16` migration guide

### DIFF
--- a/content/learn/migration-guides/0.15-to-0.16.md
+++ b/content/learn/migration-guides/0.15-to-0.16.md
@@ -7,7 +7,7 @@ long_title = "Migration Guide: 0.15 to 0.16"
 +++
 
 {% callout(type="warning") %}
-This Guide is currently for a __Release Candidate__ and is subject to change as we work on and improve it. If you notice any errors or issues in the guides, then please submit an issue at [the Bevy website repository issue tracker](https://github.com/bevyengine/bevy-website/issues).
+This guide is currently for a __Release Candidate__ and is subject to change as we work on and improve it. If you notice any errors or issues within this guide, then please submit an issue at [the Bevy website repository issue tracker](https://github.com/bevyengine/bevy-website/issues).
 {% end %}
 
 The most important changes to be aware of this release are:

--- a/content/learn/migration-guides/0.15-to-0.16.md
+++ b/content/learn/migration-guides/0.15-to-0.16.md
@@ -6,6 +6,10 @@ weight = 11
 long_title = "Migration Guide: 0.15 to 0.16"
 +++
 
+{% callout(type="warning") %}
+This Guide is currently for a __Release Candidate__ and is subject to change as we work on and improve it. If you notice any errors or issues in the guides, then please submit an issue at [the Bevy website repository issue tracker](https://github.com/bevyengine/bevy-website/issues).
+{% end %}
+
 The most important changes to be aware of this release are:
 
 - Bevy has reworked its error handling to make it easier to handle `Result`s everywhere. As a result, `Query::single` and friends now return results, rather than panicking.


### PR DESCRIPTION
This is added so that folks who see the migration guide are not confused at a migration guide being out for an unreleased version, and so that folks know that it is a work in progress.

![image](https://github.com/user-attachments/assets/5f4686e9-f1c6-4a68-9588-b6e0fdcc02ea)

