### PR TITLE
Remove extraneous period from index page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -37,7 +37,7 @@
             All engine and game logic uses Bevy ECS, a custom Entity Component System
             <ul class="feature-sublist">
               <li>
-                <b>Fast:</b> Massively Parallel and Cache-Friendly.
+                <b>Fast:</b> Massively Parallel and Cache-Friendly
               </li>
               <li>
                 <b>Simple:</b> Components are Rust structs, Systems are Rust functions


### PR DESCRIPTION
Critical fix for an issue introduced in https://github.com/bevyengine/bevy-website/pull/2241

None of the other lines on this page end in periods and this kept bothering me every time I looked at the website. Meow :3