### PR TITLE
Fix metadata retrieval for assets using Rust 2024 edition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1666,12 +1666,12 @@ dependencies = [
 
 [[package]]
 name = "cargo_toml"
-version = "0.15.3"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "599aa35200ffff8f04c1925aa1acc92fa2e08874379ef42e210a80e527e60838"
+checksum = "02260d489095346e5cafd04dea8e8cb54d1d74fcd759022a9b72986ebe9a1257"
 dependencies = [
  "serde",
- "toml 0.7.8",
+ "toml 0.8.19",
 ]
 
 [[package]]

--- a/generate-assets/Cargo.toml
+++ b/generate-assets/Cargo.toml
@@ -13,7 +13,7 @@ toml = "0.7"
 serde = { version = "1", features = ["derive"] }
 rand = "0.8"
 regex = "1"
-cargo_toml = "0.15"
+cargo_toml = "0.22"
 url = "2.2.2"
 anyhow = "1.0.58"
 base64 = "0.13.0"

--- a/generate-assets/src/lib.rs
+++ b/generate-assets/src/lib.rs
@@ -801,6 +801,7 @@ mod tests {
                     metadata: Default::default(),
                     resolver: Default::default(),
                     dependencies: workspace_dependencies,
+                    lints: Default::default(),
                 }),
                 dependencies,
                 dev_dependencies,
@@ -816,6 +817,7 @@ mod tests {
                 bench: Default::default(),
                 test: Default::default(),
                 example: Default::default(),
+                lints: Default::default(),
             }
         }
 
@@ -995,10 +997,10 @@ mod tests {
 
             dependencies.insert(
                 "bevy".to_string(),
-                Dependency::Detailed(cargo_toml::DependencyDetail {
+                Dependency::Detailed(Box::new(cargo_toml::DependencyDetail {
                     path: Some("fake/path/to/crate".to_string()),
                     ..Default::default()
-                }),
+                })),
             );
             dev_dependencies.insert(
                 "bevy_transform".to_string(),
@@ -1019,10 +1021,10 @@ mod tests {
             // Alphabetical order could matter in this example, "first" < "second"
             dependencies.insert(
                 "bevy_first_third_party_crate".to_string(),
-                Dependency::Detailed(cargo_toml::DependencyDetail {
+                Dependency::Detailed(Box::new(cargo_toml::DependencyDetail {
                     path: Some("fake/path/to/crate".to_string()),
                     ..Default::default()
-                }),
+                })),
             );
             dependencies.insert(
                 "bevy_second_third_party_crate".to_string(),


### PR DESCRIPTION
## Motivation

Asset metadata retrieval currently fails for assets that use Rust 2024 edition with the following error:

```
GITHUB_TOKEN=xxx ./generate-assets.sh
```

```
(...)
Error getting metadata from root cargo file from github: TOML parse error at line 4, column 11
  |
4 | edition = "2024"
  |           ^^^^^^
data did not match any variant of untagged enum Inheritable
```

## Solution

Update `cargo_toml`

## Note

Some tests in `generate-assets` fail, but they also fail on main in the same way. See #2121 