### PR TITLE
Add book page on queries

### DIFF
--- a/content/learn/book/storing-data/disabling-entities.md
+++ b/content/learn/book/storing-data/disabling-entities.md
@@ -1,7 +1,0 @@
-+++
-title = "Disabling entities"
-insert_anchor_links = "right"
-[extra]
-weight = 6
-status = 'hidden'
-+++

--- a/content/learn/book/storing-data/queries.md
+++ b/content/learn/book/storing-data/queries.md
@@ -96,11 +96,54 @@ it's helpful to know that [`Changed`] and [`Added`] are both query filters.
 [`Access`]: https://dev-docs.bevy.org/bevy/ecs/query/struct.Access.html
 [B0002]: https://bevy.org/learn/errors/b0002/
 
-## Query::get
+## Accessing data on specific entities
 
-ENTITY QUERY DATA
+While many systems will operate by simply iterating over all of the entities in a query,
+it is often helpful to look up (and possibly mutate) the data of a specific entity.
 
-QUERY GET
+This is fast and easy to do, using [`Query::get`] and its mutable sibling [`Query::get_mut`].
+These respect the query data and query filters of the query they are called on,
+making them an extremely powerful tool.
+
+Of course, this begs the question: where do we get the [`Entity`] identifier.
+The simplest way to get this information is to record it when spawning an entity.
+
+```rust
+# use bevy::prelude::*;
+
+#[derive(Resource)]
+struct SelectedEntity(Entity);
+
+fn spawn_selected_entity(mut commands: Commands, mut selected_entity: ResMut<SelectedEntity>){
+    // .id() records the allocated identifier of the entity that is about to be spawned
+    let special_entity_id = commands.spawn(Name::new("Throckmorton")).id();
+    special_entity.0 = special_entity_id;
+}
+
+fn print_selected_entity_name(query: Query<&Name>, special_entity: Res<SelectedEntity>){
+    if let Ok(name) = query.get(special_entity.0){
+        info!("{name} is selected.");
+    } else {
+        warn!("Selected entity {} has been despawned, or does not have a Name component", special_entity.0);
+    }
+}
+```
+
+As the example shows, you can store the retrieved `Entity` identifiers inside of components or resources,
+creating flexible connections between entities and lookup tables.
+Inside of Bevy itself, this pattern is combined with [hooks] to make it more robust
+and exposed to users as [relations].
+
+The other common way to get an [`Entity`] is to take advantage of its [`QueryData`] implementation,
+allowing you to determine the identifier for entities in queries that you are iterating over.
+
+```rust
+// TODO: fill this in with a nice self-contained example,
+// which ideally uses Query::get
+```
+
+[hooks]: ../control-flow/hooks.md
+[relations]: ./relations.md
 
 ## Working with singleton entities
 
@@ -111,12 +154,6 @@ CONTRAST TO SINGLE SYSTEM PARAM
 ## Accessing multiple items from the same query
 
 QUERY::GET_MANY
-
-## Multiple queries in a single system
-
-MUTABILITY RULES.
-AVOID WITH WITHOUT
-PARAMSET
 
 ## Disabling entities
 

--- a/content/learn/book/storing-data/queries.md
+++ b/content/learn/book/storing-data/queries.md
@@ -6,10 +6,55 @@ weight = 4
 status = 'hidden'
 +++
 
-Queries let you pull data from the world.
+Queries are your primary tool for interacting with the Bevy world,
+allowing you to carefully and efficiently read and write component data from matching entities.
 
-- Query::iter
-- Query::single
-- Query::get
-- Multiple items in queries
-- Query filters
+ANATOMY OF TRAITS
+
+COMBINE AS TUPLES
+
+LOOK AT DOCS FOR IMPLEMENTORS
+
+## Query::get
+
+ENTITY QUERY DATA
+
+QUERY GET
+
+## Working with singleton entities
+
+QUERY::SINGLE
+
+CONTRAST TO SINGLE SYSTEM PARAM
+
+## Accessing multiple items from the same query
+
+QUERY::GET_MANY
+
+## Multiple queries in a single system
+
+MUTABILITY RULES.
+AVOID WITH WITHOUT
+PARAMSET
+
+## Disabling entities
+
+DEFAULT QUERY FILTERS
+
+DISABLED COMPONENT
+
+## Working with complex queries
+
+DERIVE QUERYDATA / QUERYFILTER
+
+USE SYSTEMPARAM DERIVE INSTEAD
+
+CONTRAST TO TYPE ALIASES
+
+## Advanced query tools
+
+- change detection
+- Option
+- Has and AnyOf
+- Or
+- EntityMut, EntityRef, FilteredEntityMut, FilteredEntityRef, EntityMutExcept, EntityRefExcept

