### PR TITLE
Migration guide for changes to optional access and default query filters

### DIFF
--- a/content/learn/migration-guides/0.16-to-0.17.md
+++ b/content/learn/migration-guides/0.16-to-0.17.md
@@ -57,6 +57,43 @@ Use `world.query::<EntityMut>().iter(&world)` and `world.query::<EntityRef>().it
 
 This may not return every single entity, because of [default filter queries](https://docs.rs/bevy/latest/bevy/ecs/entity_disabling/index.html). If you really intend to query disabled entities too, consider removing the `DefaultQueryFilters` resource from the world before querying the elements. You can also add an `Allow<Component>` filter to allow a specific disabled `Component` to show up in the query.
 
+### `EntityRef`, `EntityMut`, and `Option<&Disabled>` no longer disable default query filters
+
+{{ heading_metadata(prs=[20163]) }}
+
+Previously, `Query<EntityRef>` would include entities with a `Disabled` component,
+even though queries like `Query<Entity>` and `Query<()>` would not.
+To make this more consistent, `EntityRef` and `EntityMut` no longer disable all default query filters.
+As a side-effect, `Option<&Disabled>` will *also* no longer disable a default query filter.
+
+If you want to include entities with a default query filter like `Disabled`,
+you will need to add an `Allows<Disabled>` query filter
+or a `Has<Disabled>` query data.
+
+```rust
+// 0.16
+// This query would include all entities, even `Disabled` ones
+fn entity_system(query: Query<EntityRef>)
+// This query would include `Disabled` entities, but respect other filters
+fn option_system(query: Query<Option<&Disabled>>)
+// This dynamic query would include `Disabled` entities, but respect other filters
+let query = QueryBuilder::<Entity>::new(&mut world)
+    .optional(|builder| {
+        builder.data::<&CustomDisabled>();
+    })
+    .build();
+
+// 0.17
+// Now we need to explicitly allow `Disabled` entities if we want to query them
+fn entity_system(query: Query<EntityRef, Allows<Disabled>>)
+// Consider replacing `Option<&Disabled>` with `Has<Disabled>`
+fn option_system(query: Query<Has<Disabled>>)
+// Dynamic queries can also use `Allows` to include `Disabled` entities
+let query = QueryBuilder::<Entity>::new(&mut world)
+    .filter::<Allows<CustomDisabled>>()
+    .build();
+```
+
 ### `RelativeCursorPosition` is now object-centered
 
 {{ heading_metadata(prs=[16615]) }}

--- a/content/learn/migration-guides/0.16-to-0.17.md
+++ b/content/learn/migration-guides/0.16-to-0.17.md
@@ -57,7 +57,7 @@ Use `world.query::<EntityMut>().iter(&world)` and `world.query::<EntityRef>().it
 
 This may not return every single entity, because of [default filter queries](https://docs.rs/bevy/latest/bevy/ecs/entity_disabling/index.html). If you really intend to query disabled entities too, consider removing the `DefaultQueryFilters` resource from the world before querying the elements. You can also add an `Allow<Component>` filter to allow a specific disabled `Component` to show up in the query.
 
-### `EntityRef`, `EntityMut`, and `Option<&Disabled>` no longer disable default query filters
+### `EntityRef`, `EntityMut`, and `Option<&Disabled>` no longer ignore default query filters
 
 {{ heading_metadata(prs=[20163]) }}
 


### PR DESCRIPTION
bevyengine/bevy#20163 made breaking changes, as noted in bevyengine/bevy#21228.  

Add a migration guide for those changes.
