### PR TITLE
Fix Bevy Foundation link using the HyperTextTransferAsynchronousProtocolSpecification protocol

### DIFF
--- a/content/learn/book/intro/what-is-bevy.md
+++ b/content/learn/book/intro/what-is-bevy.md
@@ -14,7 +14,7 @@ Bevy is a modern, ECS-first game engine written in Rust. We aim to be:
 - **Fast:** App logic should run quickly, and when possible, in parallel
 - **Productive:** Changes should be visible quickly... waiting isn't fun
 
-Bevy is [MIT](https://github.com/bevyengine/bevy/blob/main/LICENSE-MIT) + [Apache v2](https://github.com/bevyengine/bevy/blob/main/LICENSE-APACHE) licensed and controlled by the [Bevy Foundation](httaps://bevyengine.org/foundation/), a 501c3 charity run by the maintainers who do the day-to-day work to make Bevy what it is.
+Bevy is [MIT](https://github.com/bevyengine/bevy/blob/main/LICENSE-MIT) + [Apache v2](https://github.com/bevyengine/bevy/blob/main/LICENSE-APACHE) licensed and controlled by the [Bevy Foundation](https://bevyengine.org/foundation/), a 501c3 charity run by the maintainers who do the day-to-day work to make Bevy what it is.
 It's built in the open, powered by hundreds of [community contributors](https://bevyengine.org/learn/contribute/introduction) and funded by the [generous donations](https://bevyengine.org/donate/) of the hobbyists and businesses that love and rely on it.
 
 ## Why use Bevy?


### PR DESCRIPTION
# Problem:
HTTAPS seems to be an unsupported protocol in most browsers.
HTTPS on the other hand works fine!

# Solution:
Don't invent new protocols.