### PR TITLE
Update setup guide Rust edition to 2024

### DIFF
--- a/content/learn/quick-start/getting-started/setup.md
+++ b/content/learn/quick-start/getting-started/setup.md
@@ -130,20 +130,6 @@ cargo add bevy
 
 Make sure to use the latest `bevy` crate version ([![Crates.io](https://img.shields.io/crates/v/bevy.svg)](https://crates.io/crates/bevy)).
 
-<details>
-  <summary>
-
-  ### Cargo Workspaces
-  </summary>
-
-  If you are using [Cargo Workspaces](https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html), you will also need to add the resolver to your Cargo.toml file in the root directory:
-
-  ```toml
-  [workspace]
-  resolver = "3"
-  ```
-</details>
-
 ### Compile with Performance Optimizations
 
 While it may not be an issue for simple projects, debug builds in Rust can be _very slow_ - especially when you start using Bevy to make real games.

--- a/content/learn/quick-start/getting-started/setup.md
+++ b/content/learn/quick-start/getting-started/setup.md
@@ -98,7 +98,7 @@ fn main() {
 [package]
 name = "my_bevy_game"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 ```
@@ -121,7 +121,7 @@ cargo add bevy
   [package]
   name = "my_bevy_game"
   version = "0.1.0"
-  edition = "2021" # this needs to be 2021, or you need to set "resolver=2"
+  edition = "2024"
 
   [dependencies]
   bevy = "0.16" # make sure this is the latest version
@@ -140,7 +140,7 @@ Make sure to use the latest `bevy` crate version ([![Crates.io](https://img.shie
 
   ```toml
   [workspace]
-  resolver = "2" # Important! wgpu/Bevy needs this!
+  resolver = "3"
   ```
 </details>
 


### PR DESCRIPTION
Regarding `resolver` in virtual workspaces: Bevy with default plugins runs for me regardless of value, but cargo will warn and default to `resolver = "1"` if none is specified.

```
warning: virtual workspace defaulting to `resolver = "1"` despite one or more workspace members being on edition 2024 which implies `resolver = "3"`
note: to use the edition 2024 resolver, specify `workspace.resolver = "3"` in the workspace root's manifest
note: for more details see https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
```