### PR TITLE
Support highlighting RON syntax

### DIFF
--- a/syntaxes/LICENSE-RON
+++ b/syntaxes/LICENSE-RON
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/syntaxes/README.md
+++ b/syntaxes/README.md
@@ -1,0 +1,11 @@
+# Extra Highlighting Syntaxes
+
+This folder contains [Sublime Text syntax definitions](https://www.sublimetext.com/docs/syntax.html) for languages that are [not supported by Zola out of the box](https://www.getzola.org/documentation/content/syntax-highlighting/).
+
+## WGSL
+
+The WGSL syntax package is from <https://github.com/relrelb/sublime-wgsl>.
+
+## RON
+
+The Rusty Object Notation syntax package is from <https://github.com/ron-rs/sublime-ron>, licensed under the Apache-2.0 license, which you can find at [`LICENSE-RON`](./LICENSE-RON).

--- a/syntaxes/RON.sublime-syntax
+++ b/syntaxes/RON.sublime-syntax
@@ -1,0 +1,203 @@
+%YAML 1.2
+---
+# FROM: https://github.com/ron-rs/sublime-ron
+# http://www.sublimetext.com/docs/syntax.html
+name: RON
+file_extensions:
+  - ron
+version: 2
+scope: source.ron
+variables: # from RustEnhanced
+  non_raw_ident: '[[:alpha:]][_[:alnum:]]*|_[_[:alnum:]]+'
+  identifier: '(?:(?:(?:r\#)?{{non_raw_ident}})\b)' # include a word boundary at the end to ensure all possible characters are consumed, to prevent catastrophic backtracking
+contexts:
+  main:
+    - include: extension
+    - include: value
+  extension:
+    - match: '\#\!\['
+      scope: punctuation.section.array.begin.ron
+      push:
+        - meta_scope: meta.structure.array.ron
+        - match: '\]'
+          scope: punctuation.section.array.end.ron
+          pop: true
+        - include: extension_inner
+        - match: ','
+          scope: punctuation.separator.array.ron
+        - match: '[^\s\]]'
+          scope: invalid.illegal.expected-array-separator.ron
+  extension_inner:
+    - match: 'enable\('
+      push:
+        - meta_scope: meta.structure.entity.ron
+        - match: '\)'
+          scope: punctuation.section.entity.end.ron
+          pop: true
+        - include: extension_name
+        - match: ','
+          scope: punctuation.separator.entity.ron
+  extension_name:
+    - match: 'unwrap_newtypes'
+      scope: entity.name.tag.ron
+    - match: 'implicit_some'
+      scope: entity.name.tag.ron
+  array:
+    - match: '\['
+      scope: punctuation.section.array.begin.ron
+      push:
+        - meta_scope: meta.structure.array.ron
+        - match: '\]'
+          scope: punctuation.section.array.end.ron
+          pop: true
+        - include: value
+        - match: ','
+          scope: punctuation.separator.array.ron
+        - match: '[^\s\]]'
+          scope: invalid.illegal.expected-array-separator.ron
+  comments:
+    - match: /\*\*(?!/)
+      scope: punctuation.definition.comment.ron
+      push:
+        - meta_scope: comment.block.documentation.ron
+        - include: block_comment
+    - match: /\*
+      scope: punctuation.definition.comment.ron
+      push:
+        - meta_scope: comment.block.ron
+        - include: block_comment
+    - match: (//).*$\n?
+      scope: comment.line.double-slash.ron
+      captures:
+        1: punctuation.definition.comment.ron
+  block_comment:
+    - match: \*/
+      pop: true
+    - match: /\*
+      push: block_comment
+  constant:
+    - match: \b(true|false)\b
+      scope: constant.language.ron
+  number:
+    # handles integer and decimal numbers
+    - match: |-
+        (?x:         # turn on extended mode
+          -?         # an optional minus
+          (?:
+            0        # a zero
+            |        # ...or...
+            [1-9]    # a 1-9 character
+            \d*      # followed by zero or more digits
+          )
+          (?:
+            (?:
+              \.     # a period
+              \d+    # followed by one or more digits
+            )?
+            (?:
+              [eE]   # an e character
+              [+-]?  # followed by an option +/-
+              \d+    # followed by one or more digits
+            )?       # make exponent optional
+          )?         # make decimal portion optional
+        )
+      scope: constant.numeric.ron
+  object:
+    - match: '[A-Za-z_][A-Za-z_0-9]*'
+      scope: entity.name.class.ron
+    - match: '\('
+      scope: punctuation.section.dictionary.begin.ron
+      push:
+        - meta_scope: meta.structure.entity.ron
+        - match: '\)'
+          scope: punctuation.section.dictionary.end.ron
+          pop: true
+        - match: '[a-z_][A-Za-z_0-9]*(?!#")'
+          scope: entity.name.tag.ron
+        - match: '\:'
+          scope: punctuation.separator.dictionary.key-value.ron
+        - include: value
+        - match: ','
+          scope: punctuation.separator.dictionary.ron
+  dictionary:
+    - match: '\{'
+      scope: punctuation.section.dictionary.begin.ron
+      push:
+        - meta_scope: meta.structure.dictionary.ron
+        - match: '\}'
+          scope: punctuation.section.dictionary.end.ron
+          pop: true
+        - include: value
+        - match: ':'
+          scope: punctuation.separator.dictionary.key-value.ron
+        - include: value
+        - match: ','
+          scope: punctuation.separator.dictionary.ron
+  string:
+    - match: '"'
+      scope: punctuation.definition.string.begin.ron
+      push: inside-string
+  inside-string:
+    - meta_scope: string.quoted.double.ron
+    - match: '"'
+      scope: punctuation.definition.string.end.ron
+      pop: true
+    - include: string-escape
+    - match: $\n?
+      scope: invalid.illegal.unclosed-string.ron
+      pop: true
+  string-escape:
+    - match: |-
+        (?x:                # turn on extended mode
+          \\                # a literal backslash
+          (?:               # ...followed by...
+            ["\\/bfnrt]     # one of these characters
+            |               # ...or...
+            u               # a u
+            [0-9a-fA-F]{4}  # and four hex digits
+          )
+        )
+      scope: constant.character.escape.ron
+    - match: \\.
+      scope: invalid.illegal.unrecognized-string-escape.ron
+  format-raw-string: # from RustEnhanced
+    - match: (r)(#*)"
+      captures:
+        1: storage.type.string.ron
+        2: punctuation.definition.string.begin.ron
+      push:
+        - meta_include_prototype: false
+        - meta_scope: string.quoted.double.raw.ron
+        - match     : '"\2'
+          scope     : punctuation.definition.string.end.ron
+          pop       : true
+        - include   : format-escapes
+  format-escapes:
+    - match: '\{\{|\}\}'
+      scope: constant.character.escape.ron
+    - match: |-
+        (?x)                      # Spec from http://doc.rust-lang.org/std/fmt/
+        \{
+          (\d+|{{identifier}})?
+          (
+            :                     # format_spec delimiter
+            (.?[<>^])?            # [[fill]align]
+            [+-]?                 # [sign]
+            \#?                   # ['#']
+            0?                    # [0]
+            (\d+\$?)?             # [width]
+            (\.(\d+\$?|\*)?)?     # ['.' precision]
+            (\?|{{identifier}})?  # [type]
+          )?
+        \}
+      scope: constant.other.placeholder.ron
+
+  value:
+    - include: constant
+    - include: number
+    - include: format-raw-string
+    - include: string
+    - include: array
+    - include: dictionary
+    - include: object
+    - include: comments


### PR DESCRIPTION
As Zola does not support RON out of the box, this PR adds RON syntax definitions from <https://github.com/ron-rs/sublime-ron> and its corresponding Apache-2.0 license. I also created `README.md` that describes the purpose of the `syntaxes` folder and gives proper credit to the syntax definitions we have.

Fixes #2258.

## Before

<img width="2940" height="1452" alt="image" src="https://github.com/user-attachments/assets/23665049-d601-49ca-a7f9-93921c04dceb" />

From <https://bevy.org/learn/migration-guides/0-14-to-0-15/#use-fromreflect-when-extracting-entities-in-dynamic-scenes>

## After

<img width="2940" height="1452" alt="image" src="https://github.com/user-attachments/assets/180016a5-c8ba-42d6-8ed6-fcf83a19c82c" />
