### PR TITLE
Add blur for assets with nsfw=true

### DIFF
--- a/generate-assets/src/bin/generate.rs
+++ b/generate-assets/src/bin/generate.rs
@@ -127,6 +127,7 @@ struct FrontMatterAssetExtra {
     image: Option<String>,
     licenses: Option<Vec<String>>,
     bevy_versions: Option<Vec<String>>,
+    nsfw: Option<bool>,
 }
 
 impl From<&Asset> for FrontMatterAsset {
@@ -140,6 +141,7 @@ impl From<&Asset> for FrontMatterAsset {
                 image: asset.image.clone(),
                 licenses: asset.licenses.clone(),
                 bevy_versions: asset.bevy_versions.clone(),
+                nsfw: asset.nsfw,
             },
         }
     }

--- a/generate-assets/src/lib.rs
+++ b/generate-assets/src/lib.rs
@@ -28,6 +28,7 @@ pub struct Asset {
     pub crate_name: Option<String>,
     pub licenses: Option<Vec<String>>,
     pub bevy_versions: Option<Vec<String>>,
+    pub nsfw: Option<bool>,
 
     // this field is not read from the toml file
     #[serde(skip)]
@@ -204,6 +205,10 @@ fn visit_dirs(
 
             let mut asset: Asset = toml::from_str(&fs::read_to_string(&path).unwrap())?;
             asset.original_path = Some(path);
+
+            if asset.name == "Lost Oppai" {
+                println!("{:?}", asset);
+            }
 
             if let Err(err) = get_extra_metadata(&mut asset, metadata_source) {
                 // We don't want to stop execution here

--- a/generate-assets/src/lib.rs
+++ b/generate-assets/src/lib.rs
@@ -206,10 +206,6 @@ fn visit_dirs(
             let mut asset: Asset = toml::from_str(&fs::read_to_string(&path).unwrap())?;
             asset.original_path = Some(path);
 
-            if asset.name == "Lost Oppai" {
-                println!("{:?}", asset);
-            }
-
             if let Err(err) = get_extra_metadata(&mut asset, metadata_source) {
                 // We don't want to stop execution here
                 eprintln!("Failed to get metadata for {}", asset.name);

--- a/sass/components/_asset-card.scss
+++ b/sass/components/_asset-card.scss
@@ -34,6 +34,14 @@ $asset-card-padding: 0.4rem;
     }
   }
 
+  &__blur-overlay {
+    backdrop-filter: blur(16px);
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    top: 0;
+  }
+
   &__title {
     position: absolute;
     width: 100%;

--- a/templates/macros/assets.html
+++ b/templates/macros/assets.html
@@ -14,7 +14,7 @@
   <div id="{{ post.title | slugify }}">
     <a class="asset-card" href="{{ post.extra.link }}">
       <div class="asset-card__banner">
-        {% if post.extra.nsfw %}<div class="asset-card__blur-overlay"></div>{%endif %}
+        {% if post.extra.nsfw %}<div class="asset-card__blur-overlay"></div>{% endif %}
         <div class="asset-card__title">{{ post.title }}</div>
         {% if post.extra.image %}
           <img src="{{ image_macros::resize_image(path=post.extra.image, width=370, height=370) }}"

--- a/templates/macros/assets.html
+++ b/templates/macros/assets.html
@@ -14,6 +14,7 @@
   <div id="{{ post.title | slugify }}">
     <a class="asset-card" href="{{ post.extra.link }}">
       <div class="asset-card__banner">
+        {% if post.extra.nsfw %}<div class="asset-card__blur-overlay"></div>{%endif %}
         <div class="asset-card__title">{{ post.title }}</div>
         {% if post.extra.image %}
           <img src="{{ image_macros::resize_image(path=post.extra.image, width=370, height=370) }}"


### PR DESCRIPTION
## Objective

Related to https://github.com/bevyengine/bevy-assets/pull/552.

See also, related [discord discussion](https://discord.com/channels/691052431525675048/695741366520512563/1410673856561021038).

This is super basic, without any way of disabling the blur.

## Preview

<img width="622" height="572" alt="Screenshot 2025-08-28 at 10 49 23 AM" src="https://github.com/user-attachments/assets/2fefc2c8-1056-45c6-9d0a-7bca1e2aa683" />

## Testing

Tested locally in FF/Chrome on macOS.

## Note

Requires a followup PR to add `nsfw=true` to that specific `toml` in the `bevy-assets` repo.

