### PR TITLE
Don't try to copy out of `Local` system param.

### DIFF
--- a/content/learn/book/storing-data/local-system-param.md
+++ b/content/learn/book/storing-data/local-system-param.md
@@ -41,7 +41,7 @@ fn increment_local_system_data(mut local: Local<Option<NoGoodDefaultValue>>){
         *local = Some(NoGoodDefaultValue(0));
     }
     
-    local.unwrap().0 += 1;
+    local.as_mut().unwrap().0 += 1;
 }
 ```
 


### PR DESCRIPTION
Copying out of the local fails with a compiler error. Even if we "fix" that by making `NoGoodDefaultValue` `Copy`, it fails to modify the local - only modifying the copy.

We need to turn the option into an `Option<&mut _>` option before attempting to unwrap it.

See [comment on the PR that introduced this](https://github.com/bevyengine/bevy-website/pull/2173#discussion_r2191066505) for slightly more detail, also for the [alternative proposal](https://github.com/bevyengine/bevy-website/pull/2173#discussion_r2190535621) (to use `get_or_insert_with`) that I prefer but was previously rejected.