### PR TITLE
Add book page on time, fixed time and timers

### DIFF
--- a/content/learn/book/control-flow/systems.md
+++ b/content/learn/book/control-flow/systems.md
@@ -43,7 +43,7 @@ See the section on [`Local`] for more details.
 ## Running systems in schedules
 
 Normally, systems are inserted into a [`Schedule`] via [`App::add_system`].
-Each schedule is evaluated once per frame, and systems within a single schedule run in parallel unless they are explicitly ordered relative to each other.
+Each of the standard schedules are evaluated once per frame, and systems within a single schedule run in parallel unless they are explicitly ordered relative to each other.
 
 There's a great deal of complexity and nuance here: please see the [Game Loop chapter] for a more complete treatment of the topic.
 

--- a/content/learn/book/the-game-loop/fixed-time.md
+++ b/content/learn/book/the-game-loop/fixed-time.md
@@ -1,6 +1,0 @@
-+++
-title = "Fixed Time"
-insert_anchor_links = "right"
-[extra]
-weight = 5
-+++

--- a/content/learn/book/the-game-loop/time-and-timers.md
+++ b/content/learn/book/the-game-loop/time-and-timers.md
@@ -102,33 +102,59 @@ Alternatively, [states] and [run conditions] can be used to skip systems while t
 
 ## Fixing your timestep
 
-FIX YOUR TIMESTEP ARTICLE.
-When thinking about fixed time, it's important to clearly distinguish **frames** and **ticks**.
+Compensating for fluctating frame times using delta time is a great start.
+But as the timeless [fix your timestep article] explains for projects that require a higher level of stability and reproducibility,
+it's better to simply always advance time by a fixed amount.
+This is particularly important for physics and
 
-To understand how to work with fixed time, we need to understand a little bit about how [`Time`] actually works under the hood.
+To understand how to work with fixed time in Bevy, we need to first learn a little bit about how [`Time`] actually works under the hood.
 As the excellent docs on [`Time`] explain, there's actually *three* distinct types of time being measured:
 
 - real time: the actual wall time
   - use this for things like UI animations that you don't want to be affected by pausing
 - virtual time: the "in-game time"
   - if you're using fixed time, this is useful for graphical effects
-  - otherwise, this is used for all of your gameplay logic
+  - otherwise, this is used for all of your gameplay logic as well
 - fixed time
-  - advances by a [`Time::timestep`] every time [`FixedMain`] runs
-  - [`FixedMain`] will run repeatedly until it has caught up with the elapsed virtual time
-  - if not enough time has elapsed, [`FixedMain`] will not run at all for the frame
-  - please read the excellent docs on [`Fixed`] for more details!
+  - all of your gameplay logic should go here if you're using a fixed timestep approach
 
-Simply requesting [`Time`] in your systems will get you the correct flavor 90% of the time: virtual time in the main schedule,
-and fixed time in the fixed main schedule.
+When thinking about fixed time, it's important to clearly distinguish **frames** and **ticks**.
+A "frame" is one pass of the [`Main`] schedule, and corresponds to a single rendered frames.
+A "tick" is one pass of the [`FixedMain`] schedule, and corresponds to one iteration of gameplay logic.
+The ratio between frames elapsed and ticks elapsed is not constant: they may be faster or slower, depending
+on the rendering performance and your game's simulation needs.
+
+{% callout(type="info") %}
+Simply requesting [`Time`] in your systems will get you the correct flavor 90% of the time: virtual time in the [`Main`] schedule,
+and fixed time in the [`FixedMain`] schedule.
 To request a specific variation, change the implicit generic in [`Time`] from `()`
 to [`Real`], [`Virtual`] or [`Fixed`].
+{% end %}
 
