### PR TITLE
Add more migration guides for Bevy 0.17

### DIFF
--- a/content/learn/migration-guides/0.16-to-0.17.md
+++ b/content/learn/migration-guides/0.16-to-0.17.md
@@ -2860,3 +2860,21 @@ or only read the fields you need with `deconstruct_moving_ptr!`:
         }
     }
 ```
+
+### Changes to `bevy_tasks` feature flags
+
+{{ heading_metadata(prs=[19019, 20369]) }}
+
+Various feature flags in `bevy_tasks` have been simplified, thanks to the addition of `bevy_platform::cfg`:
+
+- Removed `critical-section` feature (it was just a re-export of bevy_platform anyway)
+- Removed `std` and `web` features, relying on `bevy_platform::cfg` to check for availability.
+- Added `futures-lite` feature to provide access to the `block_on` implementation from `futures-lite`.
+- Added a fallback implementation of `block_on` that just busy-waits.
+- Moved `wasm-bindgen` related dependencies out of `bevy_tasks` and moved them into `bevy_platform` under a new exports module.
+- Made `async-io` implicit feature explicit.
+
+Any `std`, `web` or `critical-section` feature flags that you've enabled for `bevy_tasks` in your project can simply be removed.
+
+If you need access to `wasm-bindgen` functionality that was previously in `bevy_tasks`, you can find them in `bevy_platform`.
+However, note that the re-exports of various web-related crates (`js_sys`, `wasm_bindgen` and `wasm_bindgen_futures`) are not intended for external consumption. Instead, pull your own dependencies to these crates, making sure the version used matches to ensure interoperability.

--- a/content/learn/migration-guides/0.16-to-0.17.md
+++ b/content/learn/migration-guides/0.16-to-0.17.md
@@ -830,10 +830,10 @@ This is now possible with the new `DespawnOnEnter` component and `clear_events_o
 To support this addition, the previous method and component have been renamed.
 Also, `clear_event_on_exit` (previously `clear_event_on_exit_state`) no longer adds the event automatically, so you must call `App::add_event` manually.
 
-| Before                        | After                                      |
-|-------------------------------|--------------------------------------------|
-| `StateScoped`                 | `DespawnOnExit`                       |
-| `clear_state_scoped_entities` | `despawn_entities_on_exit_state`           |
+| Before                        | After                                |
+| ----------------------------- | ------------------------------------ |
+| `StateScoped`                 | `DespawnOnExit`                      |
+| `clear_state_scoped_entities` | `despawn_entities_on_exit_state`     |
 | `add_state_scoped_event`      | `add_event` + `clear_events_on_exit` |
 
 ### Renamed `JustifyText` to `Justify`
@@ -1625,13 +1625,13 @@ Instead, all id filtering methods were unified into generic `deny_by_ids/allow_b
 
 ## Other affected APIs
 
-| 0.16 | 0.17 |
-| - | - |
-| `EntityWorldMut::clone_with` | `EntityWorldMut::clone_with_opt_out` `EntityWorldMut::clone_with_opt_in` |
+| 0.16                                   | 0.17                                                                                         |
+| -------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `EntityWorldMut::clone_with`           | `EntityWorldMut::clone_with_opt_out` `EntityWorldMut::clone_with_opt_in`                     |
 | `EntityWorldMut::clone_and_spawn_with` | `EntityWorldMut::clone_and_spawn_with_opt_out` `EntityWorldMut::clone_and_spawn_with_opt_in` |
-| `EntityCommands::clone_with` | `EntityCommands::clone_with_opt_out` `EntityCommands::clone_with_opt_in` |
+| `EntityCommands::clone_with`           | `EntityCommands::clone_with_opt_out` `EntityCommands::clone_with_opt_in`                     |
 | `EntityCommands::clone_and_spawn_with` | `EntityCommands::clone_and_spawn_with_opt_out` `EntityCommands::clone_and_spawn_with_opt_in` |
-| `entity_command::clone_with` | `entity_command::clone_with_opt_out` `entity_command::clone_with_opt_in` |
+| `entity_command::clone_with`           | `entity_command::clone_with_opt_out` `entity_command::clone_with_opt_in`                     |
 
 ### Changes to type registration for reflection
 
@@ -2278,7 +2278,7 @@ Most Bevy Remote Protocol methods have been renamed to be more explicit.
 The word `destroy` has also been replaced with `despawn` to match the rest of the engine.
 
 | Old                    | New                           |
-|------------------------|-------------------------------|
+| ---------------------- | ----------------------------- |
 | `bevy/query`           | `world.query`                 |
 | `bevy/spawn`           | `world.spawn_entity`          |
 | `bevy/destroy`         | `world.despawn_entity`        |
@@ -2782,8 +2782,16 @@ In order to reduce the stack size taken up by spawning and inserting large bundl
 ```rust
 // 0.16
 fn spawn(self, world: &mut World, entity: Entity);
+
+let list = Spawn(my_bundle);
+list.spawn(world, entity);
+
 // 0.17
 fn spawn(self: MovingPtr<'_, Self>, world: &mut World, entity: Entity);
+
+let list = Spawn(my_bundle);
+move_as_ptr!(list);
+SpawnableList::spawn(list, world, entity);
 ```
 
 This change also means that `SpawnableList` must now also be `Sized`!
@@ -2809,6 +2817,17 @@ Similar to `Box::into_inner`, `MovingPtr<T>` also has a method `MovingPtr::read`
 let a: u32 = a_ptr.read();
 let b: String = b_ptr.read();
 ```
+
+To create a `MovingPtr<T>` from a value, you can use the `move_as_ptr!` macro:
+
+```rust
+let my_value = MySpawnableList { a: 42u32, b: "Hello".to_string() };
+move_as_ptr!(my_value);
+let _: MovingPtr = my_value;
+```
+
+This macro works by shadowing the original variable name with the newly created `MovingPtr<T>`.
+`MovingPtr<T>` can also be created manually with the `unsafe` method `MovingPtr::from_value`, which takes a `&mut` to an initialized `MaybeUninit<T>`, which the `MovingPtr<T>` takes ownership of: the `MaybeUninit<T>` should be treated as uninitialized after the `MovingPtr<T>` has been used!
 
 To migrate your implementations of `SpawnableList` to the new API, you will want to read the `this` parameter to spawn or insert any bundles stored within:
 


### PR DESCRIPTION
Fixes https://github.com/bevyengine/bevy/issues/21194, fixes https://github.com/bevyengine/bevy/issues/21041.

Adopts work by @janis-bhm that was originally opened on https://github.com/cart/bevy-website/pull/10.