### PR TITLE
Fix heading levels in 0.17 to 0.18 migration guide

### DIFF
--- a/content/learn/migration-guides/0.17-to-0.18.md
+++ b/content/learn/migration-guides/0.17-to-0.18.md
@@ -896,7 +896,7 @@ For a full explanation of the new entity paradigm, errors and terms, see the new
 If you want more background for the justification of these changes or more information about where these new terms come from, see pr #19451.
 This opens up a lot of room for performance improvement but also caused a lot of breaking changes:
 
-## `Entities` rework
+#### `Entities` rework
 
 A lot has changed here.
 First, `alloc`, `free`, `reserve`, `reserve_entity`, `reserve_entities`, `flush`, `flush_as_invalid`, `EntityDoesNotExistError`, `total_count`, `used_count`, and `total_prospective_count` have all been removed 😱.
@@ -922,7 +922,7 @@ When an entity index's `Option<EntityLocation>` is `None`, `EntityValidButNotSpa
 When an `Entity` is expected to be spawned but is not (either because its generation is outdated or because its row is not spawned), `EntityNotSpawnedError` is produced.
 A few other wrapper error types have slightly changed as well, generally moving from "entity does not exist" to "entity is not spawned".
 
-### Entity Ids
+#### Entity Ids
 
 Entity ids previously used "row" terminology, but now use "index" terminology as that more closely specifies its current implementation.
 As such, all functions and types dealing with the previous `EntityRow` have had their names 1 to 1 mapped to index.
@@ -930,7 +930,7 @@ Ex: `EntityRow` -> `EntityIndex`, `Entity::row` -> `Entity::index`, `Entity::fro
 Note that `Entity::index` did exist before. It served to give the numeric representation of the `EntityRow`.
 The same functionality exists, now under `Entity::index_u32`.
 
-### Entity Pointers
+#### Entity Pointers
 
 When migrating, entity pointers, like `EntityRef`, were changed to assume that the entity they point to is spawned.
 This was not necessarily checked before, so the errors for creating an entity pointer is now `EntityNotSpawnedError`.
@@ -939,13 +939,13 @@ This probably will not affect you since creating a pointer to an entity that was
 It is still possible to invalidate an `EntityWorldMut` by despawning it from commands. (Ex: The hook for adding a component to an entity actually despawns the entity it was added to.)
 If that happens, it may lead to panics, but `EntityWorldMut::is_spawned` has been added to help detect that.
 
-### Entity Commands
+#### Entity Commands
 
 `Commands::new_from_entities` now also needs `&EntitiesAllocator`, which can be obtained from `UnsafeWorldCell::entities_allocator`.
 `Commands::get_entity` does not error for non-spawned entities, making it useful to amend an entity you have queued to spawn through commands.
 If you only want spawned entities, use `Commands::get_spawned_entity`.
 
-### Other entity interactions
+#### Other entity interactions
 
 The `ArchetypeRow::INVALID` and `ArchetypeId::INVALID` constants have been removed, since they are no longer needed for flushing.
 If you depended on these, use options instead.


### PR DESCRIPTION
Each migration guide has an `<h3>` (`###`) heading. If that migration guide has subsections, they should use `<h4>` (`####`). In this PR I went through every subsection header and made sure they were `<h4>`s.