### PR TITLE
Add Events book page content

### DIFF
--- a/content/learn/book/control-flow/events.md
+++ b/content/learn/book/control-flow/events.md
@@ -8,11 +8,17 @@ status = 'hidden'
 
 <!-- TBW -->
 
-To make things happen in our Bevy app, we can use an **Event** to activate some logic or functionality on any observing Entities. Events require a **Trigger** that is called by accessing [`World`] (via [`World::trigger`]) to run the Event immediately, or by using [`Commands`] (via [`Commands::trigger`]) to add the Event to the Command Queue.
+While Systems are great for running logic at scheduled updates, many features need to be reactive, not scheduled. Picking up an item, performing an attack, or even hovering the mouse over an object are all actions that wouldn't work very well if they *had* to run on every schedule update. Instead of a System, we can use **Events** to activate some logic or functionality at a specific time or in response to something occurring.
 
-A basic use of an Event would something like this:
+There are three required parts when using an Event: a **Trigger**, an **Observer**, and the `Event` itself.
 
-- Implement the [`Event`] trait on a type:
+- A **Trigger** is the condition that will determine when an `Event` will happen in the `World`.
+- The Entities that will react to our `Event` are known as **Observers**. These Entities "observe" the `World` and will run some functionality in response to our `Event`.
+- Finally, the `Event` is a Rust type that implements the `Event` trait.
+
+A basic use of an `Event` would something like this:
+
+1. Implement the [`Event`] trait on a type:
 
 ```rust
 #[derive(Event)]
@@ -21,7 +27,7 @@ struct Speak {
 }
 ```
 
-- Add an [`Observer`] to the World that will watch for our event:
+2. Add an [`Observer`] to the World that will watch for our event:
 
 ```rust
 // To add the observer immediately:
@@ -35,7 +41,7 @@ commands.add_observer(|speak: On<Speak>| {
 });
 ```
 
-- Trigger the `Speak` event:
+3. Trigger the `Speak` event:
 
 ```rust
 // To trigger the event immediately:
@@ -49,7 +55,7 @@ commands.trigger(Speak {
 });
 ```
 
-Since an [`Event`] type is just a regular Rust type, we can add fields which will hold data that can be used when triggering the event. In the above example, our `Speak` event type has a `message` field which holds a `String` value. When we added an [`Observer`] that watches for our `Speak` event being triggered, we specified that the observer will print out the value held in the `message` field to the console using the `println!` macro. As such, we could trigger multiple `Speak` events and pass in different `String` values.
+Since an [`Event`] type is just a regular Rust type, we can add fields which will hold data that can be used when triggering the event. In the above example, our `Speak` event type has a `message` field which holds a `String` value. When we added an `Observer` that watches for our `Speak` event being triggered, we specified that the observer will print out the value held in the `message` field to the console using the `println!` macro. As such, we could trigger multiple `Speak` events and pass in different `String` values.
 
 ```rust
 // Triggers `Speak` immediately.
@@ -71,19 +77,13 @@ commands.trigger(custom_message);
 ```
 
 [`Event`]: https://docs.rs/bevy/latest/bevy/prelude/trait.Event.html
