### PR TITLE
Use cover image for "meta" link image

### DIFF
--- a/templates/layouts/base.html
+++ b/templates/layouts/base.html
@@ -83,8 +83,13 @@
     <meta property="og:title" content="{{ page_title }}" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://bevy.org{{ path }}" />
+    {% if page.extra.image %}
+    <meta property="og:image"
+          content="{{ "https://bevy.org" ~ current_path ~ page.extra.image }}" />
+    {% else %}
     <meta property="og:image"
           content="https://bevy.org/assets/bevy_logo_fill.png" />
+    {% endif %}
     <meta property="og:description"
           content="Bevy is a refreshingly simple data-driven game engine built in Rust. It is free and open-source forever!" />
     <link rel="shortcut icon" type="image/png" href="/assets/favicon.png">


### PR DESCRIPTION
Currently when you link to Bevy news on social media, it uses the "default" Bevy image:

<img width="595" height="602" alt="image" src="https://github.com/user-attachments/assets/80eec3a8-bf94-4aa7-9d4d-b78a6f67116c" />

When a page sets a cover image, this is now used as the "meta" image for links as well (ex: bluesky, discord, mastodon, etc).