-[`Time::timestep`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Time.html#method.timestep
+Now that we have the required vocabulary, let's go over exactly how the fixed timestep logic works in Bevy:
+
+- each frame, during the [`RunFixedMainLoop`] schedule, we determine how many times we should run the [`FixedMain`] schedule
+  - we add the the elapsed virtual time for the frame to a running time buffer
+  - if that time buffer is greater than or equal to [`Time<Fixed>::timestep`], we run the [`FixedMain`] schedule once, and subtract that timestep from our buffer
+- when the [`FixedMain`] schedule is evaluated, the various subschedules are iterated through, running [`FixedPreUpdate`], [`FixedUpdate`] and so on in order
+- within your fixed time systems, use the exact same delta time techniques to properly account for changes in your desired timestep during development
+
+This means that we may have 0, 1, 2 or more ticks per frame,
+with our fixed timestep logic running repeatedly until it's caught back up.
+For even more detail, check out the excellent documentation on [`Fixed`].
+
+Note that Bevy's "fixed timesteps" are not the right mechanism to use for gameplay logic like "every 5 seconds update this building".
+Bevy only supports a single fixed timestep across your entire project, and its use is completely optional.
+Please see our [timers and cooldowns] section below for the tools available to model this type of behavior.
+
+[`Time<Fixed>::timestep`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Time.html#method.timestep
+[`Main`]: https://docs.rs/bevy/latest/bevy/app/struct.Main.html
 [`FixedMain`]: https://docs.rs/bevy/latest/bevy/app/struct.FixedMain.html
 [`Real`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Real.html
 [`Virtual`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Virtual.html
 [`Fixed`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Fixed.html
+[fix your timestep article]: https://gafferongames.com/post/fix_your_timestep/
+[`RunFixedMainLoop`]: https://dev-docs.bevy.org/bevy/app/struct.RunFixedMainLoop.html
 
 ## Interpolation and smooth movement
 

--- a/content/learn/book/the-game-loop/time-and-timers.md
+++ b/content/learn/book/the-game-loop/time-and-timers.md
@@ -1,0 +1,18 @@
++++
+title = "Time and Timers"
+insert_anchor_links = "right"
+[extra]
+weight = 5
++++
+
+## Timers
+
+## Cooldowns
+
+## Delayed actions
+
+## Delta time
+
+## Fixed time
+
+## Interpolation best practices

--- a/content/learn/book/the-game-loop/time-and-timers.md
+++ b/content/learn/book/the-game-loop/time-and-timers.md
@@ -171,7 +171,7 @@ The core strategy is simple enough, but the devil is in the details:
 
 1. Create your own custom `GamePosition` type, holding the translation/rotation/scale information that your project needs.
 2. Modify and read this `GamePosition` type for all of your game logic and physics.
-3. Interpolate/extrapolate between the previous [`GlobalTransform`] and the `GamePosition`, based on the elapsed [`Fixed`] time.
+3. Interpolate between the previous [`GlobalTransform`] and the `GamePosition`, based on the elapsed [`Fixed`] time.
    1. This should occur after the final fixed update for the frame has run, but before rendering occurs.
    2. You ultimately want to set the [`GlobalTransform`], but doing this correctly in the presence of hierarchies is hard.
    3. As a result, modifying the local [`Transform`] and relying on transform propagation can be the least bad solution.

--- a/content/learn/book/the-game-loop/time-and-timers.md
+++ b/content/learn/book/the-game-loop/time-and-timers.md
@@ -5,14 +5,108 @@ insert_anchor_links = "right"
 weight = 5
 +++
 
-## Timers
+Responding to the passage of time is essential for gameplay, animations and audio.
+But doing so correctly is surprisingly subtle.
 
-## Cooldowns
+The [`Time`] resource in Bevy is the source of truth
+for the "current in-game time".
+Unlike [`Instant::now()`], the [`Time`] is fixed for the entire frame,
+rather than reflecting the precise wall clock time at the time of system evaluation.
+This value is set at the start of the frame based on the time supplied by the renderer,
+during the [`TimeSystem`] system set in the [`First`] schedule.
+
+This is helpful for performance reasons, but more critically,
+it ensures consistency of behavior across all of the various bits of game logic.
+
+[`Time`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Time.html
+[`Instant::now()`]: https://doc.rust-lang.org/std/time/struct.Instant.html#method.now
+[`TimeSystem`]: https://docs.rs/bevy/latest/bevy/time/struct.TimeSystem.html
+[`First`]: https://docs.rs/bevy/latest/bevy/app/struct.First.html
+
+## Frame-rate independence and delta time
+
+Suppose we want to move our player to the right:
+
+```rust
+use bevy::prelude::*;
+
+#[derive(Component)]
+struct Player;
+
+fn move_player(mut player_transform: Single<&mut Transform, With<Player>>){
+    const PLAYER_MOVEMENT: f32 = 1.;
+    
+    player_transform.translation.x += PLAYER_MOVEMENT;
+}
+```
+
+Every frame, our player will move 1 unit to the right. Great!
+But what happens when our game stutters, and the frame rate drops?
+Suddenly, rather than moving 60 units per second at our target 60 frames per second,
+our player is moving at an unsteady 20-30 units per second. Oh no!
+
+Instead, we can compensate for this effect by fixing our *speed* (or other rates of change per second),
+and then multiplying by the elapsed time.
+
+```rust, hide_lines=1-4
+# use bevy::prelude::*;
+# 
+# #[derive(Component)]
+# struct Player;
+#
+fn move_player(mut player_transform: Single<&mut Transform, With<Player>>, time: Res<Time>){
+    // At 60 FPS, this will be the same as before
+    const PLAYER_SPEED: f32 = 60.;
+    
+    player_transform.translation.x += PLAYER_SPEED * time.delta_secs_f32();
+}
+```
+
+This technique is commonly known as "delta time" among game devs, because physicists use "delta" to mean "a change in a quantity".
+
+## Pausing and time control
+
+With all of our time-dependent logic driven by the delta time,
+we can start playing tricks with the value of [`Time`] to implement features like pausing and slowing down the game.
+
+```rust
+use bevy::prelude::*;
+
+
+```
+
+## Fixing your timestep
+
+FIX YOUR TIMESTEP ARTICLE.
+When thinking about fixed time, it's important to clearly distinguish **frames** and **ticks**.
+
+To understand how to work with fixed time, we need to understand a little bit about how [`Time`] actually works under the hood.
+As the excellent docs on [`Time`] explain, there's actually *three* distinct types of time being measured:
+
+- real time: the actual wall time
+  - use this for things like UI animations that you don't want to be affected by pausing
+- virtual time: the "in-game time"
+  - if you're using fixed time, this is useful for graphical effects
+  - otherwise, this is used for all of your gameplay logic
+- fixed time
+  - advances by a [`Time::timestep`] every time [`FixedMain`] runs
+  - [`FixedMain`] will run repeatedly until it has caught up with the elapsed virtual time
+  - if not enough time has elapsed, [`FixedMain`] will not run at all for the frame
+  - please read the excellent docs on [`Fixed`] for more details!
+
+Simply requesting [`Time`] in your systems will get you the correct flavor 90% of the time: virtual time in the main schedule,
+and fixed time in the fixed main schedule.
+To request a specific variation, change the implicit generic in [`Time`] from `()`
+to [`Real`], [`Virtual`] or [`Fixed`].
+
+[`Time::timestep`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Time.html#method.timestep
+[`FixedMain`]: https://docs.rs/bevy/latest/bevy/app/struct.FixedMain.html
+[`Real`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Real.html
+[`Virtual`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Virtual.html
+[`Fixed`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Fixed.html
+
+## Interpolation and smooth movement
+
+## Timers and cooldowns
 
 ## Delayed actions
-
-## Delta time
-
-## Fixed time
-
-## Interpolation best practices

--- a/content/learn/book/the-game-loop/time-and-timers.md
+++ b/content/learn/book/the-game-loop/time-and-timers.md
@@ -169,9 +169,9 @@ games need to handle it.
 
 The core strategy is simple enough, but the devil is in the details:
 
-1. Create your own custom `GamePosition` type, holding the translation/rotation/scale information that your project needs.
-2. Modify and read this `GamePosition` type for all of your game logic and physics.
-3. Interpolate between the previous [`GlobalTransform`] and the `GamePosition`, based on the elapsed [`Fixed`] time.
+1. Create your own custom `GameTransform` type, holding the translation/rotation/scale information that your project needs.
+2. Modify and read this `GameTransform` type for all of your game logic and physics.
+3. Interpolate between the previous [`GlobalTransform`] and the `GameTransform`, based on the elapsed [`Fixed`] time.
    1. This should occur after the final fixed update for the frame has run, but before rendering occurs.
    2. You ultimately want to set the [`GlobalTransform`], but doing this correctly in the presence of hierarchies is hard.
    3. As a result, modifying the local [`Transform`] and relying on transform propagation can be the least bad solution.

--- a/content/learn/book/the-game-loop/time-and-timers.md
+++ b/content/learn/book/the-game-loop/time-and-timers.md
@@ -62,18 +62,43 @@ fn move_player(mut player_transform: Single<&mut Transform, With<Player>>, time:
 }
 ```
 
-This technique is commonly known as "delta time" among game devs, because physicists use "delta" to mean "a change in a quantity".
+This technique is commonly known as ["delta time"] among game devs, because physicists use "delta" to mean "a change in a quantity".
+
+["delta time"]: https://en.wikipedia.org/wiki/Delta_timing
 
 ## Pausing and time control
 
 With all of our time-dependent logic driven by the delta time,
 we can start playing tricks with the value of [`Time`] to implement features like pausing and slowing down the game.
+To do this, we need to change how we account for [`Virtual`] (in-game) time:
 
 ```rust
 use bevy::prelude::*;
 
+fn toggle_pause(mut time: ResMut<Time<Virtual>>) {
+    if time.is_paused() {
+        time.unpause();
+    } else {
+        time.pause();
+    }
+}
 
+#[derive(Event)]
+struct SetGameSpeed(f32);
+
+fn set_game_speed(mut time: ResMut<Time<Virtual>>, events: EventReader::<SetGameSpeed>){
+  if let Some(new_speed) = events.iter().last(){
+      time.set_relative_speed(new_speed.0);
+  }
+}
 ```
+
+If your systems uniformly rely on [`Time`], this will effect your entire game:
+halting, slowing or speeding up animations, movement, projectiles, physics and so on.
+Alternatively, [states] and [run conditions] can be used to skip systems while the game is paused.
+
+[states]: ../control-flow/states.md
+[run conditions]: ../control-flow/run-conditions.md
 
 ## Fixing your timestep
 

--- a/content/learn/book/the-game-loop/time-and-timers.md
+++ b/content/learn/book/the-game-loop/time-and-timers.md
@@ -175,8 +175,9 @@ Unfortunately, the devil is in the details:
 2. Modify and read this `GameTransform` type for all of your game logic and physics.
 3. Interpolate between the previous [`GlobalTransform`] and the `GameTransform`, based on the elapsed [`Fixed`] time.
    1. This should occur after the final fixed update for the frame has run, but before rendering occurs.
-   2. You ultimately want to set the [`GlobalTransform`], but doing this correctly in the presence of hierarchies is hard.
-   3. As a result, modifying the local [`Transform`] and relying on transform propagation can be the least bad solution.
+   2. The recommended location for this is [`RunFixedMainLoopSystems::AfterFixedMainLoop`] in the [`FixedMain`] schedule.
+   3. You ultimately want to set the [`GlobalTransform`], but doing this correctly in the presence of hierarchies is hard.
+   4. As a result, modifying the local [`Transform`] and relying on transform propagation can be the least bad solution.
 
 Bevy does not currently offer any built-in functionality for this form of interpolation,
 but open source [ecosystem crates] are available to use and learn from.
@@ -184,6 +185,7 @@ but open source [ecosystem crates] are available to use and learn from.
 [ecosystem crates]: https://bevy.org/assets/
 [`GlobalTransform`]: https://docs.rs/bevy/latest/bevy/prelude/struct.GlobalTransform.html
 [`Transform`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Transform.html
+[`RunFixedMainLoopSystems::AfterFixedMainLoop`]: https://docs.rs/bevy/latest/bevy/prelude/enum.RunFixedMainLoopSystems.html#variant.AfterFixedMainLoop
 
 ## Timers and cooldowns
 

--- a/content/learn/book/the-game-loop/time-and-timers.md
+++ b/content/learn/book/the-game-loop/time-and-timers.md
@@ -156,8 +156,33 @@ Please see our [timers and cooldowns] section below for the tools available to m
 [fix your timestep article]: https://gafferongames.com/post/fix_your_timestep/
 [`RunFixedMainLoop`]: https://dev-docs.bevy.org/bevy/app/struct.RunFixedMainLoop.html
 
-## Interpolation and smooth movement
+### Interpolation between ticks
 
-## Timers and cooldowns
+One key problem with using a fixed timestep is that your game logic (including physics!) will have an uneven
+number of updates between each frame.
+This will lead to visible jittering, lagginess and tiny speedups.
 
-## Delayed actions
+To account for this, we need to distinguish between the logical and rendered position (and rotation, and sometimes scale) of
+game objects.
+This is a common problem and pattern for multiplayer games, but using a fixed timestep means that even single player
+games need to handle it.
+
+The core strategy is simple enough, but the devil is in the details:
+
+1. Create your own custom `GamePosition` type, holding the translation/rotation/scale information that your project needs.
+2. Modify and read this `GamePosition` type for all of your game logic and physics.
+3. Interpolate/extrapolate between the previous [`GlobalTransform`] and the `GamePosition`, based on the elapsed [`Fixed`] time.
+   1. This should occur after the final fixed update for the frame has run, but before rendering occurs.
+   2. You ultimately want to set the [`GlobalTransform`], but doing this correctly in the presence of hierarchies is hard.
+   3. As a result, modifying the local [`Transform`] and relying on transform propagation can be the least bad solution.
+
+Bevy does not currently offer any built-in functionality for this form of interpolation,
+but open source [ecosystem crates] are available to use and learn from.
+
+[ecosystem crates]: https://bevy.org/assets/
+[`GlobalTransform`]: https://docs.rs/bevy/latest/bevy/prelude/struct.GlobalTransform.html
+[`Transform`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Transform.html
+
+### Smooth camera movement
+
+## Timers, cooldowns and delayed actions

--- a/content/learn/book/the-game-loop/time-and-timers.md
+++ b/content/learn/book/the-game-loop/time-and-timers.md
@@ -183,6 +183,133 @@ but open source [ecosystem crates] are available to use and learn from.
 [`GlobalTransform`]: https://docs.rs/bevy/latest/bevy/prelude/struct.GlobalTransform.html
 [`Transform`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Transform.html
 
-### Smooth camera movement
-
 ## Timers, cooldowns and delayed actions
+
+Delta time is great for physics and animations,
+but what if we want to implement other time-driven gameplay logic?
+We might want to automatically generate cookie clicks every 5 seconds,
+add a 3 second cooldown for our fireball ability,
+or cause an enemy to chase after the player a short time after seeing them.
+
+The simplest of these tools is the [`Timer`].
+Timers in Bevy hold two [`Duration`]s:
+one to store the duration of the timer, and one which stores how much time has been elapsed.
+
+Timers have no inherent logic: they do not update themselves,
+or have any inherent way to add something like an "on completion callbacks".
+They are also not components: you cannot simply add a [`Timer`] to an entity.
+
+Instead, timers are intended to be wrapped inside of simple components,
+which are updated and polled for completion by systems.
+
+```rust
+# use bevy::prelude::*;
+#
+#[derive(Resource)]
+struct Cookies(u64);
+
+#[derive(Component)]
+struct AutomaticCookieClick {
+  // This should be initialized as a repeating timer
+  // ensuring it automatically resets
+  timer: Timer,
+  resources_gained: u64,
+}
+
+fn automatically_click_cookies(
+  mut cookies: ResMut<Cookies>, 
+  time: Res<Time>, mut query: Query<&mut AutomaticCookieClick>
+){
+  let delta_time = time.delta();
+
+  for mut cookie_clicker in query.iter_mut(){
+    cookie_clicker.timer.tick(delta_time);
+    if cookie_clicker.timer.just_finished(){
+      cookies.0 += cookie_clicker.resources_gained;
+    }
+  }
+}
+```
+
+You could write your own cooldown mechanism in a similar way,
+by storing both a `duration` and a `remaining`.
+Tracking each ability as its own entity, using a custom [relationship] to link
+it to the entity with that ability would be an elegant solution,
+as it would allow you to update all cooldowns in a single system.
+
+```rust
+# use bevy::prelude::*;
+#
+#[derive(Relationship)]
+#[relationship(relationship_target = Abilities)]
+struct AbilityOf(Entity);
+
+#[derive(RelationshipTarget)]
+#[relationship_target(relationship = AbilityOf)]
+struct Abilities(Vec<Entity>)
+
+#[derive(Component)]
+struct Cooldown {
+  duration: Duration,
+  remaining: Duration,
+}
+
+impl Cooldown {
+  fn expend(&mut self) {
+    self.remaining = self.duration;
+  }
+  
+  fn is_ready(&self) -> bool {
+    self.remaining == Duration::ZERO;
+  }
+}
+
+fn update_cooldowns(time: Res<Time>, mut cooldowns: Query<&mut Cooldown>) {
+  let delta_time = time.delta();
+  for mut cooldown in cooldowns.iter_mut(){
+    // We never want our remaining time to become negative
+    cooldown.remaining.saturating_sub(delta_time);
+  }
+}
+```
+
+For something a bit more advanced,
+suppose we wanted to create a way to send commands that were only applied after a certain period of time.
+Let's create a [custom command] that wraps other commands by taking advantage of temporary entities and trait objects.
+
+FIXME: ensure this compiles and works
+
+```rust
+# use bevy::prelude;:*;
+#
+
+// We're reusing this type as both a Component and a Command
+#[derive(Component)]
+struct DelayedCommand {
+  delay_remaining: Duration,
+  // We're using dynamic dispatch rather than a generic here
+  // to allow us to update and handle any underlying command
+  // using only a single system
+  command: Box<dyn Command>,
+}
+
+impl DelayedCommand {
+  fn new(delay: Duration, command: impl Command) -> DelayedCommand {
+    DelayedCommand {
+      delay,
+      command: Box::new(command),
+    }
+  }
+}
+
+impl Command for DelayedCommand {
+  fn write(&self, world: &mut World) {
+    world.spawn()
+  }
+}
+```
+
+[`Timer`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Timer.html
+[`Duration`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Timer.html
+[relationship]: ../storing-data/relations.md
+[custom command]: ../control-flow/commdands.md

--- a/content/learn/book/the-game-loop/time-and-timers.md
+++ b/content/learn/book/the-game-loop/time-and-timers.md
@@ -153,8 +153,8 @@ Please see our [timers and cooldowns] section below for the tools available to m
 [`Real`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Real.html
 [`Virtual`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Virtual.html
 [`Fixed`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Fixed.html
-[fix your timestep article]: https://gafferongames.com/post/fix_your_timestep/
-[`RunFixedMainLoop`]: https://dev-docs.bevy.org/bevy/app/struct.RunFixedMainLoop.html
+[*Fix Your Timestep!*]: https://gafferongames.com/post/fix_your_timestep/
+[`RunFixedMainLoop`]: https://docs.rs/bevy/latest/bevy/app/struct.RunFixedMainLoop.html
 
 ### Interpolation between ticks
 
@@ -237,6 +237,7 @@ Tracking each ability as its own entity, using a custom [relationship] to link
 it to the entity with that ability would be an elegant solution,
 as it would allow you to update all cooldowns in a single system.
 
+```rust
 # use bevy::prelude::*;
 #
 #[derive(Relationship)]
@@ -270,6 +271,7 @@ fn update_cooldowns(time: Res<Time>, mut cooldowns: Query<&mut Cooldown>) {
         cooldown.remaining.saturating_sub(delta_time);
     }
 }
+```
 
 [`Timer`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Timer.html
 [`Duration`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Timer.html

--- a/content/learn/book/the-game-loop/time-and-timers.md
+++ b/content/learn/book/the-game-loop/time-and-timers.md
@@ -167,7 +167,9 @@ game objects.
 This is a common problem and pattern for multiplayer games, but using a fixed timestep means that even single player
 games need to handle it.
 
-The core strategy is simple enough, but the devil is in the details:
+The core strategy is simple enough: you need to keep track of "logical" and "visual" positions
+separately, and smooth out the visual position while tracking the logical position when updated.
+Unfortunately, the devil is in the details:
 
 1. Create your own custom `GameTransform` type, holding the translation/rotation/scale information that your project needs.
 2. Modify and read this `GameTransform` type for all of your game logic and physics.

--- a/content/learn/book/the-game-loop/time-and-timers.md
+++ b/content/learn/book/the-game-loop/time-and-timers.md
@@ -183,13 +183,12 @@ but open source [ecosystem crates] are available to use and learn from.
 [`GlobalTransform`]: https://docs.rs/bevy/latest/bevy/prelude/struct.GlobalTransform.html
 [`Transform`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Transform.html
 
-## Timers, cooldowns and delayed actions
+## Timers and cooldowns
 
 Delta time is great for physics and animations,
 but what if we want to implement other time-driven gameplay logic?
-We might want to automatically generate cookie clicks every 5 seconds,
-add a 3 second cooldown for our fireball ability,
-or cause an enemy to chase after the player a short time after seeing them.
+We might want to automatically generate cookie clicks every 5 seconds
+or add a 3 second cooldown for our fireball ability.
 
 The simplest of these tools is the [`Timer`].
 Timers in Bevy hold two [`Duration`]s:
@@ -273,43 +272,6 @@ fn update_cooldowns(time: Res<Time>, mut cooldowns: Query<&mut Cooldown>) {
 }
 ```
 
-For something a bit more advanced,
-suppose we wanted to create a way to send commands that were only applied after a certain period of time.
-Let's create a [custom command] that wraps other commands by taking advantage of temporary entities and trait objects.
-
-FIXME: ensure this compiles and works
-
-```rust
-# use bevy::prelude;:*;
-#
-
-// We're reusing this type as both a Component and a Command
-#[derive(Component)]
-struct DelayedCommand {
-  delay_remaining: Duration,
-  // We're using dynamic dispatch rather than a generic here
-  // to allow us to update and handle any underlying command
-  // using only a single system
-  command: Box<dyn Command>,
-}
-
-impl DelayedCommand {
-  fn new(delay: Duration, command: impl Command) -> DelayedCommand {
-    DelayedCommand {
-      delay,
-      command: Box::new(command),
-    }
-  }
-}
-
-impl Command for DelayedCommand {
-  fn write(&self, world: &mut World) {
-    world.spawn()
-  }
-}
-```
-
 [`Timer`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Timer.html
 [`Duration`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Timer.html
 [relationship]: ../storing-data/relations.md
-[custom command]: ../control-flow/commdands.md

--- a/content/learn/book/the-game-loop/time-and-timers.md
+++ b/content/learn/book/the-game-loop/time-and-timers.md
@@ -52,7 +52,7 @@ our player is moving at an unsteady 20-30 units per second. Oh no!
 Instead, we can compensate for this effect by fixing our *speed* (or other rates of change per second),
 and then multiplying by the elapsed time.
 
-```rust, hide_lines=1-4
+```rust, hide_lines=1-4,hide_lines=1-5
 # use bevy::prelude::*;
 # 
 # #[derive(Component)]
@@ -215,7 +215,7 @@ They are also not components: you cannot simply add a [`Timer`] to an entity.
 Instead, timers are intended to be wrapped inside of simple components,
 which are updated and polled for completion by systems.
 
-```rust
+```rust,hide_lines=1-2
 # use bevy::prelude::*;
 #
 #[derive(Resource)]
@@ -251,7 +251,7 @@ Tracking each ability as its own entity, using a custom [relationship] to link
 it to the entity with that ability would be an elegant solution,
 as it would allow you to update all cooldowns in a single system.
 
-```rust
+```rust,hide_lines=1-2
 # use bevy::prelude::*;
 #
 #[derive(Relationship)]
@@ -289,7 +289,7 @@ fn update_cooldowns(time: Res<Time>, mut cooldowns: Query<&mut Cooldown>) {
 
 To trigger a system periodically, the `on_timer` run condition can be very convenient.
 
-```rust
+```rust,hide_lines=1-7
 # use bevy::prelude::*;
 # #[derive(Component)]
 # struct Building;

--- a/content/learn/book/the-game-loop/time-and-timers.md
+++ b/content/learn/book/the-game-loop/time-and-timers.md
@@ -12,7 +12,8 @@ The [`Time`] resource in Bevy is the source of truth
 for the "current in-game time".
 Unlike [`Instant::now()`], the [`Time`] is fixed for the entire frame,
 rather than reflecting the precise wall clock time at the time of system evaluation.
-This value is set at the start of the frame based on the time supplied by the renderer,
+Time is derived from a clock whose value is fixed for the entire frame,
+set at the start of the frame based on the time supplied by the renderer
 during the [`TimeSystem`] system set in the [`First`] schedule.
 
 This is helpful for performance reasons, but more critically,

--- a/content/learn/book/the-game-loop/time-and-timers.md
+++ b/content/learn/book/the-game-loop/time-and-timers.md
@@ -34,6 +34,9 @@ use bevy::prelude::*;
 struct Player;
 
 fn move_player(mut player_transform: Single<&mut Transform, With<Player>>){
+    // With Bevy's default camera setup and a 60 fps framerate, 
+    // this will move the player 60 pixels per second in 2D (reasonable),
+    // or 60 meters per second in 3D (wheee!)
     const PLAYER_MOVEMENT: f32 = 1.;
     
     player_transform.translation.x += PLAYER_MOVEMENT;

--- a/content/learn/book/the-game-loop/time-and-timers.md
+++ b/content/learn/book/the-game-loop/time-and-timers.md
@@ -182,10 +182,14 @@ Unfortunately, the devil is in the details:
 Bevy does not currently offer any built-in functionality for this form of interpolation,
 but open source [ecosystem crates] are available to use and learn from.
 
+Note that smooth yet responsive camera interpolation is particularly tricky!
+See the [`physics_in_fixed_timestep`] example for a detailed breakdown of how to do this correctly.
+
 [ecosystem crates]: https://bevy.org/assets/
 [`GlobalTransform`]: https://docs.rs/bevy/latest/bevy/prelude/struct.GlobalTransform.html
 [`Transform`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Transform.html
 [`RunFixedMainLoopSystems::AfterFixedMainLoop`]: https://docs.rs/bevy/latest/bevy/prelude/enum.RunFixedMainLoopSystems.html#variant.AfterFixedMainLoop
+[`physics_in_fixed_timestep`]: https://github.com/bevyengine/bevy/blob/latest/examples/movement/physics_in_fixed_timestep.rs
 
 ## Timers and cooldowns
 


### PR DESCRIPTION
Some notes for reviewers:

- I've opted not to try and explain how to do delayed actions, waiting for a fix via https://github.com/bevyengine/bevy/issues/15129
- the lack of first-party interpolation seriously sucks (see https://github.com/bevyengine/bevy/issues/1259), but it's important to call out the problem. I've opted to lay out the broad shape of the solution, and hint "go look for `bevy_transform_interpolation`" without drawing controversy by straight-up linking it