### PR TITLE
Adjust the release notes for entity methods

### DIFF
--- a/content/learn/migration-guides/0.16-to-0.17.md
+++ b/content/learn/migration-guides/0.16-to-0.17.md
@@ -1539,7 +1539,7 @@ In order to reduce the stack size taken up by spawning and inserting large bundl
 // 0.16
 trait DynamicBundle {
     type Effect;
-    
+
     // hidden in the docs
     fn get_components(self, func: &mut impl FnMut(StorageType, OwningPtr<'_>)) -> Self::Effect;
 }
@@ -1547,7 +1547,7 @@ trait DynamicBundle {
 // 0.17
 trait DynamicBundle {
     type Effect;
-    
+
     unsafe fn get_components(ptr: MovingPtr<'_, Self>, func: &mut impl FnMut(StorageType, MovingPtr<'_>));
     unsafe fn apply_effect(ptr: MovingPtr<'_, MaybeUninit<Self>>, entity: &mut EntityWorldMut);
 }
@@ -1788,7 +1788,7 @@ impl FromWorld for MyPipeline {
 
         let vertex = asset_server.load("vertex.wgsl");
         let fragment = asset_server.load("fragment.wgsl");
-        
+
         Self {
             layout,
             layout_msaa,
@@ -1807,8 +1807,8 @@ impl SpecializedRenderPipeline for MyPipeline {
             layout: vec![
                 if key.msaa.samples() > 1 {
                     self.layout_msaa.clone()
-                } else { 
-                    self.layout.clone() 
+                } else {
+                    self.layout.clone()
                 }
             ],
             vertex: VertexState {
@@ -1892,7 +1892,7 @@ impl FromWorld for MyPipeline {
             },
             base_descriptor,
         );
-        
+
         Self { variants }
     }
 }
@@ -1907,7 +1907,7 @@ impl Specializer<RenderPipeline> for MySpecializer {
     ) -> Result<Canonical<Self::Key>, BevyError> {
         descriptor.multisample.count = key.msaa.samples();
 
-        let layout = if key.msaa.samples() > 1 { 
+        let layout = if key.msaa.samples() > 1 {
             self.layout_msaa.clone()
         } else {
             self.layout.clone()
@@ -2510,8 +2510,8 @@ An entity is made of two parts: and index and a generation. Both have changes:
 
 `Entity` no longer stores its index as a plain `u32` but as the new `EntityRow`, which wraps a `NonMaxU32`.
 Previously, `Entity::index` could be `u32::MAX`, but that is no longer a valid index.
-As a result, `Entity::from_raw` now takes `EntityRow` as a parameter instead of `u32`. `EntityRow` can be constructed via `EntityRow::new`, which takes a `NonMaxU32`.
-If you don't want to add [nonmax](https://docs.rs/nonmax/latest/nonmax/) as a dependency, use `Entity::from_raw_u32` which is identical to the previous `Entity::from_raw`, except that it now returns `Option` where the result is `None` if `u32::MAX` is passed.
+As a result, `Entity::from_raw` was renamed to `Entity::from_row` and now takes `EntityRow` as a parameter instead of `u32`.
+You can use `Entity::from_raw_u32` which is identical to the previous `Entity::from_raw`, except that it now returns `Option` where the result is `None` if `u32::MAX` is passed.
 
 Bevy made this change because it puts a niche in the `EntityRow` type which makes `Option<EntityRow>` half the size of `Option<u32>`.
 This is used internally to open up performance improvements to the ECS.
@@ -2521,12 +2521,12 @@ To migrate tests, use:
 
 ```diff
 - let entity = Entity::from_raw(1);
-+ let entity = Entity::from_raw_u32(1).unwrap();
++ let entity = Entity::from_row_u32(1).unwrap();
 ```
 
 If you are creating entities manually in production, don't do that!
 Use `Entities::alloc` instead.
-But if you must create one manually, either reuse a `EntityRow` you know to be valid by using `Entity::from_raw` and `Entity::row`, or handle the error case of `None` returning from `Entity::from_raw_u32(my_index)`.
+But if you must create one manually, either reuse a `EntityRow` you know to be valid by using `Entity::from_row` and `Entity::row`, or handle the error case of `None` returning from `Entity::from_row_u32(my_index)`.
 
 ### Generation
 


### PR DESCRIPTION
Update to reflect the new naming and remove the mention of `nonmax`, since there is now a better method for migration.