### PR TITLE
Add book page for Fast Compiles

### DIFF
--- a/content/learn/book/development-practices/fast-compiles.md
+++ b/content/learn/book/development-practices/fast-compiles.md
@@ -75,7 +75,7 @@ You will also need to add the following to your Cargo config at `/path/to/projec
 
 This gives access to the latest performance improvements and "unstable" optimizations, including [generic sharing](#generic-sharing) below.
 
-Create a ```rust-toolchain.toml``` file in the root of your project, next to ```Cargo.toml```.
+Create a `rust-toolchain.toml` file in the root of your project, next to `Cargo.toml`.
 
 ```toml
 [toolchain]


### PR DESCRIPTION
Per #2193, the Fast Compiles page is just porting over the existing section from the Setup page in the Quick Start guide. This is that, with an introductory paragraph and minor formatting and spelling adjustments. 