### PR TITLE
Goals can be created by contributors (carefully)

### DIFF
--- a/content/learn/contribute/project-information/project-goals.md
+++ b/content/learn/contribute/project-information/project-goals.md
@@ -25,7 +25,10 @@ Goals are tracked on the [Project Goals Board](https://github.com/orgs/bevyengin
 - Goals inherently require _collaboration_ to bring them to completion. They are never the work of a single individual. At the very least, there is someone coming up with a design / implementation, and one or more **SME** verifying the design / implementation.
 - Goals are inherently `X-Needs-SME`, so they should be given that label.
 - Anything that needs a Goal, but doesn't currently have one should be labeled with `C-Needs-Goal`.
-- Goals are only created by **SMEs** and **Maintainers**. The intent behind this restriction is that Goals are a "public facing" / marketing thing, so phrasing and framing is important. Every new Goal gets added to the Proposed goal column on the public Project Goals board. Going through SMEs + Maintainers ensures redundancies are avoided, noise is kept to a minimum, consistency is enforced, templates are used, framing / public image / marketing is taken into account, etc. This is just as true for closed Goals, which exist to be a nice consolidated list of things the project definitely doesn't want to do.
+- Goals are typically created by **SMEs** or **Maintainers**.
+  - However, trusted contributors may create Goals after discussion with at least one **SME** or **Maintainer**.
+  - Goals created without following this process will be deleted without consideration, and a warning will be issued.
+  - The intent behind this restriction is that Goals are a "public facing" / marketing thing, so phrasing and framing is important. Every new Goal gets added to the Proposed goal column on the public Project Goals board. Going through SMEs + Maintainers ensures redundancies are avoided, noise is kept to a minimum, consistency is enforced, templates are used, framing / public image / marketing is taken into account, etc. This is just as true for closed Goals, which exist to be a nice consolidated list of things the project definitely doesn't want to do.
 
 ## When does an Issue or PR need a Goal?
 
@@ -94,7 +97,10 @@ The SMEs staffing a Goal should be listed in the Goal's description.
 
 ## Goal Issue Template
 
-Only SMEs and Maintainers should create new Goals (see rationale in the "What is a Goal?" section above)! If that is you, copy this template when creating a new Goal. We put this template here, rather than adding it as a GitHub issue template, because we don't want normal users creating Goals.
+Typically, only SMEs and Maintainers should create new Goals (see rationale in the "What is a Goal?" section above)!
+However, trusted contributors may create a goal after discussion with relevant SMEs and Maintainers.
+
+If that is you, copy this template when creating a new Goal. We put this template here, rather than adding it as a GitHub issue template, because we don't want normal users creating Goals.
 
 1. Name the Goal. This should be a short, functional name, as it would be communicated to the public. This is a market-able "feature name", like "PBR Renderer", "Relationships", etc. Avoid using things like "initial" or "MVP" in the name, as this is implied.
 2. Add the `C-Goal` and `X-Needs-SME` labels.


### PR DESCRIPTION
This was a recent change made to our process, announced + discussed in [this Discord thread](https://discord.com/channels/691052431525675048/1473450744085610576).

>  `@Maintainer` `@SME` `@vero` has (once again) proposed that we remove the constraint that only SMEs / Maintainers can create Goals, now that we've started making them in practice. I agree that there has been a lot of unnecessary "forced mediation".
>
> `@vero` and I both propose that we lift the restriction, with the stipulation that the contributor wanting to propose the Goal asks SMEs / Maintainers first, so we can discuss framing / naming / how to break it up
