### PR TITLE
Add the Bevy Org's AI Policy

### DIFF
--- a/content/learn/contribute/policies/_index.md
+++ b/content/learn/contribute/policies/_index.md
@@ -1,0 +1,7 @@
++++
+title = "Policies"
+template = "docs.html"
+redirect_to = "/learn/contribute/policies/ai"
+[extra]
+weight = 4
++++

--- a/content/learn/contribute/policies/ai.md
+++ b/content/learn/contribute/policies/ai.md
@@ -1,0 +1,79 @@
++++
+title = "AI Policy"
+insert_anchor_links = "right"
+[extra]
+weight = 2
++++
+
+In recent times, there have been a growing number of contributions that are fully or 
+partially produced by generative AI (e.g. LLMs and friends) which exhibit 
+characteristics that result in undue extra work for other contributors and maintainers. 
+While we've seen PRs and issues with these characteristics produced entirely by 
+humans, generative AI tools have significantly lowered the level of effort required to produce 
+"plausibly-worthwhile" contributions that are otherwise entirely unmergable or
+incorrectly report bugs, and so have become a major source of burdensome PRs and
+issues.
+
+Whether AI generated code are copyrightable works is also a hot-button legal topic that is 
+still being openly debated and litigated. How this impacts the legal aspects of maintaining
+a FOSS project is currently a unresolved question.
+
+This policy is established as a response targeted at the problem of an 
+increasing frequency of burdensome PRs/issues and to address the potential legal issues
+currently surrounding the intersection of AI generated code and the FOSS contribution model.
+
+## AI Generated Communications
+The unsolicited use of automated systems to communicate issues, bugs, or security vulnerabilites
+about Bevy Organization projects under the guise of a human is considered unacceptable
+and a Code of Conduct violation. Any individual contributor, operator of automated systems,
+or company they may represent may be barred from future contributions and banned from regular
+communication channels if these communications were found to be submitted in bad faith.
+
+This policy applies to all regular channels of communication used by members of the 
+Bevy Organization, including but not limited to GitHub Issues, GitHub Pull Requests, Discord, 
+other social media platforms, etc.
+
+We recognize that English may not be the primarily language for all contributors and that 
+machine translation is an indispensable tool for proper collaboration, and thus not subject to
+the above policy, though it is recommended by the community to use non-LLM machine translation
+options, as they tend to be less verbose while still getting the point across.
+
+## Copyrightable AI Generated Contributions
+At the current time of writing (August 11th, 2025), the US Copyright Office has
+[stated publicly][us-copyright-office-response] that "human authorship is a
+pre-requisite to copyright protection". A [more recent report][us-copyright-office-report] 
+from the same institution shows a much more contested legal space, both within the US and 
+internationally. In the case that AI generated works are not copyrightable, those same works 
+cannot be licensed to others, and thus AI-generated code and assets would not legally be 
+licensed under MIT or Apache.
+
+Erring on the side of caution in light of a openly debated legal topic, 
+all[^1] forms of AI-generated contributions cannot be merged into repos maintained 
+by the Bevy Organization. This includes both code and non-code game assets (e.g. textures,
+audio, etc).
+
+Any triage team member suspecting a pull request to be made primarily through the use of 
+LLMs or other generative tools should mark the PR as `S-Nominated-to-Close`, upon which a 
+maintainer can then review the PR for closure. To help identify these cases, 
+pull requests subject to this policy have characteristics such as (but not limited to): 
+
+ * Needlessly or overly verbose descriptions or responses.
+ * Not internally coherent or even self-contradictory.
+ * Demonstrates misunderstanding of important aspects of what the code is doing 
+   or the purpose of the change.
+
+Any contributor, operator of automated systems, or company they may represent found to
+have repeatedly submitted contributions with majority AI-generated code or assets may be 
+subject to:
+
+ * Blanket rejection of all future contributions to Bevy Organization projects.
+ * Retroactive removal of any potentially suspect AI-generated code and asset contributions.
+ * Further Code of Conduct actions if these contributions were found to be submitted in bad faith.
+
+This policy may be revisited when the legal debate has settled.
+
+[us-copyright-office-response]: https://www.copyright.gov/rulings-filings/review-board/docs/a-recent-entrance-to-paradise.pdf
+[us-copyright-office-report]: https://www.copyright.gov/ai/Copyright-and-Artificial-Intelligence-Part-2-Copyrightability-Report.pdf
+
+[^1]: Trivial LLM generated content such as variable renames or autocompleted function calls, often branded "predictions" or "suggestions", that is indistinguishable from traditional methods such as a regex search/replace or an LSP autocompletion is by definition not detectable and can be treated like other regular IDE tools such as Intellisense. 
+This is does not include cases where the prediction generates things like entire function blocks. 

--- a/content/learn/contribute/reference/_index.md
+++ b/content/learn/contribute/reference/_index.md
@@ -3,5 +3,5 @@ title = "Reference"
 template = "docs.html"
 redirect_to = "/learn/contribute/reference/triage"
 [extra]
-weight = 4
+weight = 5
 +++

--- a/content/learn/contribute/reference/triage.md
+++ b/content/learn/contribute/reference/triage.md
@@ -91,6 +91,10 @@ Some reasons to apply `D-Trivial` include:
 2. Moving a file from one location to another.
 3. Small changes to documentation or error messages.
 
+Some reasons to apply `S-Nominated-to-Close`  include:
+
+ 1. The PR shows inconsistencies and verbosity to suggest that the code was [AI generated][ai-policy].
+
 Remember that difficulty labels are for expertise required to either solve an issue or review a pull request. By labeling an issue as `D-Trivial`, you are marking it as a good first issue for new contributors to the Bevy project.
 
 ## Closing PRs and Issues
@@ -118,6 +122,7 @@ There are several paths for PRs to be closed:
 6. In the case of PRs where some members of the community, other than the author, are in favor, and some are opposed, any two relevant SMEs or Maintainers may act in concert to close the PR.
 7. For a PR that has been sitting for a while and became bitrotten, check with the original author if they intend to continue working on it. If not, or without a response, the PR can be labeled with `S-Adopt-Me`, and closed. Tracking adoption progress will happen in a linked issue.
 8. Inactive `X-Controversial` can be closed if relevant SMEs or Maintainers have decided there's no more interest for it. If it's still interesting and controversial, a decision must be made.
+9. Majority AI-Generated PRs cannot be merged as per the Bevy org's [AI policy][ai-policy]. Please mark these PRs as `S-Nominated-to-Close` for maintainers to make a final decision.
 
 When closing a PR, check if it has an issue linked. If it does not, you should strongly consider creating an issue and linking the now-closed PR to help make sure the previous work can be discovered and credited.
 
@@ -167,3 +172,4 @@ Members of the Triage Team within the Bevy organization have permissions to labe
 If that applies to you, then feel free to ask a Maintainer on [Discord] or email <support@bevy.org>. Everyone is welcome to do this. We generally accept membership requests, so don't hesitate if you are interested!
 
 [Discord]: https://discord.gg/bevy
+[ai-policy]: /learn/contribute/policies/ai


### PR DESCRIPTION
[RENDERED](https://hackmd.io/@bevy/ai_policy/view)

Added a new Policies section to the Contributing Guide and incorporated the above draft under that section. The triage reference has also been updated to make guidance for `S-Nominated-to-Close` aligned with the new AI policy.