-[`World`]: https://docs.rs/bevy/latest/bevy/prelude/struct.World.html
-[`World::trigger`]: https://docs.rs/bevy/latest/bevy/prelude/struct.World.html#method.trigger
-[`Commands`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Commands.html
-[`Commands::trigger`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Commands.html#method.trigger
 [`Observer`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Observer.html
 
-## Event Triggers & Observers
+## Event Triggers
 
-Every `Event` requires a [`Trigger`], represented by default with the `On<Event>` syntax. It's best to think of a Trigger as the call which activates the Event, hence why we use `On`: our code will run `On` our `<Event>`.
+Every `Event` requires a [`Trigger`], represented by default with the `On<Event>` syntax. It's best to think of a `Trigger` as the call which activates the `Event`, hence why we use `On`: our code will run `On` our `<Event>`.
 
-Events are triggered for [`Observers`], special entities which are created specifically to watch for the specified event. If a Trigger is the Event's activation call, then the Observers are the ones who listen for the activation call and run their code in response.
-
-Observers are created using the `add_observer` methods on both [`World`] ([`World::add_observer`]) and [`Commands`] ([`Commands::add_observer`]). Observers are detailed further in the dedicated [Observers] page, but it's worth reviewing how they depend on Triggers and Events.
+A [`Trigger`] can be called by accessing [`World`] (via [`World::trigger`]) to run the `Event` immediately, or by using [`Commands`] (via [`Commands::trigger`]) to add the `Event` to the Command Queue.
 
 ```rust
 // An event that deals damage to the player.
@@ -119,22 +119,21 @@ fn player_damage(mut commands: Commands, player: Single<(Entity, Name), With<Pla
 
 ```
 
-The Trigger determines which Observers will be run. When we call `commands.add_observer()` in the above example, `damage_event: On<PlayerDamage>` is the Trigger which will cause the Observer to run its code. If there were other Observers added that also had `On<PlayerDamage>`, those Observers would also run their code when we trigger a `PlayerDamage` Event.
+A `Trigger` determines which observers will be activated. When we call `commands.add_observer()` in the above example, `damage_event: On<PlayerDamage>` is the `Trigger` which will cause the `Observer` to run its code. If there were other observers added that also had `On<PlayerDamage>` triggers, those observers would also run their code when we trigger a `PlayerDamage` event.
 
-As we mentioned above, Triggers can also be used to pass values from the Event to the Observer. When we triggered the `PlayerDamage` event in `fn player_damage()`, we gave it `damage_value` and `player_name` in the `amount` and `taken_by` fields. These values are then used by the Observer we created in `fn setup()` to both print to the console and to adjust the Player's Health we got from a Single query.
-
-[Observers]: /learn/book/control-flow/observers
+As we mentioned above, a `Trigger` can also be used to pass values from the `Event` to an `Observer`. When we triggered the `PlayerDamage` event in `fn player_damage()`, we gave it `damage_value` and `player_name` in the `amount` and `taken_by` fields. These values are then used by the `Observer` we created in `fn setup()` to both print to the console and to adjust the Player's Health we got from a Single query.
 
 [`Trigger`]: https://docs.rs/bevy/latest/bevy/ecs/event/trait.Trigger.html
-[`Observers`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Observer.html
-[`World::add_observer`]: https://docs.rs/bevy/latest/bevy/prelude/struct.World.html#method.add_observer
-[`Commands::add_observer`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Commands.html#method.add_observer
+[`World`]: https://docs.rs/bevy/latest/bevy/prelude/struct.World.html
+[`World::trigger`]: https://docs.rs/bevy/latest/bevy/prelude/struct.World.html#method.trigger
+[`Commands`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Commands.html
+[`Commands::trigger`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Commands.html#method.trigger
 
 ## Entity Events
 
-Up until now, Events have been utilized in a *global* context, meaning that Observers will run their code without taking any specific entities into account.
+Up until now, Events have been utilized in a *global* context, meaning that observers will run their code without taking any specific entities into account.
 
-What if we do have some unique functionality that we want to run on certain entities? We can achieve this by modifying our Event types to implement [`EntityEvent`] rather than [`Event`]:
+What if we do have some unique functionality that we want to run on certain entities? We can achieve this by modifying our `Event` types to implement [`EntityEvent`] rather than [`Event`]:
 
 ```rust
 // Global Event
@@ -150,7 +149,7 @@ struct Explode {
 }
 ```
 
-An [`EntityEvent`] must have an `event_target` containing the Entity which will observe the event. By default, `event_target` will be set to the value inside an `entity` field on a struct if it exists. Otherwise we can manually specify the `event_target` by using the `#[event_target]` field attribute.
+With [`EntityEvent`], we are selecting a single `Entity` that will respond to our event. To determine the selected `Entity`, we need to provide the `EventEntity` with an `entity_target` field. By default, `event_target` will be set to the value inside an `entity` field in a struct (if it exists). Otherwise we can manually specify the `event_target` by using the `#[event_target]` field attribute.
 
 ```rust
 // A simple EntityEvent:
@@ -178,14 +177,15 @@ struct Explode(#[event_target] Entity, i32, f32); // Using #[event_target] insid
 
 ```
 
-Just as with a global Event, Entity Events must also have a [`Trigger`]. Thankfully, we trigger an [`EntityEvent`] the same way we trigger a regular [`Event`]:
+Just as with a global [`Event`], [`EntityEvent`] also needs a [`Trigger`]. Thankfully, we trigger an `EntityEvent` the same way we trigger a regular [`Event`]:
 
 ```rust
-world.trigger(Explode{ entity });
-// OR commands.trigger() to run in the command queue.
+world.trigger(Explode(some_entity, 4, 2.5));
+// Trigger an Explode `EntityEvent`, passing in a tuple consisting of 
+// an Entity (`some_entity`), an i32 (`4`), and a f32 (`2.5`).
 ```
 
-However, [`EntityEvent`] does differ from [`Event`] when it comes to adding an Observer. To make an Entity observe an [`EntityEvent`], we have to select the Entity with [`World::entity_mut`] and then add the Observer with [`EntityCommands::observe`]:
+However, [`EntityEvent`] does differ from [`Event`] when it comes to using an observer. To make an Entity observe an [`EntityEvent`], we have to select the `Entity` with [`World::entity_mut`] and then add the observer with [`EntityCommands::observe`]:
 
 ```rust
 /// This observer will only run for Explode events triggered for `some_entity`
@@ -206,9 +206,9 @@ world.entity_mut(some_entity).observe(|explode: On<Explode| {}); // Entity obser
 
 ### EntityEvent Propagation
 
-Since [`EntityEvent`] is triggered for Entities themselves and not an independent Observer entity, we can leverage any [Relations] present on an Entity when an [`EntityEvent`] is activated. This is known as Propagation, or "Event Bubbling", and allows an [`EntityEvent`] to traverse a hierarchy chain while triggering on each Entity in that hierarchy chain.
+Since [`EntityEvent`] is triggered for individual entities themselves and not for all independent observer entities, we can leverage any [Relations] present on an `Entity` when an [`EntityEvent`] is activated. This is known as Propagation, or "Event Bubbling", and allows an [`EntityEvent`] to traverse a hierarchy chain while triggering on each `Entity` in that hierarchy chain.
 
-Propagation has to be explicitly enabled on an [`EntityEvent`], and any Observers have to opt-in. This is done by setting the `#[entity_event(propagate)]` attribute on an [`EntityEvent`] and also by allowing the desired Observer to allow propagation:
+Propagation has to be explicitly enabled on an [`EntityEvent`], and any `Observer` has to opt-in. This is done by setting the `#[entity_event(propagate)]` attribute on an [`EntityEvent`] and also by allowing the desired `Observer` to allow propagation:
 
 ```rust
 // Set the `entity_event(propagate)` attribute.
@@ -224,7 +224,7 @@ world.add_observer(|mut click: On<Click>| {
 });
 ```
 
-Likewise, if we have an [`EntityEvent`] that an Observer is observing, we can explicitly disable propagation:
+Likewise, if we have an [`EntityEvent`] that an `Observer` is observing, we can explicitly disable propagation:
 
 ```rust
 // Disable event propagation on an observer.
@@ -244,7 +244,7 @@ struct Click {
 }
 ```
 
-By default, [`EntityEvent`] propagation will follow the [`ChildOf`] relation, starting at the original entity ("child") that the [`EntityEvent`] was triggered on and then repeatedly triggering on the Entity that is contained within the [`ChildOf`] component ("parent"). However, we can also specify a custom traversal implementation that will propagate along a custom relation.
+By default, [`EntityEvent`] propagation will follow the [`ChildOf`] relation, starting at the original entity ("child") that the [`EntityEvent`] was triggered on and then repeatedly triggering on the `Entity` that is contained within the [`ChildOf`] component ("parent"). However, we can also specify a custom traversal implementation that will propagate along a custom relation.
 
 ```rust
 // "ChildOf" equivalent. 
@@ -265,7 +265,7 @@ struct Click {
 }
 ```
 
-To see an example of [`EntityEvent`] propagation in action, the [Bevy Examples Page] has an [Observer Propagation] example which showcases an `Attack` [`EntityEvent`] propagating up from a piece of armor to the entity that is wearing the armor.
+To see [`EntityEvent`] propagation in action, the [Bevy Examples Page] has an [Observer Propagation] example which showcases an `Attack` [`EntityEvent`] propagating up from a piece of armor to the entity that is wearing the armor.
 
 [Relations]: /learn/book/storing-data/relations
 [Bevy Examples Page]: https://bevy.org/examples


### PR DESCRIPTION
With the Event rework in 0.17, I thought I'd try and take a stab at filling out a book page for Events. I pretty much just followed the 0.17 release post features, along with double checking the docs pages to make sure that I wasn't missing anything major.

Hope this is in the direction of content that is wanted, let me know if I need to change or re-work anything!