### PR TITLE
Add warning about 0.16.x and earlier examples in quick start guide

### DIFF
--- a/content/learn/quick-start/getting-started/_index.md
+++ b/content/learn/quick-start/getting-started/_index.md
@@ -49,6 +49,14 @@ You can also speed up compile times by following the ["fast compiles"] section.
     cargo run --example breakout
     ```
 
+{% callout(type="warning") %}
+Since Rust `1.89+` and when you use Bevy `0.16.x` and earlier versions the examples will not run and instead error. For more info on *why* see the issue: [bevyengine/bevy#20475 "0.16 fails to build breakout example due to bevy_mikktspace not compiling on Rust 1.89"](<https://github.com/bevyengine/bevy/issues/20475>)
+
+Some workarounds:
+- Use Rust 1.88 or earlier using this command: `rustup default 1.88.0`
+- Use Rust 1.88 *only* in your Bevy Engine directory using this command: `rustup override set 1.88` (See https://rust-lang.github.io/rustup/overrides.html#directory-overrides for more on this)
+{% end %}
+
 ### Add Bevy as a Dependency
 
 Bevy is [available as a library on crates.io](https://crates.io/crates/bevy).

--- a/content/learn/quick-start/getting-started/_index.md
+++ b/content/learn/quick-start/getting-started/_index.md
@@ -50,7 +50,7 @@ You can also speed up compile times by following the ["fast compiles"] section.
     ```
 
 {% callout(type="warning") %}
-Since Rust `1.89+` and when you use Bevy `0.16.x` and earlier versions the examples will not run and instead error. For more info on *why* see the issue: [bevyengine/bevy#20475 "0.16 fails to build breakout example due to bevy_mikktspace not compiling on Rust 1.89"](<https://github.com/bevyengine/bevy/issues/20475>)
+When using Rust `1.89+` and Bevy `0.16.x or earlier` the examples will not run and instead error. For more info on *why* see the issue: [bevyengine/bevy#20475 "0.16 fails to build breakout example due to bevy_mikktspace not compiling on Rust 1.89"](<https://github.com/bevyengine/bevy/issues/20475>)
 
 Some workarounds:
 - Use Rust 1.88 or earlier using this command: `rustup default 1.88.0`


### PR DESCRIPTION
## Why
Was brought to my attention by #2230 that https://github.com/bevyengine/bevy/issues/20475 had happened and that our current quick start instructions for running the examples currently breaks, or could break if someone used a version prior to 0.17.

## Goal
Add a warning that the examples are broken on versions 0.16.x and earlier when ran with Rust 1.89 and later and give workarounds for this issue for those using 0.16.x and earlier.