### PR TITLE
Configure Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directories:
+      - /
+    schedule:
+      interval: weekly
+    labels:
+      - C-Dependencies
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - C-Dependencies


### PR DESCRIPTION
The configuration is almost identical to [the `dependabot.yml` in the engine repo](https://github.com/bevyengine/bevy/blob/eab4ad1e2058d49062a611c157f976a487323756/.github/dependabot.yml). Every week, Dependabot will run and check for updates for our Cargo and Github Actions dependencies. PRs that it opens will automatically be labelled as https://github.com/bevyengine/bevy-website/labels/C-Dependencies.

Dependabot has been setup for this repo for a while, but previously it didn't update Github Actions and used the wrong labels.