### PR TITLE
Fix several typos on 0.15 to 0.16 migration guides

### DIFF
--- a/release-content/0.16/migration-guides/16348_Remove_deprecated_component_reads_and_writes.md
+++ b/release-content/0.16/migration-guides/16348_Remove_deprecated_component_reads_and_writes.md
@@ -8,11 +8,11 @@ As `try_iter_component_access()` returns a `Result`, you’ll now need to handle
 
 Additionally, you’ll need to `filter_map()` the accesses based on which method you’re attempting to replace:
 
-|0.15|0.16|
-|-|-|
-|`Access::component_reads_and_writes()`|`Exclusive(_) | Shared(_)`|
-|`Access::component_reads()`|`Shared(_)`|
-|`Access::component_writes()`|`Exclusive(_)`|
+| 0.15                                   | 0.16                        |
+|----------------------------------------|-----------------------------|
+| `Access::component_reads_and_writes()` | `Exclusive(_) \| Shared(_)` |
+| `Access::component_reads()`            | `Shared(_)`                 |
+| `Access::component_writes()`           | `Exclusive(_)`              |
 
 To ease migration, please consider the below extension trait which you can include in your project:
 

--- a/release-content/0.16/migration-guides/17233_If_there_is_no_movement_DragStart_is_not_triggered.md
+++ b/release-content/0.16/migration-guides/17233_If_there_is_no_movement_DragStart_is_not_triggered.md
@@ -1,1 +1,1 @@
->  Fix the missing part of Drag https://github.com/bevyengine/bevy/pull/16950
+Fix the missing part of Drag [https://github.com/bevyengine/bevy/pull/16950](https://github.com/bevyengine/bevy/pull/16950)

--- a/release-content/0.16/migration-guides/17605_Support_decibels_in_bevy_audioVolume.md
+++ b/release-content/0.16/migration-guides/17605_Support_decibels_in_bevy_audioVolume.md
@@ -15,4 +15,4 @@ let volume = Volume::Decibels(0.0);
 
 With this change, `AudioSinkPlayback`'s volume-related methods (`volume()` and `set_volume()`) and `GlobalVolume` now deal in `Volume`s rather than `f32`s.
 
-Finally, `Volume::ZERO` has been renamed to the more semantically correct `Volume::SILENT`. This is because 0 decibals is equivalent to "normal volume", which could lead to confusion with the old naming.
+Finally, `Volume::ZERO` has been renamed to the more semantically correct `Volume::SILENT`. This is because 0 decibels is equivalent to "normal volume", which could lead to confusion with the old naming.

--- a/release-content/0.16/migration-guides/17743_Fix_rounding_in_steps_easing_function.md
+++ b/release-content/0.16/migration-guides/17743_Fix_rounding_in_steps_easing_function.md
@@ -1,3 +1,3 @@
 <!-- Note to editors: this should be adjusted if 17744 is addressed, and possibly combined with the notes from the PR that fixes it. -->
 
-`EaseFunction::Steps` now behaves like css’s default, “jump-end.” If you were relying on the old behavior, we plan on providing it. See https://github.com/bevyengine/bevy/issues/17744.
+`EaseFunction::Steps` now behaves like css’s default, “jump-end.” If you were relying on the old behavior, we plan on providing it. See [https://github.com/bevyengine/bevy/issues/17744](https://github.com/bevyengine/bevy/issues/17744).


### PR DESCRIPTION
I've noticed that generated listing in the migration guides (`release-content/0.16/migration-guides`) doesn't reflect the newest migration guides supplied from the respective PR (e.g. after being edited by the author). 

I found several typos and table formatting that breaks when rendered on the bevy website.

Additional note: a TODO is still found in [Cold Specialization](https://bevyengine.org/learn/migration-guides/0-15-to-0-16/#cold-specialization). It might need additional guide, considering its size.