### PR TITLE
release-notes: replace all `dev-docs` links with 0.16 `doc.rs` links

### DIFF
--- a/release-content/0.16/release-notes/13120_Add_DefaultQueryFilters.md
+++ b/release-content/0.16/release-notes/13120_Add_DefaultQueryFilters.md
@@ -19,7 +19,7 @@ To disable or enable an entity, simply remove or add the disabling component of 
 Note that for maximum control and explicitness, only the entities that you directly add disabling components to are disabled: their children or other related entities are not automatically disabled!
 This can lead to strange bugs, so in most cases, you should either be careful to call [`Commands::insert_recursive`] and [`Commands::remove_recursive`] or add a hook or observer to get automatic hierarchy-aware disabling.
 
-[`World`]: https://dev-docs.bevyengine.org/bevy/ecs/prelude/struct.World.html
-[`Disabled`]: https://dev-docs.bevyengine.org/bevy/ecs/entity_disabling/struct.Disabled.html
-[`Commands::insert_recursive`]: https://dev-docs.bevyengine.org/bevy/prelude/struct.EntityCommands.html#method.insert_recursive
-[`Commands::remove_recursive`]: https://dev-docs.bevyengine.org/bevy/prelude/struct.EntityCommands.html#method.remove_recursive
+[`World`]: https://docs.rs/bevy/0.16/bevy/ecs/prelude/struct.World.html
+[`Disabled`]: https://docs.rs/bevy/0.16/bevy/ecs/entity_disabling/struct.Disabled.html
+[`Commands::insert_recursive`]: https://docs.rs/bevy/0.16/bevy/prelude/struct.EntityCommands.html#method.insert_recursive
+[`Commands::remove_recursive`]: https://docs.rs/bevy/0.16/bevy/prelude/struct.EntityCommands.html#method.remove_recursive

