### PR TITLE
Add final counts and contributor / changelog for 0.16 release

### DIFF
--- a/content/news/2025-XX-XX-bevy-0.16/index.md
+++ b/content/news/2025-XX-XX-bevy-0.16/index.md
@@ -10,7 +10,7 @@ public_draft = 2008
 status = 'hidden'
 +++
 
-Thanks to **??** contributors, **???** pull requests, community reviewers, and our [**generous donors**](/donate), we're happy to announce the **Bevy 0.16** release on [crates.io](https://crates.io/crates/bevy)!
+Thanks to **??** contributors, **1244** pull requests, community reviewers, and our [**generous donors**](/donate), we're happy to announce the **Bevy 0.16** release on [crates.io](https://crates.io/crates/bevy)!
 
 For those who don't know, Bevy is a refreshingly simple data-driven game engine built in Rust. You can check out our [Quick Start Guide](/learn/quick-start) to try it today. It's free and open source forever! You can grab the full [source code](https://github.com/bevyengine/bevy) on GitHub. Check out [Bevy Assets](https://bevyengine.org/assets) for a collection of community-developed plugins, games, and learning resources.
 
@@ -44,3 +44,4 @@ Peering deep into the mists of time (predictions are _extra_ hard when your team
 
 TODO: add  contributors
 TODO: add changelog
+For those interested in a complete changelog, you can see the entire log (and linked pull requests) via the [relevant commit history](https://github.com/bevyengine/bevy/compare/v0.15.0...v0.16.0-rc.5).

--- a/content/news/2025-XX-XX-bevy-0.16/index.md
+++ b/content/news/2025-XX-XX-bevy-0.16/index.md
@@ -10,7 +10,7 @@ public_draft = 2008
 status = 'hidden'
 +++
 
-Thanks to **??** contributors, **1244** pull requests, community reviewers, and our [**generous donors**](/donate), we're happy to announce the **Bevy 0.16** release on [crates.io](https://crates.io/crates/bevy)!
+Thanks to **261** contributors, **1244** pull requests, community reviewers, and our [**generous donors**](/donate), we're happy to announce the **Bevy 0.16** release on [crates.io](https://crates.io/crates/bevy)!
 
 For those who don't know, Bevy is a refreshingly simple data-driven game engine built in Rust. You can check out our [Quick Start Guide](/learn/quick-start) to try it today. It's free and open source forever! You can grab the full [source code](https://github.com/bevyengine/bevy) on GitHub. Check out [Bevy Assets](https://bevyengine.org/assets) for a collection of community-developed plugins, games, and learning resources.
 
@@ -42,6 +42,6 @@ Peering deep into the mists of time (predictions are _extra_ hard when your team
 
 {{ support_bevy() }}
 
-TODO: add  contributors
-TODO: add changelog
+{{ contributors(version="0.16") }}
+
 For those interested in a complete changelog, you can see the entire log (and linked pull requests) via the [relevant commit history](https://github.com/bevyengine/bevy/compare/v0.15.0...v0.16.0-rc.5).

--- a/release-content/0.16/contributors.toml
+++ b/release-content/0.16/contributors.toml
@@ -1,0 +1,783 @@
+[[contributors]]
+name = '@jpbloom'
+
+[[contributors]]
+name = '@Nathan-Fenner'
+
+[[contributors]]
+name = '@lomirus'
+
+[[contributors]]
+name = '@MiniaczQ'
+
+[[contributors]]
+name = '@scottmcm'
+
+[[contributors]]
+name = '@hjklchan'
+
+[[contributors]]
+name = '@onkoe'
+
+[[contributors]]
+name = '@spectria-limina'
+
+[[contributors]]
+name = '@MinerSebas'
+
+[[contributors]]
+name = '@inodentry'
+
+[[contributors]]
+name = '@jakkos-net'
+
+[[contributors]]
+name = '@Emmet-v15'
+
+[[contributors]]
+name = '@Brezak'
+
+[[contributors]]
+name = '@joshua-holmes'
+
+[[contributors]]
+name = '@VictorElHajj'
+
+[[contributors]]
+name = '@cxreiff'
+
+[[contributors]]
+name = '@msvbg'
+
+[[contributors]]
+name = '@bjoernp116'
+
+[[contributors]]
+name = '@stepancheg'
+
+[[contributors]]
+name = '@copygirl'
+
+[[contributors]]
+name = '@brianreavis'
+
+[[contributors]]
+name = '@eugineerd'
+
+[[contributors]]
+name = '@kristoff3r'
+
+[[contributors]]
+name = '@jnhyatt'
+
+[[contributors]]
+name = '@benfrankel'
+
+[[contributors]]
+name = '@AlephCubed'
+
+[[contributors]]
+name = '@atornity'
+
+[[contributors]]
+name = '@szepeviktor'
+
+[[contributors]]
+name = '@urben1680'
+
+[[contributors]]
+name = '@globin'
+
+[[contributors]]
+name = '@jakobhellermann'
+
+[[contributors]]
+name = '@mysteriouslyseeing'
+
+[[contributors]]
+name = '@fjkorf'
+
+[[contributors]]
+name = '@superdump'
+
+[[contributors]]
+name = '@DasLixou'
+
+[[contributors]]
+name = '@dmyyy'
+
+[[contributors]]
+name = '@PPakalns'
+
+[[contributors]]
+name = '@AustinHellerRepo'
+
+[[contributors]]
+name = '@skimmedsquare'
+
+[[contributors]]
+name = '@andresovela'
+
+[[contributors]]
+name = '@aloucks'
+
+[[contributors]]
+name = '@lynn-lumen'
+
+[[contributors]]
+name = '@yrns'
+
+[[contributors]]
+name = '@krunchington'
+
+[[contributors]]
+name = '@akimakinai'
+
+[[contributors]]
+name = '@s-puig'
+
+[[contributors]]
+name = '@madsmtm'
+
+[[contributors]]
+name = '@Arend-Jan'
+
+[[contributors]]
+name = '@tbillington'
+
+[[contributors]]
+name = '@xuwaters'
+
+[[contributors]]
+name = '@couyit'
+
+[[contributors]]
+name = '@ilyvion'
+
+[[contributors]]
+name = '@yonzebu'
+
+[[contributors]]
+name = '@Threadzless'
+
+[[contributors]]
+name = '@berylllium'
+
+[[contributors]]
+name = '@pemattern'
+
+[[contributors]]
+name = '@nakedible'
+
+[[contributors]]
+name = '@chendaohan'
+
+[[contributors]]
+name = '@Kees-van-Beilen'
+
+[[contributors]]
+name = '@cBournhonesque'
+
+[[contributors]]
+name = '@tychedelia'
+
+[[contributors]]
+name = '@clarfonthey'
+
+[[contributors]]
+name = '@ad-kr'
+
+[[contributors]]
+name = '@ChristopherBiscardi'
+
+[[contributors]]
+name = '@IceSentry'
+
+[[contributors]]
+name = '@NiklasEi'
+
+[[contributors]]
+name = '@Wuketuke'
+
+[[contributors]]
+name = '@atlv24'
+
+[[contributors]]
+name = '@axlitEels'
+
+[[contributors]]
+name = '@Leinnan'
+
+[[contributors]]
+name = '@chronicl'
+
+[[contributors]]
+name = '@aevyrie'
+
+[[contributors]]
+name = '@silvestrpredko'
+
+[[contributors]]
+name = '@JMS55'
+
+[[contributors]]
+name = '@sirius94'
+
+[[contributors]]
+name = '@dependabot[bot]'
+
+[[contributors]]
+name = '@robtfm'
+
+[[contributors]]
+name = '@tim-blackbird'
+
+[[contributors]]
+name = '@Shatur'
+
+[[contributors]]
+name = '@MarcoMeijer'
+
+[[contributors]]
+name = '@mockersf'
+
+[[contributors]]
+name = '@venhelhardt'
+
+[[contributors]]
+name = '@Windsdon'
+
+[[contributors]]
+name = '@IQuick143'
+
+[[contributors]]
+name = '@andrewhickman'
+
+[[contributors]]
+name = '@hukasu'
+
+[[contributors]]
+name = '@johanhelsing'
+
+[[contributors]]
+name = '@mate-h'
+
+[[contributors]]
+name = '@DaAlbrecht'
+
+[[contributors]]
+name = '@Knar33'
+
+[[contributors]]
+name = '@greeble-dev'
+
+[[contributors]]
+name = '@RobWalt'
+
+[[contributors]]
+name = '@ldubos'
+
+[[contributors]]
+name = '@jiangheng90'
+
+[[contributors]]
+name = '@Freyja-moth'
+
+[[contributors]]
+name = '@nicoburns'
+
+[[contributors]]
+name = '@TomMD'
+
+[[contributors]]
+name = '@Bleachfuel'
+
+[[contributors]]
+name = '@JaySpruce'
+
+[[contributors]]
+name = '@alice-i-cecile'
+
+[[contributors]]
+name = '@shafferchance'
+
+[[contributors]]
+name = '@CrushedPixel'
+
+[[contributors]]
+name = '@Lege19'
+
+[[contributors]]
+name = '@andriyDev'
+
+[[contributors]]
+name = '@Peepo-Juice'
+
+[[contributors]]
+name = '@PixelDust22'
+
+[[contributors]]
+name = '@theotherphil'
+
+[[contributors]]
+name = '@Cyborus04'
+
+[[contributors]]
+name = '@Satellile'
+
+[[contributors]]
+name = '@notmd'
+
+[[contributors]]
+name = '@joseph-gio'
+
+[[contributors]]
+name = '@bas-ie'
+
+[[contributors]]
+name = '@GuillaumeGomez'
+
+[[contributors]]
+name = '@Vrixyz'
+
+[[contributors]]
+name = '@to-bak'
+
+[[contributors]]
+name = '@Jondolf'
+
+[[contributors]]
+name = '@ItsDoot'
+
+[[contributors]]
+name = '@alex5nader'
+
+[[contributors]]
+name = '@musjj'
+
+[[contributors]]
+name = '@MrGVSV'
+
+[[contributors]]
+name = '@bytemunch'
+
+[[contributors]]
+name = '@JeanMertz'
+
+[[contributors]]
+name = '@ickshonpe'
+
+[[contributors]]
+name = '@GglLfr'
+
+[[contributors]]
+name = '@inact1v1ty'
+
+[[contributors]]
+name = '@colepoirier'
+
+[[contributors]]
+name = '@TurtIeSocks'
+
+[[contributors]]
+name = '@villor'
+
+[[contributors]]
+name = '@OwlyCode'
+
+[[contributors]]
+name = '@Sorseg'
+
+[[contributors]]
+name = '@UkoeHB'
+
+[[contributors]]
+name = '@mwcampbell'
+
+[[contributors]]
+name = '@Henauxg'
+
+[[contributors]]
+name = '@darthLeviN'
+
+[[contributors]]
+name = '@MalekiRe'
+
+[[contributors]]
+name = '@jatimix'
+
+[[contributors]]
+name = '@Noxmore'
+
+[[contributors]]
+name = '@NyxAlexandra'
+
+[[contributors]]
+name = '@mgi388'
+
+[[contributors]]
+name = '@SludgePhD'
+
+[[contributors]]
+name = '@mweatherley'
+
+[[contributors]]
+name = '@shuoli84'
+
+[[contributors]]
+name = '@lcnr'
+
+[[contributors]]
+name = 'Threadzless'
+
+[[contributors]]
+name = '@JusSchw'
+
+[[contributors]]
+name = '@terahlunah'
+
+[[contributors]]
+name = '@fatho'
+
+[[contributors]]
+name = '@rambip'
+
+[[contributors]]
+name = '@mintlu8'
+
+[[contributors]]
+name = '@tjlaxs'
+
+[[contributors]]
+name = '@dbeckwith'
+
+[[contributors]]
+name = '@raldone01'
+
+[[contributors]]
+name = '@hymm'
+
+[[contributors]]
+name = 'Freya Pines'
+
+[[contributors]]
+name = '@fschlee'
+
+[[contributors]]
+name = '@spvky'
+
+[[contributors]]
+name = '@arunke'
+
+[[contributors]]
+name = '@DGriffin91'
+
+[[contributors]]
+name = '@sophrosyne97'
+
+[[contributors]]
+name = '@SparkyPotato'
+
+[[contributors]]
+name = '@Zoomulator'
+
+[[contributors]]
+name = '@djeedai'
+
+[[contributors]]
+name = '@StrikeForceZero'
+
+[[contributors]]
+name = '@newclarityex'
+
+[[contributors]]
+name = '@nicopap'
+
+[[contributors]]
+name = '@ndarilek'
+
+[[contributors]]
+name = '@james-j-obrien'
+
+[[contributors]]
+name = '@eckz'
+
+[[contributors]]
+name = '@Soulghost'
+
+[[contributors]]
+name = '@Novakasa'
+
+[[contributors]]
+name = '@hocop'
+
+[[contributors]]
+name = '@andristarr'
+
+[[contributors]]
+name = '@chescock'
+
+[[contributors]]
+name = '@pcwalton'
+
+[[contributors]]
+name = '@bushrat011899'
+
+[[contributors]]
+name = '@mdickopp'
+
+[[contributors]]
+name = '@ethereumdegen'
+
+[[contributors]]
+name = '@Victoronz'
+
+[[contributors]]
+name = '@omaskery'
+
+[[contributors]]
+name = '@vandie'
+
+[[contributors]]
+name = '@RCoder01'
+
+[[contributors]]
+name = '@DataTriny'
+
+[[contributors]]
+name = '@CrazyRoka'
+
+[[contributors]]
+name = '@anlumo'
+
+[[contributors]]
+name = '@shanecelis'
+
+[[contributors]]
+name = '@doup'
+
+[[contributors]]
+name = '@Lyndon-Mackay'
+
+[[contributors]]
+name = '@nicholasc'
+
+[[contributors]]
+name = '@scvalex'
+
+[[contributors]]
+name = '@bash'
+
+[[contributors]]
+name = '@SpecificProtagonist'
+
+[[contributors]]
+name = '@SolarLiner'
+
+[[contributors]]
+name = '@foxzool'
+
+[[contributors]]
+name = '@SOF3'
+
+[[contributors]]
+name = '@Jaso333'
+
+[[contributors]]
+name = '@moonheart08'
+
+[[contributors]]
+name = '@romamik'
+
+[[contributors]]
+name = '@HugoPeters1024'
+
+[[contributors]]
+name = '@flokli'
+
+[[contributors]]
+name = '@harun-ibram'
+
+[[contributors]]
+name = '@wolf-in-space'
+
+[[contributors]]
+name = '@NiseVoid'
+
+[[contributors]]
+name = '@jf908'
+
+[[contributors]]
+name = '@ecoskey'
+
+[[contributors]]
+name = '@Friz64'
+
+[[contributors]]
+name = '@janis-bhm'
+
+[[contributors]]
+name = '@LogicFan'
+
+[[contributors]]
+name = '@mnmaita'
+
+[[contributors]]
+name = '@TimJentzsch'
+
+[[contributors]]
+name = '@chamaloriz'
+
+[[contributors]]
+name = 'AxiomaticSemantics'
+
+[[contributors]]
+name = '@HyperCodec'
+
+[[contributors]]
+name = '@alphastrata'
+
+[[contributors]]
+name = '@Phoqinu'
+
+[[contributors]]
+name = '@NthTensor'
+
+[[contributors]]
+name = '@Azorlogh'
+
+[[contributors]]
+name = '@cart'
+
+[[contributors]]
+name = '@pin3-free'
+
+[[contributors]]
+name = '@younes-io'
+
+[[contributors]]
+name = '@LikeLakers2'
+
+[[contributors]]
+name = '@rendaoer'
+
+[[contributors]]
+name = '@vil-mo'
+
+[[contributors]]
+name = '@Trashtalk217'
+
+[[contributors]]
+name = '@rparrett'
+
+[[contributors]]
+name = '@purplg'
+
+[[contributors]]
+name = '@homersimpsons'
+
+[[contributors]]
+name = '@Mathspy'
+
+[[contributors]]
+name = '@Carter0'
+
+[[contributors]]
+name = '@VitalyAnkh'
+
+[[contributors]]
+name = '@komadori'
+
+[[contributors]]
+name = '@ElliottjPierce'
+
+[[contributors]]
+name = '@brookman'
+
+[[contributors]]
+name = '@Weshnaw'
+
+[[contributors]]
+name = '@Mclilzee'
+
+[[contributors]]
+name = '@boondocklabs'
+
+[[contributors]]
+name = '@BenjaminBrienen'
+
+[[contributors]]
+name = '@Sigma-dev'
+
+[[contributors]]
+name = '@aecsocket'
+
+[[contributors]]
+name = '@chompaa'
+
+[[contributors]]
+name = '@Wcubed'
+
+[[contributors]]
+name = '@SilentSpaceTraveller'
+
+[[contributors]]
+name = '@VictorKoenders'
+
+[[contributors]]
+name = '@772'
+
+[[contributors]]
+name = '@grind086'
+
+[[contributors]]
+name = '@repnop'
+
+[[contributors]]
+name = '@coreh'
+
+[[contributors]]
+name = '@eero-lehtinen'
+
+[[contributors]]
+name = '@EmbersArc'
+
+[[contributors]]
+name = '@BD103'
+
+[[contributors]]
+name = '@viridia'
+
+[[contributors]]
+name = '@Person-93'
+
+[[contributors]]
+name = '@attila-lin'
+
+[[contributors]]
+name = '@hexroll'
+
+[[contributors]]
+name = '@SmakoszJan'
+
+[[contributors]]
+name = '@LucDrenth'
+
+[[contributors]]
+name = '@ghost'
+
+[[contributors]]
+name = '@mamekoro'
+
+[[contributors]]
+name = '@RJ'
+
+[[contributors]]
+name = '@super-saturn'
+
+[[contributors]]
+name = '@nandee95'
+
+[[contributors]]
+name = '@Kanabenki'
+


### PR DESCRIPTION
I've opted to omit the generated change log this release: it's simply a regurgitation of the commit history, and not a good use of real estate in our release notes relative to a link.

We should remove that functionality from the tool in the future, but I've opted not to do that in this PR for ease of review :)

The exact commands used are in the commit messages; check those to validate!