### PR TITLE
Fix binaryen version in WASM build workflow

### DIFF
--- a/.github/workflows/build-wasm-examples.yml
+++ b/.github/workflows/build-wasm-examples.yml
@@ -62,7 +62,7 @@ jobs:
         run: |
           cargo install --force wasm-bindgen-cli
           mkdir ./binaryen
-          wget -qO- https://github.com/WebAssembly/binaryen/releases/download/version_126/binaryen-version_126-arm64-macos.tar.gz | tar xvz --strip-components 1 -C ./binaryen binaryen-version_114
+          wget -qO- https://github.com/WebAssembly/binaryen/releases/download/version_126/binaryen-version_126-arm64-macos.tar.gz | tar xvz --strip-components 1 -C ./binaryen binaryen-version_126
 
       - name: Build WASM Examples
         run: |


### PR DESCRIPTION
missed in #2368 