### PR TITLE
content: fix broken getting started plugins link

### DIFF
--- a/content/learn/quick-start/getting-started/plugins.md
+++ b/content/learn/quick-start/getting-started/plugins.md
@@ -53,7 +53,7 @@ Try running the app again. It should do exactly what it did before. In the next 
 [`UiPlugin`]: https://docs.rs/bevy/latest/bevy/ui/struct.UiPlugin.html
 [`RenderPlugin`]: https://docs.rs/bevy/latest/bevy/render/struct.RenderPlugin.html
 [`WindowPlugin`]: https://docs.rs/bevy/latest/bevy/window/struct.WindowPlugin.html
-[`WininitPlugin`]: https://docs.rs/bevy/latest/bevy/winit/struct.WinitPlugin.html
+[`WinitPlugin`]: https://docs.rs/bevy/latest/bevy/winit/struct.WinitPlugin.html
 [`DefaultPlugins`]: https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html
 [`PluginGroup`]: https://docs.rs/bevy/latest/bevy/app/trait.PluginGroup.html
 [`MinimalPlugins`]: https://docs.rs/bevy/latest/bevy/struct.MinimalPlugins.html


### PR DESCRIPTION
The markdown link target was incorrectly named "WininitPlugin" instead of "WinitPlugin", resulting in the following broken link at render time:

<img width="826" height="236" alt="markdown glitch_000" src="https://github.com/user-attachments/assets/ea0798a9-2db3-4793-a691-6e6479fc2ab3" />
