### PR TITLE
Add a note on how Bevy uses milestones to the Contributing Guide

### DIFF
--- a/content/learn/contribute/reference/triage.md
+++ b/content/learn/contribute/reference/triage.md
@@ -148,6 +148,8 @@ By contrast, major version milestones serve three purposes:
 
 At the start of each release cycle, the milestone will tend towards the first two use cases.
 As we near the end, the milestone is gradually trimmed down to only the most critical problems that would justify delaying a release.
+It's common to move issues and PRs that are near completion or still helpful to implement
+into the milestone for the major release after the current milestone.
 
 Members of the triage team should follow these guidelines for how we use milestones,
 but are encouraged to add, remove and modify milestones for various work, based on their own subjective judgement


### PR DESCRIPTION
I'm tackling this for 0.17, and realized we don't actually clear explain how milestones work (and especially how triage team members can help) in our Contributing Guide. None of this is new policy: it simply codifies existing practices.