### PR TITLE
Don't link to the ecs_guide example

### DIFF
--- a/content/learn/book/intro/apps-worlds.md
+++ b/content/learn/book/intro/apps-worlds.md
@@ -35,7 +35,7 @@ In most cases, your world will be contained within your app.
 The app is responsible for scheduling and executing your systems, and passing the data in and out of them appropriately.
 It also handles other app-level config, like windowing settings.
 
-## Off you go, now
+## Off you go now
 
 With that, you should have everything you need to understand a relatively straightforward example, such as the [`ecs_guide` example](https://github.com/bevyengine/bevy/blob/main/examples/ecs/ecs_guide.rs).
 The rest of this book contains different chapters that can be read or referenced in any order.

--- a/content/learn/book/intro/apps-worlds.md
+++ b/content/learn/book/intro/apps-worlds.md
@@ -37,5 +37,7 @@ It also handles other app-level config, like windowing settings.
 
 ## Off you go now
 
-With that, you should have everything you need to understand a relatively straightforward example, such as the [`ecs_guide` example](https://github.com/bevyengine/bevy/blob/main/examples/ecs/ecs_guide.rs).
-The rest of this book contains different chapters that can be read or referenced in any order.
+With that, you should have everything you need to start [exploring our examples](https://github.com/bevyengine/bevy/tree/latest/examples#examples),
+or diving into the rest of the book.
+
+The remaining chapters of this book are non-linear: you can read or referenced them in any order.


### PR DESCRIPTION
This is a) not a particularly useful example for beginners and b) not an example I'd like to keep around due to its very unfocused goals.

I've opted to reword this section and link to the examples as a whole.