### PR TITLE
Fix indentation of headings in 0.17 migration guide

### DIFF
--- a/content/learn/migration-guides/0.16-to-0.17.md
+++ b/content/learn/migration-guides/0.16-to-0.17.md
@@ -1650,7 +1650,7 @@ This change is done because the behavior of the two is too different to share th
 
 The methods of the two builder types are different to 0.16 and to each other now:
 
-## Opt-Out variant
+#### Opt-Out variant
 
 - Still offers variants of the `deny` methods.
 - No longer offers `allow` methods, you need to be exact with denying components.
@@ -1658,14 +1658,14 @@ The methods of the two builder types are different to 0.16 and to each other now
 - Required components of denied components are no longer considered. Denying `A`, which requires `B`, does not imply `B` alone would not be useful at the target. So if you do not want to clone `B` too, you need to deny it explicitly. This also means there is no `without_required_components` method anymore as that would be redundant.
 - It is now the other way around: Denying `A`, which is required _by_ `C`, will now also deny `C`. This can be bypassed with the new `without_required_by_components` method.
 
-## Opt-In variant
+#### Opt-In variant
 
 - Still offers variants of the `allow` methods.
 - No longer offers `deny` methods, you need to be exact with allowing components.
 - Offers now `allow_if_new` method variants that only clone this component if the target does not contain it. If it does, required components of it will also not be cloned, except those that are also required by one that is actually cloned.
 - Still offers the `without_required_components` method.
 
-## Common methods
+#### Common methods
 
 All other methods `EntityClonerBuilder` had in 0.16 are still available for both variants:
 
@@ -1674,14 +1674,14 @@ All other methods `EntityClonerBuilder` had in 0.16 are still available for both
 - `clone_behavior` variants
 - `linked_cloning`
 
-## Unified id filtering
+#### Unified id filtering
 
 Previously `EntityClonerBuilder` supported filtering by 2 types of ids: `ComponentId` and `TypeId`, the functions taking in `IntoIterator` for them.
 Since now `EntityClonerBuilder` supports filtering by `BundleId` as well, the number of method variations would become a bit too unwieldy.
 Instead, all id filtering methods were unified into generic `deny_by_ids/allow_by_ids(_if_new)` methods, which allow to filter components by
 `TypeId`, `ComponentId`, `BundleId` and their `IntoIterator` variations.
 
-## Other affected APIs
+#### Other affected APIs
 
 | 0.16                                   | 0.17                                                                                         |
 | -------------------------------------- | -------------------------------------------------------------------------------------------- |
@@ -1740,7 +1740,7 @@ pub struct Variants<T: Specializable, S: Specializer<T>>{ ... };
 
 For more info on specialization, see the docs for `bevy_render::render_resources::Specializer`
 
-## Mutation and Base Descriptors
+#### Mutation and Base Descriptors
 
 The main difference between the old and new trait is that instead of
 _producing_ a pipeline descriptor, `Specializer`s _mutate_ existing descriptors
@@ -1753,7 +1753,7 @@ itself should only change the parts demanded by the key. In the full example
 below, instead of creating the entire pipeline descriptor the specializer
 only changes the msaa sample count and the bind group layout.
 
-## Composing Specializers
+#### Composing Specializers
 
 `Specializer`s can also be _composed_ with the included derive macro to combine
 their effects! This is a great way to encapsulate and reuse specialization logic,
@@ -1774,13 +1774,13 @@ pub struct MySpecializer {
 }
 ```
 
-## Misc Changes
+#### Misc Changes
 
 The analogue of `SpecializedRenderPipelines`, `Variants`, is no longer a
 Bevy `Resource`. Instead, the cache should be stored in a user-created `Resource`
 (shown below) or even in a `Component` depending on the use case.
 
-## Full Migration Example
+#### Full Migration Example
 
 Before:
 
@@ -2014,7 +2014,7 @@ reduce the risk of soundness problems and unblock features such as resources-as-
 For now, the API for user-provided `NonSend` types is unchanged, but we are considering forcing
 all users to migrate to a solution similar to the one discussed below.
 
-## First-party `NonSend` Resources Replaced
+#### First-party `NonSend` Resources Replaced
 
 Internally, we have replaced the following resources:
 
@@ -2026,7 +2026,7 @@ Each of these are now using `thread_local`s to store the data and are temporary 
 
 Here is an example of how the data can now be accessed. This example will use `WINIT_WINDOWS` as an example, but the same technique can be applied to the others:
 
-### Immutable Access
+##### Immutable Access
 
 ```rust
 use bevy_winit::WINIT_WINDOWS;
@@ -2038,7 +2038,7 @@ WINIT_WINDOWS.with_borrow(|winit_windows| {
 });
 ```
 
-### Mutable Access
+##### Mutable Access
 
 ```rust
 use bevy_winit::WINIT_WINDOWS;
