### PR TITLE
Remove old failing tests from generate-assets and run tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,31 @@ jobs:
       - name: Check clippy
         run: cargo clippy --workspace -- -Dwarnings
 
+
+  test-tools:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-test-tools-${{ hashFiles('**/Cargo.toml') }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install alsa and udev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+
+      - name: Run tests
+        run: cargo test
+
   typos:
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Check hide-lines
         run: cd write-rustdoc-hide-lines && cargo run --release -- check ../content
 
-  lint-crates:
+  lint-tools:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -57,7 +57,6 @@ jobs:
         run: cargo clippy --all-targets -- -Dwarnings
 
   test-crates:
-    needs: ["generate-errors"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -70,7 +69,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-test-tools-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-test-crates-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -78,11 +77,9 @@ jobs:
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
 
-      # Some tests assume errors have been generated
-      - uses: actions/download-artifact@v4
-        with:
-          name: generated-errors
-          path: content/learn/errors
+      # Some tests assume the generate-errors/bevy/errors folder exists
+      - name: Checkout errors
+        run: generate-errors/download_errors.sh
 
       - name: Run tests
         run: cargo test
@@ -104,7 +101,7 @@ jobs:
           echo 'You can find the extension here: https://marketplace.visualstudio.com/items?itemName=tekumara.typos-vscode'
 
   generate-assets:
-    needs: [mega-linter, lint-crates, check-hide-lines, typos]
+    needs: [mega-linter, lint-tools, check-hide-lines, typos]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -140,7 +137,7 @@ jobs:
           retention-days: 1
 
   generate-errors:
-    needs: [mega-linter, lint-crates, check-hide-lines, typos]
+    needs: [mega-linter, lint-tools, check-hide-lines, typos]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -167,7 +164,7 @@ jobs:
           retention-days: 1
 
   generate-wasm-examples:
-    needs: [mega-linter, lint-crates, check-hide-lines, typos]
+    needs: [mega-linter, lint-tools, check-hide-lines, typos]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -194,7 +191,7 @@ jobs:
           retention-days: 1
 
   generate-community:
-    needs: [mega-linter, lint-crates, check-hide-lines, typos]
+    needs: [mega-linter, lint-tools, check-hide-lines, typos]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -222,7 +219,7 @@ jobs:
 
   build-website:
     runs-on: ubuntu-latest
-    needs: [mega-linter, lint-crates, check-hide-lines, typos, generate-assets, generate-errors, generate-wasm-examples, generate-community, test-crates]
+    needs: [mega-linter, lint-tools, check-hide-lines, typos, generate-assets, generate-errors, generate-wasm-examples, generate-community, test-crates]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,20 +28,6 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main
 
-  test-code-examples:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install alsa and udev
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
-
-      - name: Build & run doc tests
-        run: cd learning-code-examples && ./validate_examples.sh
-
   check-hide-lines:
     runs-on: ubuntu-latest
     steps:
@@ -49,11 +35,11 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-      
+
       - name: Check hide-lines
         run: cd write-rustdoc-hide-lines && cargo run --release -- check ../content
 
-  lint-tools:
+  lint-crates:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -68,10 +54,10 @@ jobs:
         run: cargo fmt --check --all
 
       - name: Check clippy
-        run: cargo clippy --workspace -- -Dwarnings
+        run: cargo clippy --all-targets -- -Dwarnings
 
-
-  test-tools:
+  test-crates:
+    needs: ["generate-errors"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -91,6 +77,12 @@ jobs:
 
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+
+      # Some tests assume errors have been generated
+      - uses: actions/download-artifact@v4
+        with:
+          name: generated-errors
+          path: content/learn/errors
 
       - name: Run tests
         run: cargo test
@@ -112,7 +104,7 @@ jobs:
           echo 'You can find the extension here: https://marketplace.visualstudio.com/items?itemName=tekumara.typos-vscode'
 
   generate-assets:
-    needs: [mega-linter, test-code-examples, lint-tools, check-hide-lines, typos]
+    needs: [mega-linter, lint-crates, check-hide-lines, typos]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -148,7 +140,7 @@ jobs:
           retention-days: 1
 
   generate-errors:
-    needs: [mega-linter, test-code-examples, lint-tools, check-hide-lines, typos]
+    needs: [mega-linter, lint-crates, check-hide-lines, typos]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -175,7 +167,7 @@ jobs:
           retention-days: 1
 
   generate-wasm-examples:
-    needs: [mega-linter, test-code-examples, lint-tools, check-hide-lines, typos]
+    needs: [mega-linter, lint-crates, check-hide-lines, typos]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -202,7 +194,7 @@ jobs:
           retention-days: 1
 
   generate-community:
-    needs: [mega-linter, test-code-examples, lint-tools, check-hide-lines, typos]
+    needs: [mega-linter, lint-crates, check-hide-lines, typos]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -230,7 +222,7 @@ jobs:
 
   build-website:
     runs-on: ubuntu-latest
-    needs: [mega-linter, test-code-examples, lint-tools, check-hide-lines, typos, generate-assets, generate-errors, generate-wasm-examples, generate-community]
+    needs: [mega-linter, lint-crates, check-hide-lines, typos, generate-assets, generate-errors, generate-wasm-examples, generate-community, test-crates]
 
     steps:
       - uses: actions/checkout@v4

--- a/generate-assets/src/lib.rs
+++ b/generate-assets/src/lib.rs
@@ -929,23 +929,6 @@ mod tests {
         }
 
         #[test]
-        fn from_third_party() {
-            let mut dependencies = BTreeMap::new();
-            let dev_dependencies = BTreeMap::new();
-            let workspace_dependencies = BTreeMap::new();
-
-            dependencies.insert(
-                "bevy_third_party_crate_example".to_string(),
-                Dependency::Simple("0.5".to_string()),
-            );
-
-            let manifest = get_manifest(dependencies, dev_dependencies, workspace_dependencies);
-            let version = get_bevy_version_from_manifest(&manifest, &get_bevy_crates_names());
-            // Note that this result is expected, but potentially wrong
-            assert_eq!(version, Some("0.5".to_string()));
-        }
-
-        #[test]
         fn from_dependencies_ignore_third_party() {
             let mut dependencies = BTreeMap::new();
             let dev_dependencies = BTreeMap::new();
@@ -1022,49 +1005,6 @@ mod tests {
             let manifest = get_manifest(dependencies, dev_dependencies, workspace_dependencies);
             let version = get_bevy_version_from_manifest(&manifest, &get_bevy_crates_names());
             assert_eq!(version, Some("0.10".to_string()));
-        }
-
-        #[test]
-        fn from_third_party_crate_with_path_dependency() {
-            let mut dependencies = BTreeMap::new();
-            let dev_dependencies = BTreeMap::new();
-            let workspace_dependencies = BTreeMap::new();
-
-            // Alphabetical order could matter in this example, "first" < "second"
-            dependencies.insert(
-                "bevy_first_third_party_crate".to_string(),
-                Dependency::Detailed(Box::new(cargo_toml::DependencyDetail {
-                    path: Some("fake/path/to/crate".to_string()),
-                    ..Default::default()
-                })),
-            );
-            dependencies.insert(
-                "bevy_second_third_party_crate".to_string(),
-                Dependency::Simple("0.10".to_string()),
-            );
-
-            let manifest = get_manifest(dependencies, dev_dependencies, workspace_dependencies);
-            let version = get_bevy_version_from_manifest(&manifest, &get_bevy_crates_names());
-            assert_eq!(version, Some("0.10".to_string()));
-        }
-
-        #[test]
-        fn from_third_party_with_no_official_bevy_crates() {
-            let mut dependencies = BTreeMap::new();
-            let mut dev_dependencies = BTreeMap::new();
-            let mut workspace_dependencies = BTreeMap::new();
-
-            dependencies.insert(
-                "bevy_third_party_crate_example".to_string(),
-                Dependency::Simple("0.5".to_string()),
-            );
-            dev_dependencies.insert("bevy".to_string(), Dependency::Simple("0.10".to_string()));
-            workspace_dependencies
-                .insert("bevy".to_string(), Dependency::Simple("0.10".to_string()));
-
-            let manifest = get_manifest(dependencies, dev_dependencies, workspace_dependencies);
-            let version = get_bevy_version_from_manifest(&manifest, &Some(vec![]));
-            assert_eq!(version, Some("0.5".to_string()));
         }
 
         #[test]

--- a/generate-errors/download_errors.sh
+++ b/generate-errors/download_errors.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Switch to script's directory, letting it be called from any folder.
+cd $(dirname $0)
+
+# Only download the `errors` folder from the main Bevy repository.
+git init bevy
+cd bevy
+git remote add origin https://github.com/bevyengine/bevy
+git sparse-checkout set "errors"
+git pull --depth=1 origin latest
+cd ..

--- a/generate-errors/generate_errors.sh
+++ b/generate-errors/generate_errors.sh
@@ -3,12 +3,6 @@
 # Switch to script's directory, letting it be called from any folder.
 cd $(dirname $0)
 
-# Only download the `errors` folder from the main Bevy repository.
-git init bevy
-cd bevy
-git remote add origin https://github.com/bevyengine/bevy
-git sparse-checkout set "errors"
-git pull --depth=1 origin latest
-cd ..
+./download_errors.sh
 
 cargo run --bin generate -- --errors-path bevy/errors --output-path ../content/learn

--- a/learning-code-examples/README.md
+++ b/learning-code-examples/README.md
@@ -60,4 +60,4 @@ To validate code you can run the bash script contained in this directory:
 >[!TIP]
 > The bash script can be called from any directory!
 
-However, if you can't run the bash script for one reason or another then you can run `cargo check --examples && cargo clippy --examples && cargo fmt --check` _in this directory_.
+However, if you can't run the bash script for one reason or another then you can run `cargo check --examples && cargo clippy --examples -- -Dwarnings && cargo fmt --check` _in this directory_.

--- a/learning-code-examples/examples/quick-start/getting_started_v3.rs
+++ b/learning-code-examples/examples/quick-start/getting_started_v3.rs
@@ -5,6 +5,7 @@ use bevy::prelude::*;
 struct Person;
 // ANCHOR_END: person_component
 
+#[expect(dead_code)]
 // ANCHOR: name_component
 #[derive(Component)]
 struct Name(String);

--- a/learning-code-examples/examples/quick-start/getting_started_v7.rs
+++ b/learning-code-examples/examples/quick-start/getting_started_v7.rs
@@ -1,3 +1,4 @@
+#![expect(unused_variables)]
 use bevy::prelude::*;
 
 // ANCHOR: hello_plugin

--- a/learning-code-examples/examples/quick-start/getting_started_v9.rs
+++ b/learning-code-examples/examples/quick-start/getting_started_v9.rs
@@ -1,3 +1,4 @@
+#![expect(unused_variables)]
 use bevy::prelude::*;
 
 #[derive(Component)]

--- a/learning-code-examples/validate_examples.sh
+++ b/learning-code-examples/validate_examples.sh
@@ -3,4 +3,4 @@
 # Switch to script's directory, letting it be called from any folder.
 cd $(dirname $0)
 
-cargo check --examples && cargo clippy --examples && cargo fmt --check
+cargo check --examples && cargo clippy --examples -- -Dwarnings && cargo fmt --check


### PR DESCRIPTION
Fixes #2121 

I also did the following:
* Add `test-crates` job that runs all tests in the workspace
* Remove `test-code-examples` as it is covered by the lint/check jobs
* Fix that the output of clippy was discarded when checking code examples, and fix the warnings