### PR TITLE
Remove release candidate warning in migration guide

### DIFF
--- a/content/learn/migration-guides/0.15-to-0.16.md
+++ b/content/learn/migration-guides/0.15-to-0.16.md
@@ -6,10 +6,6 @@ weight = 11
 long_title = "Migration Guide: 0.15 to 0.16"
 +++
 
-{% callout(type="warning") %}
-This guide is currently for a __Release Candidate__ and is subject to change as we work on and improve it. If you notice any errors or issues within this guide, then please submit an issue at [the Bevy website repository issue tracker](https://github.com/bevyengine/bevy-website/issues).
-{% end %}
-
 The most important changes to be aware of this release are:
 
 - Bevy has reworked its error handling to make it easier to handle `Result`s everywhere. As a result, `Query::single` and friends now return results, rather than panicking.


### PR DESCRIPTION
Since we're no longer in the release candidate phase, this warning should be removed :)

![image](https://github.com/user-attachments/assets/d72df888-a8e5-4612-ae15-9c30d72877d8)
