### PR TITLE
Update migration guides with new `deconstruct_moving_ptr` syntax

### DIFF
--- a/content/learn/migration-guides/0.16-to-0.17.md
+++ b/content/learn/migration-guides/0.16-to-0.17.md
@@ -1528,7 +1528,9 @@ struct MySpecialBundle<A: Bundle, B: Bundle> {
     b: B,
 }
 let my_ptr: MovingPtr<'_, MySpecialBundle<u32, String>> = ...;
-deconstruct_moving_ptr!(my_ptr => { a, b, });
+deconstruct_moving_ptr!({
+    let MySpecialBundle { a, b } = my_ptr;
+});
 let a_ptr: MovingPtr<'_, u32> = a;
 let b_ptr: MovingPtr<'_, String> = b;
 ```
@@ -1542,7 +1544,7 @@ let b: String = b_ptr.read();
 
 `apply_effect` is a new method that takes the job of the old `BundleEffect` trait, and gets called once after `get_components` for any `B::Effect: !NoBundleEffect`.
 Since `get_components` might have already partially moved out some of the fields of the bundle, `apply_effect` takes a `MovingPtr<'_, MaybeUninit<Self>>` and implementers must make sure not to create any references to fields that are no longer initialized.
-Likewise, implementers of `get_components` must take care not to move out fields that will be needed in `apply_effect`. `deconstruct_moving_ptr!` can be used to selectively move out fields while ensuring the rest are forgotten, and remain valid for the subsequent call to `apply_effect`.
+Likewise, implementers of `get_components` must take care not to move out fields that will be needed in `apply_effect`. `deconstruct_moving_ptr!` can be used to selectively move out fields, which can then be forgotten with `mem::forget` to be valid for the subsequent call to `apply_effect`.
 The associated type `Effect` remains as a vestigial marker to keep track of whether `apply_effect` needs to be called for any `B::Effect: !NoBundleEffect`.
 
 ### Exclusive systems may not be used as observers
@@ -2806,7 +2808,9 @@ struct MySpawnableList<A: Bundle, B: Bundle> {
     b: B,
 }
 let my_ptr: MovingPtr<'_, MySpawnableList<u32, String>> = ...;
-deconstruct_moving_ptr!(my_ptr => { a, b, });
+deconstruct_moving_ptr!({
+    let MySpawnableList { a, b } = my_ptr;
+});
 let a_ptr: MovingPtr<'_, u32> = a;
 let b_ptr: MovingPtr<'_, String> = b;
 ```
@@ -2853,8 +2857,10 @@ or only read the fields you need with `deconstruct_moving_ptr!`:
 ```rust
     fn spawn(this: MovingPtr<'_, Self>, world: &mut World, entity: Entity) {
         unsafe {
-            // Only `a` is kept, `b` will be forgotten without being dropped!
-            deconstruct_moving_ptr!(this => { a, });
+            // `a` is read, but `b` will be dropped in place without being copied to the stack
+            deconstruct_moving_ptr!({
+                let MySpawnableList { a, b: _ } = this;
+            });
             let a = a.read();
             world.spawn((R::from(entity), a));
         }


### PR DESCRIPTION
# Objective

The syntax for `deconstruct_moving_ptr!` was changed in bevyengine/bevy#20990, but the migration guides currently show the old syntax.  

## Solution

Update the migration guides to use the new syntax.  