### PR TITLE
Replace `from_row_u32` by `from_raw_u32` in 0.16->0.17 migration guide

### DIFF
--- a/content/learn/migration-guides/0.16-to-0.17.md
+++ b/content/learn/migration-guides/0.16-to-0.17.md
@@ -2542,12 +2542,12 @@ To migrate tests, use:
 
 ```diff
 - let entity = Entity::from_raw(1);
-+ let entity = Entity::from_row_u32(1).unwrap();
++ let entity = Entity::from_raw_u32(1).unwrap();
 ```
 
 If you are creating entities manually in production, don't do that!
 Use `Entities::alloc` instead.
-But if you must create one manually, either reuse a `EntityRow` you know to be valid by using `Entity::from_row` and `Entity::row`, or handle the error case of `None` returning from `Entity::from_row_u32(my_index)`.
+But if you must create one manually, either reuse a `EntityRow` you know to be valid by using `Entity::from_row` and `Entity::row`, or handle the error case of `None` returning from `Entity::from_raw_u32(my_index)`.
 
 #### Generation
 


### PR DESCRIPTION
I think this was a typo. There are [no references](https://github.com/search?q=repo%3Abevyengine%2Fbevy+Entity%3A%3Afrom_row_u32&type=code) to `Entity::from_row_u32` in Bevy, but I think it should be called `Entity::from_raw_u32` instead (for which there are [references](https://github.com/search?q=repo%3Abevyengine%2Fbevy+Entity%3A%3Afrom_raw_u32&type=code)). 

The naming is maybe a bit confusing because there is a `Entity::from_row` function, but no `Entity::from_row_u32`.