### PR TITLE
fix: mis-rendered table

### DIFF
--- a/release-content/0.16/migration-guides/17029_Refactor_hierarchyrelated_commands_to_remove_structs.md
+++ b/release-content/0.16/migration-guides/17029_Refactor_hierarchyrelated_commands_to_remove_structs.md
@@ -18,6 +18,6 @@ If you were queuing the structs of hierarchy-related commands directly, you will
 If you were queuing the structs of event-related commands directly, you will need to change them to methods implemented on `Commands`:
 
 |Struct|Method|
-|-|
+|-|-|
 |`commands.queue(SendEvent { event })`|`commands.send_event(event)`|
 |`commands.queue(TriggerEvent { event, targets })`|`commands.trigger_targets(event, targets)`|


### PR DESCRIPTION
A table was mis-rendered:
![image](https://github.com/user-attachments/assets/b2bd9c86-297c-44a2-aaa1-f2bfe404b63a)
