### PR TITLE
Added description truncation and fallbacks to opengraph description

### DIFF
--- a/templates/layouts/base.html
+++ b/templates/layouts/base.html
@@ -92,9 +92,9 @@
     {% endif %}
     <meta property="og:description"
       {% if page.description %}
-        content = "{{ page.description }}"
+        content="{{ page.description }}"
       {% elif page.content %}
-        content = "{{ page.content | striptags | truncate(length=150) }}"
+        content="{{ page.content | striptags | truncate(length=150) }}"
       {% else %}
         content="Bevy is a refreshingly simple data-driven game engine built in Rust. It is free and open-source forever!" 
       {% endif %}


### PR DESCRIPTION
This adds a unique opengraph description to posts with several fallbacks. I thought it may be a useful addition with #2351, but let me know your thoughts for or against this change. 

Currently, all posts have the same static text opengraph description:

> Bevy is a refreshingly simple data-driven game engine built in Rust. It is free and open-source forever!"

First, if a `description` is provided in the page's frontmatter, it will take priority as the opengraph description.   It does not appear that any articles have a description today. 

In the case of no specified description, it will default to the first 150 characters of the post as the opengraph description.

If there is no content (e.g., the page is an index or category page) the description will default to the original text.