### PR TITLE
Fix typo in "Generic Option Parameter" for migration guide 0.17

### DIFF
--- a/content/learn/migration-guides/0.16-to-0.17.md
+++ b/content/learn/migration-guides/0.16-to-0.17.md
@@ -243,10 +243,10 @@ fn my_system(single: Option<Single<&Player>>) {
 // 0.17
 fn my_system(query: Query<&Player>) {
     let result = query.single();
-    if matches!(r, Err(QuerySingleError(MultipleEntities(_)))) {
+    if matches!(result, Err(QuerySingleError(MultipleEntities(_)))) {
         return;
     }
-    let single: Option<&Player> = r.ok();
+    let single: Option<&Player> = result.ok();
 }
 ```
 


### PR DESCRIPTION
Fix migration guide code typo.

`r`s should be `result`s to match the binding.