### PR TITLE
Reframe get_components_mut note to add context

### DIFF
--- a/content/news/2026-01-12-bevy-0.18/index.md
+++ b/content/news/2026-01-12-bevy-0.18/index.md
@@ -351,7 +351,7 @@ particularly for an API that's designed for convenience and often most attractiv
 
 In Bevy 0.18, we're finally introducing safe equivalents, in the form of [`EntityMut::get_components_mut`] and [`EntityWorldMut::get_components_mut`].
 These methods allow you to access multiple mutable or imutable references to the components on a single entity.
-To ensure that we don't hand out multiple mutable references to the same data, these APIs use quadratic time complexity
+To ensure that we don't hand out multiple mutable references to the same data, these APIs use quadratic time complexity (over the number of components accessed)
 runtime checks, safely erroring if illegal access was requested.
 
 Quadratic time complexity is bad news, but in many cases, the list of components requested is very small:


### PR DESCRIPTION
This note was well-written but excessively technical and dry.

I've rewritten it to better explain the story and importance of this seemingly innocuous bit of ECS work.