### PR TITLE
Book: Replace EventReader/-Writer with new version 

### DIFF
--- a/content/learn/book/control-flow/systems.md
+++ b/content/learn/book/control-flow/systems.md
@@ -25,7 +25,7 @@ across multiple systems in parallel at the same time.
 
 Systems in Bevy are any Rust function where every argument implements the [`SystemParam`].
 The full list can be seen in the API docs linked (and you can create your own!),
-but the most common are [`Query`], [`Res`], [`ResMut`], [`EventReader`], [`EventWriter`], [`Local`] and [`Commands`].
+but the most common are [`Query`], [`Res`], [`ResMut`], [`MessageReader`], [`MessageWriter`], [`Local`] and [`Commands`].
 
 The requested data is automatically fetched from the [`World`] when the system is run,
 locking out access to the underlying data to avoid violating the rules of the borrow checker.

--- a/content/learn/book/storing-data/local-system-param.md
+++ b/content/learn/book/storing-data/local-system-param.md
@@ -18,7 +18,7 @@ However, from time to time, you might want to:
 
 Bevy itself uses `Local` system params in two prominent places:
 
-1. As part of the [`EventReader`] abstraction, keeping track of which events each system has read.
+1. As part of the [`MessageReader`] abstraction, keeping track of which events each system has read.
 2. In run conditions like [`on_timer`], to track how much time has run.
 
 ## Starting values
@@ -45,7 +45,7 @@ fn increment_local_system_data(mut local: Local<Option<NoGoodDefaultValue>>){
 }
 ```
 
-[`Local<T>`]: https://docs.rs/bevy/0.16.0/bevy/ecs/system/struct.Local.html
+[`Local<T>`]: https://docs.rs/bevy/latest/bevy/ecs/system/struct.Local.html
 [resource]: [./resources.md]
-[`EventReader`]: https://docs.rs/bevy/latest/bevy/ecs/event/struct.EventReader.html
+[`MessageReader`]: https://docs.rs/bevy/latest/bevy/ecs/message/struct.MessageReader.html
 [`on_timer`]: https://docs.rs/bevy/latest/bevy/time/common_conditions/fn.on_timer.html

--- a/content/learn/book/the-game-loop/time-and-timers.md
+++ b/content/learn/book/the-game-loop/time-and-timers.md
@@ -90,10 +90,8 @@ fn toggle_pause(mut time: ResMut<Time<Virtual>>) {
 #[derive(Event)]
 struct SetGameSpeed(f32);
 
-fn set_game_speed(mut time: ResMut<Time<Virtual>>, events: EventReader<SetGameSpeed>) {
-    if let Some(new_speed) = events.iter().last() {
-        time.set_relative_speed(new_speed.0);
-    }
+fn set_game_speed(new_speed: On<SetGameSpeed>, mut time: ResMut<Time<Virtual>>) {
+    time.set_relative_speed(new_speed.0);
 }
 ```
 


### PR DESCRIPTION
In bevy 0.17  `EventReader/-Writer` was split into two separate APIs, but the book still had the old terminology.

Two of the changes are just renames, I also verified that `MessageReader` still uses `Local`.
In the chapter on timers I decided that using `Event` instead of `Message` is probably the right decision, despite the system previously using `EventReader`, as changing the game speed doesn't seem like it would be a frequent occurence in most applications and therefore not in need of the additional buffering `Message` provides