@@ -2052,7 +2052,7 @@ WINIT_WINDOWS.with_borrow_mut(|winit_windows| {
 
 If a borrow is attempted while the data is borrowed elsewhere, the method will panic.
 
-## NonSend Systems
+#### NonSend Systems
 
 The use of a `NonSend` or `NonSendMut` resource in a system would force the system to execute on the main thread.
 However, when using the new `thread_local` pattern, we still need to prevent systems from running on non-main threads.
@@ -2275,7 +2275,7 @@ P::init_access(&param_state, &mut meta, &mut component_access_set, world);
 A more performant zstd backend has been added for texture decompression. To enable it, disable default-features and enable feature "zstd_c".
 If you have default-features disabled and use functionality that requires zstd decompression ("tonemapping_luts" or "ktx2"), you must choose a zstd implementation with one of the following feature flags: "zstd_c" (faster) or "zstd_rust" (safer)
 
-## Migration Guide
+#### Migration Guide
 
 If you previously used the `zstd` feature explicitly, it has been renamed to `zstd_rust`:
 
@@ -2527,7 +2527,7 @@ commands.add_observer(|add: On<Add, Player>| {
 
 An entity is made of two parts: and index and a generation. Both have changes:
 
-### Index
+#### Index
 
 `Entity` no longer stores its index as a plain `u32` but as the new `EntityRow`, which wraps a `NonMaxU32`.
 Previously, `Entity::index` could be `u32::MAX`, but that is no longer a valid index.
@@ -2549,7 +2549,7 @@ If you are creating entities manually in production, don't do that!
 Use `Entities::alloc` instead.
 But if you must create one manually, either reuse a `EntityRow` you know to be valid by using `Entity::from_row` and `Entity::row`, or handle the error case of `None` returning from `Entity::from_row_u32(my_index)`.
 
-### Generation
+#### Generation
 
 An entity's generation is no longer a `NonZeroU32`.
 Instead, it is an `EntityGeneration`.
@@ -2559,14 +2559,14 @@ Working with the generation directly has never been recommended, but it is somet
 To create a generation do `EntityGeneration::FIRST.after_versions(expected_generation)`.
 To use this in tests, do `assert_eq!(entity.generation(), EntityGeneration::FIRST.after_versions(expected_generation))`.
 
-### Removed Interfaces
+#### Removed Interfaces
 
 The `identifier` module and all its contents have been removed.
 These features have been slimmed down and rolled into `Entity`.
 
 This means that where `Result<T, IdentifierError>` was returned, `Option<T>` is now returned.
 
-### Functionality
+#### Functionality
 
 It is well documented that both the bit format, serialization, and `Ord` implementations for `Entity` are subject to change between versions.
 Those have all changed in this version.
@@ -2578,7 +2578,7 @@ Effectively, this means that all serialized and transmuted entities will not wor
 To migrate, invert the lower 32 bits of the 64 representation of the entity, and subtract 1 from the upper bits.
 Again, this is still subject to change, and serialized scenes may break between versions.
 
-### Length Representation
+#### Length Representation
 
 Because the maximum index of an entity is now `NonZeroU32::MAX`, the maximum number of entities (and length of unique entity row collections) is `u32::MAX`.
 As a result, a lot of APIs that returned `usize` have been changed to `u32`.
@@ -2588,7 +2588,7 @@ These include:
 - `Archetype::len`
 - `Table::entity_count`
 
-### Other kinds of entity rows
+#### Other kinds of entity rows
 
 Since the `EntityRow` is a `NonMaxU32`, `TableRow` and `ArchetypeRow` have been given the same treatment.
 They now wrap a `NonMaxU32`, allowing more performance optimizations.


### PR DESCRIPTION
As [noticed](https://discord.com/channels/691052431525675048/1404237363550486751/1422544673523630150) on [Discord](https://discord.com/channels/691052431525675048/1404237363550486751/1422685434504282334), the heading levels in the 0.17 migration guide are slightly messed up.

<img width="1400" height="1647" alt="image" src="https://github.com/user-attachments/assets/799e769a-d3de-48d3-ad28-c03c2b5de0e7" />

This PR fixes these issues with the following rules:

- Individual migration guides have level 3 headings (`###`)
  - These are the sections that each have their own `{{ heading_metadata(prs=[...]) }}`, and represent a distinct set of PRs.
- Subsections within a migration guide have level 4 headings (`####`)
- Sub-subsections within a migration guide have level 5 headings (`#####`)
- Sub-sub-subsections within a migration guide don't exist and can't hurt you  <img width="24" height="29" alt="image" src="https://github.com/user-attachments/assets/ef188b86-9d2e-4e11-b4da-bc177248064a" />

Much better!

<img width="1255" height="1406" alt="image" src="https://github.com/user-attachments/assets/75333f30-a42c-49fb-914c-1315c6be08aa" />
