### PR TITLE
Add banner to warn user of required feature flags for examples

### DIFF
--- a/templates/layouts/example.html
+++ b/templates/layouts/example.html
@@ -30,7 +30,7 @@
     </aside>
     {% if page.extra.required_features %}
     <aside class="callout callout--warning">
-      <h3 class="warning">Optional feature flag</h3>
+      <h3 class="warning">Feature flag required</h3>
       <p>
         The code in this example requires {% if page.extra.required_features | length > 1
         %}these feature flags{% else %}this feature flag{% endif %} to be enabled in order to function:


### PR DESCRIPTION
As a user, it kinda sucks copying a website example only to see it not working and with unhelpful rust errors.

Some examples do mention it in their description, but it's not universal and can be forgotten. It's also easy to miss.

My solution is to add a warning banner that lists out the optional feature flags that are required for the example to work (no banner if no required features).

The information is collected from the required_features specified in the root `Cargo.toml` of the bevy engine.
This data is not yet available to the website so I made another PR in bevy to make it available: https://github.com/bevyengine/bevy/pull/21975.

EDIT: The required change has now been merged, this is ready to go

Feel free to give feedback on the wording or anything else.

This is how it would look: 
<img width="1241" height="974" alt="image" src="https://github.com/user-attachments/assets/36ff36fa-aaca-4e66-b9a8-77328606c5bf" />

