### PR TITLE
Clean up hyperlinks, especially in auto directional nav note

### DIFF
--- a/content/news/2026-01-12-bevy-0.18/index.md
+++ b/content/news/2026-01-12-bevy-0.18/index.md
@@ -268,7 +268,7 @@ Now, you can simply add the [`AutoDirectionalNavigation`] component to your UI e
 - **Overlap**: For cardinal directions (N/S/E/W), the system ensures sufficient perpendicular overlap
 
 [`DirectionalNavigationMap`]: https://docs.rs/bevy/0.18.0/bevy/input_focus/directional_navigation/struct.DirectionalNavigationMap.html
-[`AutoDirectionalNavigation`]: https://docs.rs/bevy/0.18.0/bevy/input_focus/directional_navigation/struct.AutoDirectionalNavigation.html
+[`AutoDirectionalNavigation`]: https://docs.rs/bevy/0.18.0/bevy/ui/auto_directional_navigation/struct.AutoDirectionalNavigation.html
 
 ### How to Use It
 


### PR DESCRIPTION
Part of #2320.

Things got shuffled around last minute as part of https://github.com/bevyengine/bevy/pull/22340, so the items weren't present in the release-candidate docs.

I've also remembered to fix up all the other hyperlinks here; that should have been done in #2330 but I forgot!