### PR TITLE
Replace `On::original_entity()` in migration guide with `On::original_event_target()`

### DIFF
--- a/content/learn/migration-guides/0.16-to-0.17.md
+++ b/content/learn/migration-guides/0.16-to-0.17.md
@@ -625,7 +625,7 @@ If you were relying on the previous value of the `Name` component on meshes, use
 {{ heading_metadata(prs=[19663]) }}
 
 The `Pointer.target` field, which tracks the original target of the pointer event before bubbling, has been removed.
-Instead, all "bubbling entity event" observers now track this information, available via the `On::original_entity()` method.
+Instead, all "bubbling entity event" observers now track this information, available via the `On::original_event_target()` method.
 
 If you were using this information via the Pointer API of picking, please migrate to observers.
 If you cannot for performance reasons, please open an issue explaining your exact use case!
@@ -641,7 +641,7 @@ struct EntityEventMessage<E: EntityEvent> {
 
 // A generic observer that handles this transformation
 fn transform_entity_event<E: EntityEvent>(event: On<E>, message_writer: MessageWriter<EntityEventMessage<E>>){
-    if event.entity() == event.original_entity() {
+    if event.entity() == event.original_event_target() {
         message_writer.send(EntityEventMessage {
             event: event.event().clone(),
             entity: event.entity(),


### PR DESCRIPTION
Simple fix. Tripped on this while migrating some game logic.