--- a/release-content/0.16/release-notes/14069_Add_support_for_specular_tints_and_maps_per_the_KHR_materi.md
+++ b/release-content/0.16/release-notes/14069_Add_support_for_specular_tints_and_maps_per_the_KHR_materi.md
@@ -17,4 +17,4 @@ As a result, specular maps are off by default, and gated behind the `pbr_specula
 
 To support this work, we now support the KHR_materials_specular glTF extension, allowing artists to set these properties in 3D modelling tools like Blender, then import them into Bevy.
 
-[`StandardMaterial`]: https://dev-docs.bevyengine.org/bevy/pbr/struct.StandardMaterial.html
+[`StandardMaterial`]: https://docs.rs/bevy/0.16/bevy/pbr/struct.StandardMaterial.html

--- a/release-content/0.16/release-notes/16372_Add_Immutable_Component_Support.md
+++ b/release-content/0.16/release-notes/16372_Add_Immutable_Component_Support.md
@@ -66,10 +66,10 @@ For example, Bevy 0.16 uses immutable components (and hooks!) as the foundation 
 
 We're keen to develop a first-class indexing solution using these new tools, and excited to hear about your ideas. Stay tuned; we've only scratched the surface here!
 
-[`Component`]: https://dev-docs.bevyengine.org/bevy/ecs/component/trait.Component.html
+[`Component`]: https://docs.rs/bevy/0.16/bevy/ecs/component/trait.Component.html
 [`mem::swap`]: https://doc.rust-lang.org/std/mem/fn.swap.html
 [flecs]: https://github.com/SanderMertens/flecs
-[`World`]: https://dev-docs.bevyengine.org/bevy/ecs/prelude/struct.World.html
-[`World::modify_component`]: https://dev-docs.bevyengine.org/bevy/prelude/struct.World.html#method.modify_component
-[`ChildOf`]: https://dev-docs.bevyengine.org/bevy/ecs/hierarchy/struct.ChildOf.html
-[`Children`]: https://dev-docs.bevyengine.org/bevy/ecs/hierarchy/struct.Children.html
+[`World`]: https://docs.rs/bevy/0.16/bevy/ecs/prelude/struct.World.html
+[`World::modify_component`]: https://docs.rs/bevy/0.16/bevy/prelude/struct.World.html#method.modify_component
+[`ChildOf`]: https://docs.rs/bevy/0.16/bevy/ecs/hierarchy/struct.ChildOf.html
+[`Children`]: https://docs.rs/bevy/0.16/bevy/ecs/hierarchy/struct.Children.html

--- a/release-content/0.16/release-notes/16810_Add_AssetChanged_query_filter.md
+++ b/release-content/0.16/release-notes/16810_Add_AssetChanged_query_filter.md
@@ -13,8 +13,8 @@ To solve this, we've added an [`AssetChanged`] query filter, which works for any
 which implements the new [`AsAssetId`] trait.
 Something like `Query<&mut Aabb, With<AssetChanged<Mesh3d>>>` now Just Works™️, allowing you to recompute data whenever the underlying asset is changed for any reason.
 
-[`Assets<T>`]: https://dev-docs.bevyengine.org/bevy/asset/struct.Assets.html
-[`Sprite`]: https://dev-docs.bevyengine.org/bevy/prelude/struct.Sprite.html
-[`Handle<T>`]: https://dev-docs.bevyengine.org/bevy/asset/enum.Handle.html
-[`AssetChanged`]: https://dev-docs.bevyengine.org/bevy/asset/prelude/struct.AssetChanged.html
-[`AsAssetId`]: https://dev-docs.bevyengine.org/bevy/asset/trait.AsAssetId.html
+[`Assets<T>`]: https://docs.rs/bevy/0.16/bevy/asset/struct.Assets.html
+[`Sprite`]: https://docs.rs/bevy/0.16/bevy/prelude/struct.Sprite.html
+[`Handle<T>`]: https://docs.rs/bevy/0.16/bevy/asset/enum.Handle.html
+[`AssetChanged`]: https://docs.rs/bevy/0.16/bevy/asset/prelude/struct.AssetChanged.html
+[`AsAssetId`]: https://docs.rs/bevy/0.16/bevy/asset/trait.AsAssetId.html

--- a/release-content/0.16/release-notes/17096_Anamorphic_Bloom.md
+++ b/release-content/0.16/release-notes/17096_Anamorphic_Bloom.md
@@ -9,4 +9,4 @@ When heavily skewed (usually horizontally), this effect is known as **anamorphic
 This effect is associated with a cinematic, futuristic vibe, and emulates the unusual geometry of certain film cameras as they compress a wider image onto narrower film.
 But, regardless of why it occurs, it simply looks neat!
 
-[`Bloom`]: https://dev-docs.bevyengine.org/bevy/core_pipeline/bloom/struct.Bloom.html
+[`Bloom`]: https://docs.rs/bevy/0.16/bevy/core_pipeline/bloom/struct.Bloom.html

--- a/release-content/0.16/release-notes/17398_Relationships_nonfragmenting_onetomany.md
+++ b/release-content/0.16/release-notes/17398_Relationships_nonfragmenting_onetomany.md
@@ -57,7 +57,7 @@ Note that this is just the first step for relationships. We have plans to expand
 1. Many-To-Many Relationships: The current system is one-to-many (ex: The `ChildOf` relationship points to "one" target entity and the `RelationshipTarget` can be targeted by "many" child entities). Some relationships could benefit from supporting many relationship targets.
 2. Fragmenting Relationships: In the current system, relationship components "fragment" ECS archetypes based on their _type_, just like a normal component (Ex: `(Player, ChildOf(e1))`, and `(Player, ChildOf(e2))` exist in the same archetype). Fragmenting relationships would be an opt-in system that fragment archetypes based on their _value_ as well, which would result in entities with the same relationship targets being stored next to each other. This serves as an index, making querying by value faster, and making some access patterns more cache friendly.
 
-[`Relationship`]: https://dev-docs.bevyengine.org/bevy/ecs/relationship/trait.Relationship.html
-[`RelationshipTarget`]: https://dev-docs.bevyengine.org/bevy/prelude/trait.RelationshipTarget.html
-[`ChildOf`]: https://dev-docs.bevyengine.org/bevy/prelude/struct.ChildOf.html
-[`Children`]: https://dev-docs.bevyengine.org/bevy/ecs/hierarchy/struct.Children.html
+[`Relationship`]: https://docs.rs/bevy/0.16/bevy/ecs/relationship/trait.Relationship.html
+[`RelationshipTarget`]: https://docs.rs/bevy/0.16/bevy/prelude/trait.RelationshipTarget.html
+[`ChildOf`]: https://docs.rs/bevy/0.16/bevy/prelude/struct.ChildOf.html
+[`Children`]: https://docs.rs/bevy/0.16/bevy/ecs/hierarchy/struct.Children.html

--- a/release-content/0.16/release-notes/17559_Basic_UI_text_shadows.md
+++ b/release-content/0.16/release-notes/17559_Basic_UI_text_shadows.md
@@ -7,6 +7,6 @@ TODO: generate and add an image of text shadows in action
 While this is a simple first implementation (no blurring), and only supports `bevy_ui` text (sorry [`Text2d`]),
 we hope that this helps make Bevy a better fit for stylized game UIs.
 
-[`TextShadow`]: https://dev-docs.bevyengine.org/bevy/prelude/struct.TextShadow.html
-[`Text`]: https://dev-docs.bevyengine.org/bevy/prelude/struct.Text.html
-[`Text2d`]: https://dev-docs.bevyengine.org/bevy/prelude/struct.Text2d.html
+[`TextShadow`]: https://docs.rs/bevy/0.16/bevy/prelude/struct.TextShadow.html
+[`Text`]: https://docs.rs/bevy/0.16/bevy/prelude/struct.Text.html
+[`Text2d`]: https://docs.rs/bevy/0.16/bevy/prelude/struct.Text2d.html

--- a/release-content/0.16/release-notes/occlusion_culling.md
+++ b/release-content/0.16/release-notes/occlusion_culling.md
@@ -25,8 +25,8 @@ If you're a rendering engineer who'd like to help us resolve these precision iss
 Chime in at [issue #14062] (and read our [Contributing Guide]) and we can help you get started.
 
 [PR #17413]: https://github.com/bevyengine/bevy/pull/17413
-[`DepthPrepass`]: https://dev-docs.bevyengine.org/bevy/core_pipeline/prepass/struct.DepthPrepass.html
-[`OcclusionCulling`]: https://dev-docs.bevyengine.org/bevy/render/experimental/occlusion_culling/struct.OcclusionCulling.html
+[`DepthPrepass`]: https://docs.rs/bevy/0.16/bevy/core_pipeline/prepass/struct.DepthPrepass.html
+[`OcclusionCulling`]: https://docs.rs/bevy/0.16/bevy/render/experimental/occlusion_culling/struct.OcclusionCulling.html
 [issue #14062]: https://github.com/bevyengine/bevy/issues/14062
 [Granite]: https://github.com/Themaister/Granite
 [Contributing Guide]: https://bevyengine.org/learn/contribute/introduction/

--- a/release-content/0.16/release-notes/unified_error_handling.md
+++ b/release-content/0.16/release-notes/unified_error_handling.md
@@ -55,9 +55,9 @@ making it dead simple to swap out the behavior with a single `#[cfg(prod)]`-gate
 
 [`?` operator]: https://doc.rust-lang.org/rust-by-example/std/result/question_mark.html
 [`anyhow`]: https://docs.rs/anyhow/latest/anyhow/
