### PR TITLE
Fix example workflows for screenshots and wasm

### DIFF
--- a/.github/workflows/build-wasm-examples.yml
+++ b/.github/workflows/build-wasm-examples.yml
@@ -68,6 +68,8 @@ jobs:
         run: |
           export PATH=$PATH:`pwd`/binaryen/bin
           cargo run -p example-showcase -- --per-page ${{ env.PER_PAGE }} --page ${{ matrix.page }} build-wasm-examples --content-folder wasm-examples --api ${{ matrix.api }} --website-hacks --optimize-size
+        env:
+          CARGO_PROFILE_RELEASE_OPT_LEVEL: "z"
 
       - name: Upload Generated Files
         uses: actions/upload-artifact@v4

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -27,7 +27,7 @@ jobs:
           example_count=`cat Cargo.toml | grep '\[\[example\]\]' | wc -l`
           page_count=$((example_count / ${{ env.PER_PAGE }} + 1))
           echo "pages=`jq -n -c \"[range($page_count)]\"`" >> $GITHUB_OUTPUT
- 
+
   take-screenshots:
     name: Take Screenshots
     needs: prepare-pages
@@ -57,7 +57,7 @@ jobs:
           sudo apt-get update -y -qq
           sudo add-apt-repository ppa:kisak/turtle -y
           sudo apt-get update
-          sudo apt install -y xvfb libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
+          sudo apt install -y xvfb libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
 
       - name: Install oxipng
         run: |
@@ -85,7 +85,7 @@ jobs:
       pull-requests: write
       contents: write
     steps:
-      
+
       - name: Clone bevy-website repo
         uses: actions/checkout@v4
 


### PR DESCRIPTION
* screenshots workflow failed on dependency that doesn't exist anymore: https://github.com/bevyengine/bevy-website/actions/runs/14663792163/job/41153825762#step:5:71
  * don't install it, it's the fix we did for the main repo
* Example wasm files are now too big to upload to cloudflare
  * optimise for size even more