### PR TITLE
Write migration guide for 2024 edition panicking closure inference regression

### DIFF
--- a/release-content/0.16/migration-guides/_guides.toml
+++ b/release-content/0.16/migration-guides/_guides.toml
@@ -1018,3 +1018,9 @@ title = "Use `target_abi = \"sim\"` instead of `ios_simulator` feature"
 prs = [17702]
 areas = []
 file_name = "17702_Use_target_abi__sim_instead_of_ios_simulator_feature.md"
+
+[[guides]]
+title = "Closures which panic now need to explicitly specify a `()` return type"
+prs = [17967]
+areas = ["ECS"]
+file_name = "panicking_closures.md"

--- a/release-content/0.16/migration-guides/panicking_closures.md
+++ b/release-content/0.16/migration-guides/panicking_closures.md
@@ -1,0 +1,11 @@
+As a result of changes to [Never type fallback] in Rust 2024, closures which panic now have an inferred return type of `!`, rather than `()`. This might occur if you're using `panic!`, `todo!`, `unimplemented!`, `unreachable!` or other means of panicking.
+
+This affects Bevy users as our blanket implementations for `Command`, `IntoSystem` and `IntoObserverSystem` which operate on all matching functions with the correct type signature no longer cover closures of this sort.
+
+While this may be fixable on Bevy's end (see [#18778]), for now, you can work around this issue by either:
+
+1. Converting your closures to ordinary named functions, whose return type is not inferred.
+2. Explicitly specifying the return type of your closure as `()`.
+
+[Never type fallback]: https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html
+[#18778]: https://github.com/bevyengine/bevy/issues/18778

--- a/release-content/0.16/migration-guides/panicking_closures.md
+++ b/release-content/0.16/migration-guides/panicking_closures.md
@@ -1,6 +1,6 @@
 As a result of changes to [Never type fallback] in Rust 2024, closures which panic now have an inferred return type of `!`, rather than `()`. This might occur if you're using `panic!`, `todo!`, `unimplemented!`, `unreachable!` or other means of panicking.
 
-This affects Bevy users as our blanket implementations for `Command`, `IntoSystem` and `IntoObserverSystem` which operate on all matching functions with the correct type signature no longer cover closures of this sort.
+This affects Bevy users as our blanket implementations for `Command`, `IntoSystem` and `IntoObserverSystem`, which operate on all matching functions with the correct type signature, no longer cover closures of this sort.
 
 While this may be fixable on Bevy's end (see [#18778]), for now, you can work around this issue by either:
 


### PR DESCRIPTION
Covers the issue reported in https://github.com/bevyengine/bevy/issues/18778.