### PR TITLE
Mark Jondolf as co-author to docs trait tags PR

### DIFF
--- a/release-content/0.16/release-notes/_release-notes.toml
+++ b/release-content/0.16/release-notes/_release-notes.toml
@@ -248,7 +248,7 @@ file_name = "gpu_tracing.md"
 
 [[release_notes]]
 title = "Trait Tags on docs.rs"
-authors = ["@SpecificProtagonist"]
-contributors = ["@Jondolf", "@Carter0"]
+authors = ["@SpecificProtagonist", "@Jondolf"]
+contributors = ["@Carter0"]
 prs = [17758]
 file_name = "17758_Trait_tags_on_docsrs.md"


### PR DESCRIPTION
@Jondolf was a significant contributor to https://github.com/bevyengine/bevy/pull/17758, having worked largely on the [initial demo](https://github.com/Jondolf/bevy_docs_extension_demo/). He should be credited for his hard work! :)