### PR TITLE
Add a callout to the example pages if JavaScript is disabled

### DIFF
--- a/templates/layouts/example.html
+++ b/templates/layouts/example.html
@@ -13,6 +13,11 @@
       </a>
     </div>
     <div class="example__canvas bevy-instance">
+      <noscript>
+        <aside class="example__callout media-content callout callout--plain callout--warning">
+          Examples require JavaScript to be enabled. Please enable JavaScript to run examples.
+        </aside>
+      </noscript>
       <div class="bevy-instance__progress-status" data-progress-status>
         <div class="bevy-instance__progress-file" data-progress-file></div>
         <div class="bevy-instance__progress-track">


### PR DESCRIPTION
This adds a warning-type callout to the example pages, if the browser detects that JavaScript is disabled for one reason or another. This callout is between the header (which says the name of the example) and the canvas showing the example.

![image](https://github.com/user-attachments/assets/81604a42-6f88-4e8b-9ae7-d48d8ea548ba)

A couple thoughts:

* I thought about linking to a resource on how to enable javascript, but I'm unsure if it's wanted.
* I thought about putting the warning inside the canvas (similar to how the loading bar does), but I'm proficient enough with CSS to understand how to do that - plus, I don't know how to ensure it looks nice on mobile (or how to test on mobile, for that matter).
* Yes, the `<aside>` tag used is copied from the callout below the canvas. I'm lazy, and it works anyways. :P

In any case, I'm satisfied with the result thus far. So I'm submitting this PR. :)