### PR TITLE
Add no_std to migration guide highlights

### DIFF
--- a/content/learn/migration-guides/0.15-to-0.16.md
+++ b/content/learn/migration-guides/0.15-to-0.16.md
@@ -14,5 +14,6 @@ The most important changes to be aware of this release are:
 
 - Bevy has reworked its error handling to make it easier to handle `Result`s everywhere. As a result, `Query::single` and friends now return results, rather than panicking.
 - Bevy's ECS now has built-in one-to-many entity relationships. The existing parent-child hierarchy system has been modified to use these relationships, causing minor breaking changes in entity despawning behavior and how children are added / replaced for a parent entity.
+- The `bevy` crate now supports `no_std` platforms. As part of this, many items (like `HashMap`) from `bevy_utils` have been moved into `bevy_platform_support`. If you are the author of an ecosystem crate, you may want to offer `no_std` support to your users as well: it's generally straightforward unless you're interfacing directly with the underlying operating system.
 
 {{ migration_guides(version="0.16") }}


### PR DESCRIPTION
After chewing on it, this stood out to me as one of the more important / common breaking changes of the 0.16 cycle, so I figured we can declare it upfront.