### PR TITLE
Remove reference to removed `publish.sh`

### DIFF
--- a/content/learn/contribute/helping-out/opening-pull-requests.md
+++ b/content/learn/contribute/helping-out/opening-pull-requests.md
@@ -90,8 +90,7 @@ If you're new to Bevy, here's the workflow we use:
 
 If you end up adding a new official Bevy crate to the `bevy` repository:
 
-1. Add the new crate to the [tools/publish.sh](https://github.com/bevyengine/bevy/blob/main/tools/publish.sh) file.
-2. Check if a new cargo feature was added, update [docs/cargo_features.md](https://github.com/bevyengine/bevy/blob/main/docs/cargo_features.md) as needed.
+1. Check if a new cargo feature was added, update [docs/cargo_features.md](https://github.com/bevyengine/bevy/blob/main/docs/cargo_features.md) as needed.
 
 When contributing, please:
 


### PR DESCRIPTION
We used to have a `publish.sh` script that published Bevy's crates in a designated order. It was removed in https://github.com/bevyengine/bevy/pull/21064, however, once `cargo publish --workspace` was introduced.

This PR removes the one reference to `publish.sh` from our contributing guide, to clear up any confusion. :)

Fixes #2269!