--- a/content/learn/book/storing-data/queries.md
+++ b/content/learn/book/storing-data/queries.md
@@ -9,11 +9,56 @@ status = 'hidden'
 Queries are your primary tool for interacting with the Bevy world,
 allowing you to carefully and efficiently read and write component data from matching entities.
 
-ANATOMY OF TRAITS
+## Anatomy of a query
 
-COMBINE AS TUPLES
+To understand how queries work in a bit more detail, let's take a look at the anatomy of a [`Query`].
+The [`Query`] type has two generics: `D`, which must implement the [`QueryData`] trait,
+and `F`, which must implement the [`QueryFilter`] trait.
+`D` describes "which data should I access", while `F` describes "how should I restrict the returned entities".
+Only entities which match *all* of the terms in `D` *and* `F` will be included in your query.
 
-LOOK AT DOCS FOR IMPLEMENTORS
+When we write `Query<&Life, With<Player>>`, we're supplying these generics, setting `D` to `&Life` and `F` to `With<Player>`,
+separated by a comma.
+Bevy uses the information in the [`QueryData`] and [`QueryFilter`] traits,
+along with the [`WorldQuery`] supertrait, in order to know how to lookup components of
+the correct type in the world and supply them to your system via [dependency injection].
+
+If we don't want to fetch any data, or perform any filtering,
+we can use `()`, Rust's "unit type" in the place of `D` or `F`.
+The `F: QueryFilter` argument defaults to `()`, allowing us to conveniently write
+`Query<&Life>`, rather than spelling out that we don't want to filter via `Query<&Life, ()>`.
+
+To access more than one component at once, or filter by multiple predicates at the same time,
+we can combine [`QueryData`] or [`QueryFilter`] types by putting them inside of a [tuple],
+wrapping them with parentheses.
+
+If we have two components, `Life` and `Mana`, we can fetch all entities with the `Life` component
+by requesting `Query<&Life>` (if we want the data), or `Query<(), With<Life>>` (if we don't need the data).
+We can do the same thing for `Mana`, and we could add two queries in the same system, one for `Life`, and one for `Mana`,
+if we wanted to examine these two lists side by side.
+
+But to fetch entities with *both* the life and mana components,
+we would need:
+
+- `Query<(&Life, &Mana)>`, giving us access to the data of both components
+- `Query<&Life, With<Mana>>` or `Query<&Mana, With<Life>>`, accessing the data of one and filtering on the presence of the other
+- `Query<(), (With<Life>, With<Mana>)>` to filter on both components
+
+These tuples can be extended to multiple elements: `Query<(&Life, &Mana, &Energy)>` and so on works just fine!
+To swap from the default "and" logic, where all of the components must be present, to "or" logic,
+where any of the components can be present, you can use:
+
+- `Query<Option<&Life>>`, for an [`Option`] that contains the component value if present and nothing if it is absent
+- `Query<AnyOf<(&Life, &Mana)>>` which acts as a wrapper for multiple `Option` `QueryData` types
+- `Query<Has<Life>>`, which contains `true` if the component is present, and `false` if the component is absent
+- `Query<(), Or<(With<Life>, With<Mana>)>>`, which combines query filters via an `Or` relationship
+
+As you can see, Bevy's type-driven querying can be quite expressive and elaborate!
+Don't worry though: most of your queries will be quite simple, requesting a few pieces of data with some filter.
+
+[dependency injection]: https://en.wikipedia.org/wiki/Dependency_injection
+
+## Mutable and immutable query data
 
 ## Query::get
 
@@ -54,7 +99,7 @@ CONTRAST TO TYPE ALIASES
 ## Advanced query tools
 
 - change detection
-- Option
-- Has and AnyOf
+- Option, Has and AnyOf
 - Or
+- Mut and Ref
 - EntityMut, EntityRef, FilteredEntityMut, FilteredEntityRef, EntityMutExcept, EntityRefExcept

--- a/content/learn/book/storing-data/queries.md
+++ b/content/learn/book/storing-data/queries.md
@@ -238,10 +238,6 @@ adding an overridable filter to each query.
 You can even add your own disabling components,
 which can be helpful if you want to assign a specific meaning for *why* entities are disabled.
 
-## Accessing all data from a single entity via queries
-
-- EntityMut, EntityRef, FilteredEntityMut, FilteredEntityRef, EntityMutExcept, EntityRefExcept
-
 ## Working with complex queries
 
 In real projects, queries can get quite complex!

--- a/content/learn/book/storing-data/queries.md
+++ b/content/learn/book/storing-data/queries.md
@@ -238,16 +238,32 @@ adding an overridable filter to each query.
 You can even add your own disabling components,
 which can be helpful if you want to assign a specific meaning for *why* entities are disabled.
 
-## Working with complex queries
-
-DERIVE QUERYDATA / QUERYFILTER
-
-USE SYSTEMPARAM DERIVE INSTEAD
-
-CONTRAST TO TYPE ALIASES
-
 ## Accessing all data from a single entity via queries
 
-- change detection
-- Mut and Ref
 - EntityMut, EntityRef, FilteredEntityMut, FilteredEntityRef, EntityMutExcept, EntityRefExcept
+
+## Working with complex queries
+
+In real projects, queries can get quite complex!
+As a result, Bevy users tend to disable [`clippy`'s `type_complexity` lint] altogether.
+But even without red squiggles, working with complex types can be frustrating and hard to reuse.
+
+Bevy offers three good tools for this, each with their own niche:
+
+- [type aliases]
+  - reduces typing and cognitive complexity
+  - quick and easy to define
+  - simple and flexible
+  - no added functionality
+- custom [`QueryData`] / [`QueryFilter`] types
+  - derive macro makes this easy!
+  - define custom methods on the struct or the generated item type
+  - bypass the standard 16-element limit of terms without nesting tuples
+  - more composable than a [`SystemParam`]
+- custom [`SystemParam`] types
+  - derive macro is great for simple cases
+  - combine data from multiple queries, or queries with other resources
+  - custom methods can be used to encapsulate complex logic
+
+[`clippy`'s `type_complexity` lint]: https://rust-lang.github.io/rust-clippy/master/index.html#type_complexity
+[type aliases]: https://doc.rust-lang.org/reference/items/type-aliases.html

--- a/content/learn/book/storing-data/queries.md
+++ b/content/learn/book/storing-data/queries.md
@@ -60,6 +60,42 @@ Don't worry though: most of your queries will be quite simple, requesting a few 
 
 ## Mutable and immutable query data
 
+The most useful way to modify a query is to change whether we're requesting the data "immutably" (read-only) or "mutably" (read-write).
+We can do that by changing `Query<&Life>` to `Query<&mut Life>` (pronounced "ref Life" and "ref mute Life" respectively).
+The ampersand is Rust's read-only [reference] indicator,
+while `&mut` is for mutable references, making it easy to remember the syntax once you're familiar with Rust.
+
+{% callout(type="info") %}
+
+You can include multiple queries within a single system, allowing you to access component data in more flexible ways.
+But if Bevy is handing out mutable references to component data in safe Rust, how does it ensure that users don't
+invoke undefined behavior due to the forbidden [mutable aliasing]?
+
+Bevy protects against this by examining the [`Access`] of each of the system params in each systems,
+and then panicking if they could conflict.
+If you run into this, you'll be pointed to the [B0002] error page,
+which has advice on how to fix and avoid this problem.
+
+{% end %}
+
+By changing our [`QueryData`] terms in this way, we change the type of [query item] returned,
+changing the type of object we get when we iterate over our queries.
+`Query<&Life>` corresponds to a `&Life`, giving us direct read-only access to data inside of our world.
+However, you may have noticed that `Query<&mut Life>` returns a [`Mut<Life>`]. Why?
+
+This [smart pointer] wraps a `&mut T` and allows Bevy to automatically detect changes.
+While this is talked about in more depth in the chapter on [change detection],
+it's helpful to know that [`Changed`] and [`Added`] are both query filters.
+
+[reference]: https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html
+[query item]: https://dev-docs.bevy.org/bevy/ecs/query/trait.QueryData.html#associatedtype.Item
+[`Mut<Life>`]: https://dev-docs.bevy.org/bevy/ecs/change_detection/struct.Mut.html
+[smart pointer]: https://doc.rust-lang.org/book/ch15-00-smart-pointers.html
+[change detection]: ../control-flow/change-detection.md
+[mutable aliasing]: https://doc.rust-lang.org/rust-by-example/scope/borrow/alias.html
+[`Access`]: https://dev-docs.bevy.org/bevy/ecs/query/struct.Access.html
+[B0002]: https://bevy.org/learn/errors/b0002/
+
 ## Query::get
 
 ENTITY QUERY DATA

--- a/content/learn/book/storing-data/queries.md
+++ b/content/learn/book/storing-data/queries.md
@@ -138,8 +138,17 @@ The other common way to get an [`Entity`] is to take advantage of its [`QueryDat
 allowing you to determine the identifier for entities in queries that you are iterating over.
 
 ```rust
-// TODO: fill this in with a nice self-contained example,
-// which ideally uses Query::get
+# use bevy::prelude::*;
+#
+#[derive(Component)]
+struct Enemy;
+
+// Note: no `&` for Entity as a QueryData!
+fn despawn_all_enemies(enemies: Query<Entity, With<Enemy>>, mut commands: Commands){
+    for enemy_entity in enemies.iter(){
+        commands.entity(enemy_entity).despawn();
+    }
+}
 ```
 
 [hooks]: ../control-flow/hooks.md

--- a/content/learn/book/storing-data/queries.md
+++ b/content/learn/book/storing-data/queries.md
@@ -213,13 +213,30 @@ Similarly, see the [resources] chapter of this book for a discussion on the choi
 
 ## Accessing multiple items from the same query
 
-QUERY::GET_MANY
+By contrast, you may have a query and need to access multiple items from it at once.
+The obvious method is to simply call [`Query::get`] multiple times on it.
+While this works for read-only access,
+it falls apart when using [`Query::get_mut`] as the borrow checker complains at you.
+
+To help with this, Bevy offers two particularly helpful methods on [`Query`]:
+
+- [`Query::get_multiple_mut`]: fetch multiple entities by their [`Entity`] ids, which must be unique. Helpful for things like collisions.
+- [`Query::iter_combinations_mut`]: iterate over all pairs, triples or so on of query items. Great for gravity simulations!
 
 ## Disabling entities
 
-DEFAULT QUERY FILTERS
+From time-to-time, you might want to hide or disable an entity without despawning it.
+While simply setting its [`Visibility`] can work well,
+it won't stop any gameplay effects.
 
-DISABLED COMPONENT
+Bevy offers a [`Disabled`] component, which works by hiding entities with this component from
+queries unless the [`Disabled`] component is explicitly permitted,
+such as via [`With`], [`Has`] or [`Allows`].
+
+Under the hood, this acts as a [default query filter],
+adding an overridable filter to each query.
+You can even add your own disabling components,
+which can be helpful if you want to assign a specific meaning for *why* entities are disabled.
 
 ## Working with complex queries
 

--- a/content/learn/book/storing-data/queries.md
+++ b/content/learn/book/storing-data/queries.md
@@ -96,10 +96,8 @@ USE SYSTEMPARAM DERIVE INSTEAD
 
 CONTRAST TO TYPE ALIASES
 
-## Advanced query tools
+## Accessing all data from a single entity via queries
 
 - change detection
-- Option, Has and AnyOf
-- Or
 - Mut and Ref
 - EntityMut, EntityRef, FilteredEntityMut, FilteredEntityRef, EntityMutExcept, EntityRefExcept


### PR DESCRIPTION
Queries! Essential, but surprisingly complex.

Notes:
- I've stuck default query filters in here because I didn't think it warranted a whole page, and it can help explain mysterious query behavior.
- change detection gets its own page, but it gets a breadcrumb here because it's important
- I've kept the final section on tools for complex queries very short, because the linked docs are good and frankly they're not helpful for beginners
- I've completely omitted a section on EntityMut / EntitryRef and their filtered and except variants. I don't have a good example of why they're useful, and I don't have a good answer for why both filtered and except variants exist, other than "performance man"
- I've avoided the details of B0002 workarounds, especially ParamSet, because frankly you should only reach for this after hitting the error, which has excellent advice