-[`bevy::ecs::error::Result`]: https://dev-docs.bevyengine.org/bevy/ecs/error/type.Result.html
+[`bevy::ecs::error::Result`]: https://docs.rs/bevy/0.16/bevy/ecs/error/type.Result.html
 [high quality custom backtraces]: https://github.com/bevyengine/bevy/pull/18144
-[`GLOBAL_ERROR_HANDLER`]: https://dev-docs.bevyengine.org/bevy/ecs/error/static.GLOBAL_ERROR_HANDLER.html
-[`Single`]: https://dev-docs.bevyengine.org/bevy/ecs/prelude/struct.Single.html
-[`warn`]: https://dev-docs.bevyengine.org/bevy/ecs/error/fn.warn.html
-[`BevyError`]: https://dev-docs.bevyengine.org/bevy/ecs/error/struct.BevyError.html
+[`GLOBAL_ERROR_HANDLER`]: https://docs.rs/bevy/0.16/bevy/ecs/error/static.GLOBAL_ERROR_HANDLER.html
+[`Single`]: https://docs.rs/bevy/0.16/bevy/ecs/prelude/struct.Single.html
+[`warn`]: https://docs.rs/bevy/0.16/bevy/ecs/error/fn.warn.html
+[`BevyError`]: https://docs.rs/bevy/0.16/bevy/ecs/error/struct.BevyError.html

--- a/release-content/0.16/release-notes/virtual_geometry_improvements.md
+++ b/release-content/0.16/release-notes/virtual_geometry_improvements.md
@@ -4,6 +4,6 @@ In Bevy 0.16, virtual geometry got some performance improvements thanks to new a
 
 Read more details on the [author's blog post](https://jms55.github.io/posts/2025-03-27-virtual-geometry-bevy-0-16).
 
-Users are not required to regenerate their [`MeshletMesh`](https://dev-docs.bevyengine.org/bevy/pbr/experimental/meshlet/struct.MeshletMesh.html) assets, but doing so is recommended in order to take advantage of the improved clustering algorithm in Bevy 0.16.
+Users are not required to regenerate their [`MeshletMesh`](https://docs.rs/bevy/0.16/bevy/pbr/experimental/meshlet/struct.MeshletMesh.html) assets, but doing so is recommended in order to take advantage of the improved clustering algorithm in Bevy 0.16.
 
 ![Screenshot of the meshlet example](meshlet_bunnies.png)


### PR DESCRIPTION
- Fixes #2082

Replaced the `dev-doc` links in release note files in the `release-content/0.16/release-notes/` directory.