### PR TITLE
Update 0.17 -> 0.18 migration guide for EarthlikeAtmosphere

### DIFF
--- a/content/learn/migration-guides/0.17-to-0.18.md
+++ b/content/learn/migration-guides/0.17-to-0.18.md
@@ -568,17 +568,16 @@ pub struct Atmosphere {
 ```
 
 Unfortunately, this means `Atmosphere` no longer implements `Default`. Instead,
-you can still access the default earthlike atmosphere through the
-`EarthlikeAtmosphere` resource:
+you can access the default earthlike atmosphere by using `ScatteringMedium::default()`:
 
 ```rust
 fn setup_camera(
     mut commands: Commands,
-    earthlike_atmosphere: Res<EarthlikeAtmosphere>
+    mut scattering_mediums: ResMut<Assets<ScatteringMedium>>
 ) {
     commands.spawn((
         Camera3d,
-        earthlike_atmosphere.get(),
+        Atmosphere::earthlike(scattering_mediums.add(ScatteringMedium::default())),
     ));
 }
 ```


### PR DESCRIPTION
Right before 0.18 was released, Cart had removed the `EarthlikeAtmosphere` resource. However, a migration guide still referenced the resource. https://github.com/bevyengine/bevy/pull/22463#issuecomment-3765484652

This updates that migration guide to what Cart has in the description of the PR for “manual initialization” (and what’s used in the 3d atmosphere example)

cc @inspirateur 