### PR TITLE
Fix small errors in iOS migration section

### DIFF
--- a/release-content/0.16/migration-guides/14780_Link_iOS_example_with_rustc_and_avoid_C_trampoline.md
+++ b/release-content/0.16/migration-guides/14780_Link_iOS_example_with_rustc_and_avoid_C_trampoline.md
@@ -9,18 +9,19 @@ You have two options for dealing with this.
 Preferred option is to remove your “compile” and “link” build phases, and instead replace it with a “run script” phase that invokes `cargo build --bin ...`, and moves the built binary to the Xcode path `$TARGET_BUILD_DIR/$EXECUTABLE_PATH`. An example of how to do this can be viewed in [mobile example](https://github.com/bevyengine/bevy/tree/main/examples/mobile).
 
 If you are not sure how to do this, consider one of two ways:
-- replace local mobile `game` crate with the one in repo and reaplly your changes.
+
+- replace local mobile `game` crate with the one in repo and reapply your changes.
 - replicate the changes from [pull request](https://github.com/bevyengine/bevy/pull/14780) in your `mobile` crate.
 
 To make the debugging experience in Xcode nicer after this, you might also want to consider either enabling `panic = "abort"` or to set a breakpoint on the `rust_panic` symbol.
 
 #### Restoring old behaviour
 
-If you’ve added further C code and Xcode customizations, or it makes sense for your use-case to continue link with Xcode, you can revert to the old behaviour by adding code below to your `main.rs` file:
+If you’re using additional ObjC code, Swift packages, Xcode customizations, or if it otherwise it makes sense for your use-case to continue link with Xcode, you can revert to the old behavior by adding code below to your `main.rs` file:
 
 ```rust
 #[cfg(target_os = "ios")]
-#[no_mangle]
+#[unsafe(no_mangle)]
 extern "C" fn main_rs() {
     main()
 }


### PR DESCRIPTION
This fixes a few small typographical errors, but also hopefully clarifies language around when users would want to use "the old way."

I found that using the new "rust does the linking" strategy completely locks you out of using packages like [bevy_ios_safearea](https://github.com/rustunit/bevy_ios_safearea). I went deep down that rabbit hole, and found that in the end, Swift *must* be statically linked by xcode.

You can manually build swift libraries and even link them from rust, and they'll work in the simulator, because the simulator has a swift runtime dylib. But this isn't the case on real iOS devices, by design.

Long story short, mentioning Swift somewhere in this text may have saved me some time.