### PR TITLE
Update and rename EntityHashSet 0.16 migration section

### DIFF
--- a/release-content/0.16/migration-guides/17447_Dont_reexport_EntityHashSet_and_EntityHashMap.md
+++ b/release-content/0.16/migration-guides/17447_Dont_reexport_EntityHashSet_and_EntityHashMap.md
@@ -2,8 +2,8 @@
 
 ```rust
 // 0.15
-use bevy::ecs::entity::{HashSet, HashMap};
+use bevy::ecs::entity::{EntityHashSet, EntityHashMap};
 
 // 0.16
-use bevy::ecs::entity::{hash_set::HashSet, hash_map::HashMap};
+use bevy::ecs::entity::{hash_set::EntityHashSet, hash_map::EntityHashMap};
 ```

--- a/release-content/0.16/migration-guides/17447_Dont_reexport_EntityHashSet_and_EntityHashMap.md
+++ b/release-content/0.16/migration-guides/17447_Dont_reexport_EntityHashSet_and_EntityHashMap.md
@@ -1,9 +1,0 @@
-`EntityHashSet` and `EntityHashMap` are no longer re-exported in `bevy::ecs::entity`, although they are still accessible through the prelude. If you were directly importing `EntityHashSet` and `EntityHashMap`, please access them from `bevy::ecs::entity::hash_set` and `bevy::ecs::entity::hash_map`.
-
-```rust
-// 0.15
-use bevy::ecs::entity::{EntityHashSet, EntityHashMap};
-
-// 0.16
-use bevy::ecs::entity::{hash_set::EntityHashSet, hash_map::EntityHashMap};
-```

--- a/release-content/0.16/migration-guides/_guides.toml
+++ b/release-content/0.16/migration-guides/_guides.toml
@@ -350,7 +350,7 @@ file_name = "17685_Split_Componentregister_component_hooks_into_individual_me.md
 title = "Don't re-export `EntityHashSet` and `EntityHashMap`"
 prs = [17447]
 areas = ["ECS"]
-file_name = "17447_Support_nonVec_data_structures_in_relations.md"
+file_name = "17447_Dont_reexport_EntityHashSet_and_EntityHashMap.md"
 
 [[guides]]
 title = "Turn `apply_deferred()` into a ZST system"

--- a/release-content/0.16/migration-guides/_guides.toml
+++ b/release-content/0.16/migration-guides/_guides.toml
@@ -347,12 +347,6 @@ areas = ["ECS"]
 file_name = "17685_Split_Componentregister_component_hooks_into_individual_me.md"
 
 [[guides]]
-title = "Don't re-export `EntityHashSet` and `EntityHashMap`"
-prs = [17447]
-areas = ["ECS"]
-file_name = "17447_Dont_reexport_EntityHashSet_and_EntityHashMap.md"
-
-[[guides]]
 title = "Turn `apply_deferred()` into a ZST system"
 prs = [16642]
 areas = ["ECS"]


### PR DESCRIPTION
Solves https://github.com/bevyengine/bevy/issues/18841

I also renamed the md file, since the name seems like a mistake to me.

I didn't test the md - should I compile the docs locally? Or is a review enough?

The 0.16 doesn't get any rust analyzer errors and go to definition works for it, and the 0.15 version compiles. (I didn't have a compiling 0.16 projects at hand)