### PR TITLE
Suggest renaming release note / migration guide labels

### DIFF
--- a/content/learn/contribute/reference/triage.md
+++ b/content/learn/contribute/reference/triage.md
@@ -46,8 +46,8 @@ Labels are our primary tool for organizing work. Here are a few of the most comm
   - `X-Controversial`: there's active disagreement and / or large-scale architectural implications involved.
   - `X-Blessed`: work that was previously controversial, but whose controversial (but perhaps not technical) elements have been endorsed by the relevant decision makers.
 - **M**: Meta, for supporting work that needs to be done.
-  - `M-Spotlight`:  work that should be called out in the blog post due to impact. This decision is usually made by Maintainers, but feel free to nominate a change in the comments if you think it deserves the spotlight!
-  - `M-Breaking`: this is a breaking change to Bevy's public API, and requires advice on how to migrate existing code. These changes cannot be shipped in minor versions!
+  - `M-Release-Note`:  work that should be called out in the blog post due to impact. This decision is usually made by Maintainers, but feel free to nominate a change in the comments if you think it deserves the spotlight!
+  - `M-Migration-Guide`: this is a breaking change to Bevy's public API, and requires advice on how to migrate existing code. These changes cannot be shipped in minor versions!
 
  Check Github for a complete and up-to-date list with descriptions at [the engine repo](https://github.com/bevyengine/bevy/labels) or [the website repo](https://github.com/bevyengine/bevy-website/labels).
 You can learn more about labels on [GitHub's documentation](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels).


### PR DESCRIPTION
## Problem

`M-Needs-Release-Note` and `M-Needs-Migration-Guide` commonly confuse new contributors. If it needs a release note, and then the OP adds a release note, shouldn't we remove the label?

That's not how it works though! Keeping the labels around is helpful to allow for quick searches for impactful or breaking changes.

## Solution

Just use `M-Migration-Guide` and `M-Release-Note`. Short, precise, adequately clear.

## Alternative naming scheme: Spotlight and Breaking

Rename this to `M-Spotlight` and `M-Breaking`. These names are less directly tied to release notes and migration guides, but we have both long label descriptions and a helpful bot to clarify exactly what it means.

The shorter names are easier to talk about and take up less real estate when skimming PRs.

These were the best short names I could come up with, but I'm open to other suggestions.

### Alternate naming scheme: `Worthy`

I also considered a longer, more explicit naming scheme. `M-Release-Note-Worthy` and `M-Migration-Guide-Worthy` were the best names in this category that I found. This eliminates the confusion around "needs", but is even more of a mouthful.

## Follow-up work

Once this is approved and merged, I'll change the `bevy` repo labels accordingly.