### PR TITLE
Control Flow Book Pages Polish & Edits

### DIFF
--- a/content/learn/book/control-flow/change-detection.md
+++ b/content/learn/book/control-flow/change-detection.md
@@ -122,6 +122,7 @@ fn detect_removed_position(mut removed: RemovedComponents<Position>) {
 {% callout(type="warning") %}
 It's generally better to use an [`OnRemove`] observer or a component hook to detect removals.
 This has a number of advantages over using [`RemovedComponents`]:
+
 - You get access to the component values being removed.
 - [`RemovedComponents`] can miss component removals when used in [`FixedUpdate`].
 {% end %}
@@ -134,7 +135,7 @@ Bevy does not provide any API for detecting when resources are removed.
 
 ## What Gets Detected?
 
-Change detection is triggered when a component or resource is mutably dereferenced. 
+Change detection is triggered when a component or resource is mutably dereferenced.
 [`Mut<T>`] and [`ResMut<T>`] implement `DerefMut`, with an implementation that marks the item as changed.
 
 Simply reading components via a mutable query, or resources via [`ResMut`], will _not_ trigger change detection.
@@ -182,7 +183,7 @@ fn update_player_health(mut query: Query<(Entity, &mut Health), With<Player>>) {
 }
 ```
 
-Change detection applies to each ECS system separately. 
+Change detection applies to each ECS system separately.
 A system will see whatever changes occurred since the last time the system ran.
 This includes systems that only run sometimes (such as when using [states] or [run conditions]), so you do not need to worry about "missing" changes.
 

--- a/content/learn/book/control-flow/change-detection.md
+++ b/content/learn/book/control-flow/change-detection.md
@@ -6,14 +6,12 @@ weight = 8
 status = 'hidden'
 +++
 
-Change detection is built into Bevy's Entity Component System (ECS). Each time a
-[`Component`] or [`Resource`] is modified, Bevy marks the item as changed. This mechanism helps
-optimize performance by avoiding unnecessary calculations when no relevant changes have
-occurred. Change detection can also be used to trigger actions in response to changes, such as
-synchronizing data between two contexts.
+Change detection is built into Bevy's Entity Component System (ECS).
+Each time a [`Component`] or [`Resource`] is modified, Bevy marks the item as changed.
+This mechanism helps optimize performance by avoiding unnecessary calculations when no relevant changes have occurred.
+Change detection can also be used to trigger actions in response to changes, such as synchronizing data between two contexts.
 
-In this section, we'll explore how Bevy tracks changes and how you can leverage this
-feature in your game development workflow.
+In this section, we'll explore how Bevy tracks changes and how you can leverage this feature in your game development workflow.
 
 [`Component`]: https://docs.rs/bevy/latest/bevy/ecs/component/trait.Component.html
 [`Resource`]: https://docs.rs/bevy/latest/bevy/prelude/trait.Resource.html
@@ -22,12 +20,11 @@ feature in your game development workflow.
 
 You can configure queries to filter out entities unless certain components have been modified.
 
-The [`Added<T>`] query filter detects new component instances, either if the component was added to
-an existing entity, or a new entity with that component was spawned.
+The [`Added<T>`] query filter detects new component instances, either if the component was added to an existing entity, or a new entity with that component was spawned.
 This is also triggered if a component is reinserted on an entity that already had it.
 
-The [`Changed<T>`] query filter detects when a component has been changed. Adding a new component
-counts as "changed" - in otherwords, this is a superset of [`Added<T>`].
+The [`Changed<T>`] query filter detects when a component has been changed.
+Adding a new component counts as "changed" - in otherwords, this is a superset of [`Added<T>`].
 
 ```rust
 // Detecting added components
@@ -50,18 +47,15 @@ fn detect_changed_position(query: Query<(Entity, &Position), Changed<Position>>)
 
 Removing components works differently, see the section below.
 
-## Checking for changes
+## Checking For Changes
 
-In some cases, you may want to know whether or not an entity's components have changed, but at
-the same time want to access all the entities, even the ones that have _not_ changed.
+In some cases, you may want to know whether or not an entity's components have changed, but at the same time want to access all the entities, even the ones that have _not_ changed.
 
-You can use the special [`Ref<T>`] query parameter instead of `&` for immutable access. This provides
-methods [`.is_changed()`] and [`.is_added()`] which return true if the component was changed or
-added, respectively.
+You can use the special [`Ref<T>`] query parameter instead of `&` for immutable access.
+This provides methods [`.is_changed()`] and [`.is_added()`] which return true if the component was changed or added, respectively.
 
-For mutable access, you don't need to do anything special to get the change detection methods. Using
-`&mut` in a query parameter causes Bevy to use the special [`Mut<T>`] type, which also supports change
-detection.
+For mutable access, you don't need to do anything special to get the change detection methods.
+Using `&mut` in a query parameter causes Bevy to use the special [`Mut<T>`] type, which also supports change detection.
 
 ```rust
 // Using Ref<T> for change detection with immutable access
@@ -87,13 +81,8 @@ fn check_and_update_position(mut query: Query<(Entity, Mut<Position>)>) {
 ```
 
 {% callout(type="info") %}
-Performance-wise, there's no real difference between using query filters and using the change
-detection methods: The [`Added<T>`] and [`Changed<T>`] query filters cause the iterator to skip
-over entities that have not changed, but they don't reduce the number of entities that get fetched
-by the query.
-
-[`Changed<T>`]: https://docs.rs/bevy/latest/bevy/ecs/query/struct.Changed.html
-[`Added<T>`]: https://docs.rs/bevy/latest/bevy/ecs/query/struct.Added.html
+Performance-wise, there's no real difference between using query filters and using the change detection methods.
+The [`Added<T>`] and [`Changed<T>`] query filters cause the iterator to skip over entities that have not changed, but they don't reduce the number of entities that get fetched by the query.
 {% end %}
 
 [`Ref<T>`]: https://docs.rs/bevy/latest/bevy/ecs/change_detection/struct.Ref.html
@@ -103,8 +92,7 @@ by the query.
 
 ## Resources
 
-The [`Res<T>`] and [`ResMut<T>`] provide the same [`.is_added()`] and [`.is_changed()`] methods as
-components do:
+The [`Res<T>`] and [`ResMut<T>`] provide the same [`.is_added()`] and [`.is_changed()`] methods as components do:
 
 ```rust
 fn detect_changed_score(score: Res<Score>) {
@@ -119,8 +107,7 @@ fn detect_changed_score(score: Res<Score>) {
 
 ## Removed Components
 
-Change detection works differently for removed components, since the component (and possibly the
-entity) no longer exists!
+Change detection works differently for removed components, since the component (and possibly the entity) no longer exists!
 
 To detect when components are removed, you can use the [`RemovedComponents`] param:
 
@@ -135,26 +122,23 @@ fn detect_removed_position(mut removed: RemovedComponents<Position>) {
 {% callout(type="warning") %}
 It's generally better to use an [`OnRemove`] observer or a component hook to detect removals.
 This has a number of advantages over using [`RemovedComponents`]:
-
 - You get access to the component values being removed.
 - [`RemovedComponents`] can miss component removals when used in [`FixedUpdate`].
+{% end %}
 
 [`RemovedComponents`]: https://docs.rs/bevy/latest/bevy/ecs/lifecycle/struct.RemovedComponents.html
 [`OnRemove`]: https://docs.rs/bevy/latest/bevy/ecs/component/trait.Component.html#adding-components-hooks
 [`FixedUpdate`]: https://docs.rs/bevy/latest/bevy/app/struct.FixedUpdate.html
-{% end %}
 
 Bevy does not provide any API for detecting when resources are removed.
 
-[`RemovedComponents`]: https://docs.rs/bevy/latest/bevy/ecs/lifecycle/struct.RemovedComponents.html
+## What Gets Detected?
 
-## What gets detected?
+Change detection is triggered when a component or resource is mutably dereferenced. 
+[`Mut<T>`] and [`ResMut<T>`] implement `DerefMut`, with an implementation that marks the item as changed.
 
-Change detection is triggered when a component or resource is mutably dereferenced. [`Mut<T>`] and
-[`ResMut<T>`] implement `DerefMut`, with an implementation that marks the item as changed.
-
-Simply reading components via a mutable query, or resources via [`ResMut`], will _not_ trigger change
-detection. But dereferencing the component, or taking a mutable borrow, will.
+Simply reading components via a mutable query, or resources via [`ResMut`], will _not_ trigger change detection.
+But dereferencing the component, or taking a mutable borrow, will.
 
 ```rust
 fn update_player_health(mut query: Query<(Entity, &mut Health), With<Player>>) {
@@ -169,9 +153,9 @@ fn update_player_health(mut query: Query<(Entity, &mut Health), With<Player>>) {
 }
 ```
 
-When you mutate a component, Bevy does not check whether the old value is actually different from
-the new value - it will always trigger change detection. If you want to avoid that, you'll need
-to check it yourself:
+Mutating a component will _always_ trigger change detection.
+Bevy does not check whether the old value is actually different from the new value.
+If you want to avoid that, you'll need to check it yourself:
 
 ```rust
 fn update_player_health(mut query: Query<(Entity, &mut Health), With<Player>>) {
@@ -185,8 +169,8 @@ fn update_player_health(mut query: Query<(Entity, &mut Health), With<Player>>) {
 }
 ```
 
-You can also use the [`set_if_neq()`] and similar helper methods for this, which update the component
-only if the new value is different (this requires that the component support `PartialEq`):
+You can also use the [`set_if_neq()`] and similar helper methods to simplify this task.
+These helper methods update the component only if the new value is different (this requires that the component support `PartialEq`).
 
 ```rust
 fn update_player_health(mut query: Query<(Entity, &mut Health), With<Player>>) {
@@ -198,19 +182,22 @@ fn update_player_health(mut query: Query<(Entity, &mut Health), With<Player>>) {
 }
 ```
 
-Change detection applies to each ECS system separately: a system will see whatever changes occurred
-since the last time the system ran. This includes systems that only run sometimes (such as when
-using [states] or [run conditions]), so you do not need to worry about "missing" changes.
+Change detection applies to each ECS system separately. 
+A system will see whatever changes occurred since the last time the system ran.
+This includes systems that only run sometimes (such as when using [states] or [run conditions]), so you do not need to worry about "missing" changes.
 
 {% callout(type="info") %}
-Internally, Bevy stores an "engine tick count" with every component and resource that marks the
-last time that it was updated. When a system calls `.is_changed()`, it compares the tick count
-of the component with the tick count of the last time the system was run.
+Internally, Bevy stores an "engine tick count" with every component and resource that marks the last time that it was updated.
+When a system calls `.is_changed()`, it compares the tick count of the component with the tick count of the last time the system was run.
 {% end %}
 
-One thing to beware of is potential 1-frame delay, if the system that is causing the change
-runs after the system that is checking for changes. You may need to pay attention to how you [run schedules]
-or use [explicit system ordering] to prevent this.
+One thing to beware of is potential 1-frame delay, if the system that is causing the change runs after the system that is checking for changes.
+You may need to pay attention to how you [run schedules] or use [explicit system ordering] to prevent this.
+
+[states]: ../states
+[run conditions]: ../run-conditions#run-conditions
+[run schedules]: ../../the-game-loop/schedules
+[explicit system ordering]: ../run-conditions
 
 [`set_if_neq()`]: https://docs.rs/bevy/latest/bevy/ecs/change_detection/trait.DetectChangesMut.html#method.set_if_neq
 [`ResMut`]: https://docs.rs/bevy/latest/bevy/ecs/system/struct.ResMut.html

--- a/content/learn/book/control-flow/commands.md
+++ b/content/learn/book/control-flow/commands.md
@@ -6,7 +6,7 @@ weight = 5
 status = 'hidden'
 +++
 
-When we want to make structural changes to our application, we require mutable access to the `World`. 
+When we want to make structural changes to our application, we require mutable access to the `World`.
 Since only one system can mutably access the `World` at a time, we need a way to organize that access.
 **Commands** allow us to do just that.
 Each [`Command`] represents an instruction for manipulations to be performed on the world, and when we call a `Command` it gets placed in the **Command Queue**.

--- a/content/learn/book/control-flow/commands.md
+++ b/content/learn/book/control-flow/commands.md
@@ -6,7 +6,11 @@ weight = 5
 status = 'hidden'
 +++
 
-When we want to make structural changes to our application, we require mutable access to the `World`. Since only one system can mutably access the `World` at a time, we need a way to organize that access. **Commands** allow us to do just that. Each [`Command`] represents an instruction for manipulations to be performed on the world, and when we call a `Command` it gets placed in the **Command Queue**. All [`Commands`] in this queue are then ran at a specific time when we're safely able to mutably access the `World`.
+When we want to make structural changes to our application, we require mutable access to the `World`. 
+Since only one system can mutably access the `World` at a time, we need a way to organize that access.
+**Commands** allow us to do just that.
+Each [`Command`] represents an instruction for manipulations to be performed on the world, and when we call a `Command` it gets placed in the **Command Queue**.
+All [`Commands`] in this queue are then ran at a specific time when we're safely able to mutably access the `World`.
 
 Many operations in the ECS can *only* be done via exclusive world access, such as:
 
@@ -47,7 +51,8 @@ commands.run_schedule(schedule);
 commands.trigger(event); 
 ```
 
-To use `Commands` in your systems, it is easiest to pass it in as a system parameter. This ensures that every system that needs access to `Commands` gets it and that all of the `Commands` that are called are placed into the `Command` queue.
+To use `Commands` in your systems, it is easiest to pass it in as a system parameter.
+This ensures that every system that needs access to `Commands` gets it and that all of the `Commands` that are called are placed into the `Command` queue.
 
 ```rust
 fn my_system(mut commands: Commands) {
@@ -59,7 +64,11 @@ fn my_system(mut commands: Commands) {
 }
 ```
 
-While Bevy offers a number of different pre-defined `Commands` to use, it also offers the [`queue`] method to make changes that aren't provided by default. `queue` gives us mutable access to the `World`, which we can use however we want. The most straightforward approach is to construct our modifications within the method itself, as can be seen in the example below. You can also go one step further and create *custom* commands by implementing the `Command` trait on a struct you create, or even extend the `Commands` struct with traits and methods that you define and implement yourself. We'll go more into this aspect further down the page in [Custom Commands].
+While Bevy offers a number of different pre-defined `Commands` to use, it also offers the [`queue`] method to make changes that aren't provided by default.
+`queue` gives us mutable access to the `World`, which we can use however we want.
+The most straightforward approach is to construct our modifications within the method itself, as can be seen in the example below.
+You can also go one step further and create *custom* commands by implementing the `Command` trait on a struct you create, or even extend the `Commands` struct with traits and methods that you define and implement yourself.
+We'll go more into this aspect further down the page in [Custom Commands].
 
 ```rust
 // A custom Resource
@@ -82,7 +91,10 @@ fn add_twenty_five_to_counter_system(mut commands: Commands) {
 
 ## When Do Commands Take Effect?
 
-`Commands` allow users to queue up changes as part of systems, deferring the work until later to avoid disrupting both system parallelism and data-oriented access of `Components`. Specifically, by default `Commands` are applied whenever a [`Schedule`] is completed. Ordinarily, this will occur multiple times during and after each frame. As a result, systems will always see the effects of `Commands` queued by systems in other schedules.
+`Commands` allow users to queue up changes as part of systems, deferring the work until later to avoid disrupting both system parallelism and data-oriented access of `Components`.
+Specifically, by default `Commands` are applied whenever a [`Schedule`] is completed.
+Ordinarily, this will occur multiple times during and after each frame.
+As a result, systems will always see the effects of `Commands` queued by systems in other schedules.
 
 ```rust
 // An Event we want to trigger.
@@ -106,11 +118,20 @@ fn update_system(mut commands: Commands) {
 }
 ```
 
-In the above example, we have two systems: `insert_observer_system` running in the `Startup` schedule, and `update_system` running in the `Update` schedule. Since the `Startup` schedule only runs once, the `add_observer()` command is only ran when our application is launched. However a `trigger()` command is queued everytime the `Update` schedule runs, meaning that a `trigger()` command is ran every time the `Update` schedule completes.
+In the above example, we have two systems: `insert_observer_system` running in the `Startup` schedule, and `update_system` running in the `Update` schedule.
+Since the `Startup` schedule only runs once, the `add_observer()` command is only ran when our application is launched.
+However a `trigger()` command is queued everytime the `Update` schedule runs, meaning that a `trigger()` command is ran every time the `Update` schedule completes.
 
-We mentioned above that by default `Commands` are applied at the *end* of a `Schedule`. While correct, what really happens is that all of the `Commands` we queue are placed into a special `System` known as [`ApplyDeferred`]. This system will run at the end of every `Schedule` that has a system which uses `Commands` as a `SystemParameter`. Since `ApplyDeferred` is ran after all of systems in a given schedule, all of the changes made by the `ApplyDeferred` system are able to be seen by the systems in other schedules.
+We mentioned above that by default `Commands` are applied at the *end* of a `Schedule`.
+While correct, what really happens is that all of the `Commands` we queue are placed into a special `System` known as [`ApplyDeferred`].
+This system will run at the end of every `Schedule` that has a system which uses `Commands` as a `SystemParameter`.
+Since `ApplyDeferred` is ran after all of systems in a given schedule, all of the changes made by the `ApplyDeferred` system are able to be seen by the systems in other schedules.
 
-In addition, if a system accessing `Commands` is ordered before another system also accessing `Commands` in the same `Schedule`, the second system will always see the effects of `Commands` run in the first system. Bevy ensures this occurs by dynamically inserting synchronization points, during which all `Commands` are applied. Each system can hold their own copy of `Commands` in their local system state. When `Commands` are applied, these queues are evaluated as in the same order that the systems were run. Within each system, the `Commands` are applied in a first-in-first-out order.
+In addition, if a system accessing `Commands` is ordered before another system also accessing `Commands` in the same `Schedule`, the second system will always see the effects of `Commands` run in the first system.
+Bevy ensures this occurs by dynamically inserting synchronization points, during which all `Commands` are applied.
+Each system can hold their own copy of `Commands` in their local system state.
+When `Commands` are applied, these queues are evaluated as in the same order that the systems were run.
+Within each system, the `Commands` are applied in a first-in-first-out order.
 
 ```rust
 // Add our Systems in the same Schedule, but placed in a specific order.
@@ -142,7 +163,9 @@ fn remove_the_component(mut commands: Commands, mut player: Single<Entity, With<
 
 ## Entity Commands
 
-Apart from making changes to the `World`, `Commands` are also used when making structural changes to `Entities`. When applying changes to a single entity, the [`Commands`] type is transformed into [`EntityCommands`] via [`Commands::entity`]. While the `Command` trait can have arbitrary effects on the `World`, the [`EntityCommand`] trait is designed to modify a single entity.
+Apart from making changes to the `World`, `Commands` are also used when making structural changes to `Entities`.
+When applying changes to a single entity, the [`Commands`] type is transformed into [`EntityCommands`] via [`Commands::entity`].
+While the `Command` trait can have arbitrary effects on the `World`, the [`EntityCommand`] trait is designed to modify a single entity.
 
 ```rust
 // Marker Component for a Player.
@@ -163,7 +186,9 @@ let player_commands = commands.entity(player);
 player_commands.insert_if_new((Health(10)));
 ```
 
-Like `Commands`, `EntityCommands` aren't run immediately. This means that it is possible for the `Entity` you want to modify to have despawned before the `EntityCommand` can be ran. All `EntityCommands` will check whether the `Entity` exists when the `EntityCommand` is ran and will return an error if it doesn't.
+Like `Commands`, `EntityCommands` aren't run immediately.
+This means that it is possible for the `Entity` you want to modify to have despawned before the `EntityCommand` can be ran.
+All `EntityCommands` will check whether the `Entity` exists when the `EntityCommand` is ran and will return an error if it doesn't.
 
 [`EntityCommands`]: https://docs.rs/bevy/latest/bevy/prelude/struct.EntityCommands.html
 [`Commands::entity`]: https://docs.rs/bevy/latest/bevy/ecs/prelude/struct.Commands.html#method.entity
@@ -171,7 +196,10 @@ Like `Commands`, `EntityCommands` aren't run immediately. This means that it is 
 
 ## Parallel Commands
 
-We stated above that `World` can only be mutably accessed by one system at a time, and while that is still true, that doesn't mean that we can't access and make *multiple* changes at the same time. As long as the changes we want to make are not reliant on each other, we can use [`ParallelCommands`] to achieve this. A great example of this can be seen when dealing with `Queries`. Specifically, we can use [`Query::par_iter_mut`] along with `ParallelCommands` and it's method [`command_scope`] to perform structural changes to each `Entity` in a given `Query`.
+We stated above that `World` can only be mutably accessed by one system at a time, and while that is still true, that doesn't mean that we can't access and make *multiple* changes at the same time.
+As long as the changes we want to make are not reliant on each other, we can use [`ParallelCommands`] to achieve this.
+A great example of this can be seen when dealing with `Queries`.
+Specifically, we can use [`Query::par_iter_mut`] along with `ParallelCommands` and it's method [`command_scope`] to perform structural changes to each `Entity` in a given `Query`.
 
 ```rust
 // A marker Component that indicates an Entity is going very fast.
@@ -201,9 +229,14 @@ fn parallel_command_system(
 
 ## Custom Commands
 
-By now you should be able to see that `Commands` are just a series of queued changes that affect some part of the `World`. Bevy provides many `Commands` methods that you can easily take advantage of, however it is also possible (and can even be simple!) to build your own **Custom Commands**. Because of their flexible nature, custom commands are a powerful tool for implementing game-specific operations. While they may not be as fast or transparent as working with [`Events` and `Observers`], the arbitrary flexibility can be great for quickly evolving game logic and performing operations atomically.
+By now you should be able to see that `Commands` are just a series of queued changes that affect some part of the `World`.
+Bevy provides many `Commands` methods that you can easily take advantage of, however it is also possible (and can even be simple!) to build your own **Custom Commands**.
+Because of their flexible nature, custom commands are a powerful tool for implementing game-specific operations.
+While they may not be as fast or transparent as working with [`Events` and `Observers`], the arbitrary flexibility can be great for quickly evolving game logic and performing operations atomically.
 
-Writing custom commands is quite simple: create a struct and implement `Command` for it. If you want to pass in data, add fields to your struct. To send a custom command, simply call `commands.queue(CustomCommandStruct { my_data })`.
+Writing custom commands is quite simple: create a struct and implement `Command` for it.
+If you want to pass in data, add fields to your struct.
+To send a custom command, simply call `commands.queue(CustomCommandStruct { my_data })`.
 
 ```rust
 // A custom Resource
@@ -228,9 +261,13 @@ fn some_system(mut commands: Commands) {
 }
 ```
 
-At the top of the page we used the `queue` method to perform some changes on the `World`. In the above example we took that same premise and extended it into a full custom command. Creating custom commands can help reduce the amount of boilerplate code you write, especially if you know that you need to repeat that code at multiple points.
+At the top of the page we used the `queue` method to perform some changes on the `World`.
+In the above example we took that same premise and extended it into a full custom command.
+Creating custom commands can help reduce the amount of boilerplate code you write, especially if you know that you need to repeat that code at multiple points.
 
-You can make this pattern even more ergonomic by writing an extension trait for the `Commands` type, allowing you to call new methods as long as the extension trait is imported. Calling `commands.custom_command(my_data)` is shorter and plays nicer with auto-complete, however this approach has no functional benefit or cost; it's simply a matter of style. These same strategies can also be applied for the `EntityCommand` trait and the `EntityCommands` struct.
+You can make this pattern even more ergonomic by writing an extension trait for the `Commands` type, allowing you to call new methods as long as the extension trait is imported.
+Calling `commands.custom_command(my_data)` is shorter and plays nicer with auto-complete, however this approach has no functional benefit or cost; it's simply a matter of style.
+These same strategies can also be applied for the `EntityCommand` trait and the `EntityCommands` struct.
 
 ```rust
 // A custom Resource

--- a/content/learn/book/control-flow/events.md
+++ b/content/learn/book/control-flow/events.md
@@ -27,7 +27,7 @@ struct Speak {
 }
 ```
 
-2. Add an [`Observer`] to the `World` that will watch for our event:
+1. Add an [`Observer`] to the `World` that will watch for our event:
 
 ```rust
 // To add the observer immediately:
@@ -41,7 +41,7 @@ commands.add_observer(|speak: On<Speak>| {
 });
 ```
 
-3. Trigger the `Speak` event:
+1. Trigger the `Speak` event:
 
 ```rust
 // To trigger the event immediately:

--- a/content/learn/book/control-flow/lifecycle-events.md
+++ b/content/learn/book/control-flow/lifecycle-events.md
@@ -8,9 +8,12 @@ status = 'hidden'
 
 <!-- TBW -->
 
-In the previous chapter we learned about `Events` and how they allow us to run code in the `World` or on a specific `Entity` in response to a trigger condition. We can extend this concept by using **Lifecycle Events** to run code in response to altering a `Component` within an `Entity`. Lifecycle events are still `Events`, but specifically they are `EntityEvents` meaning that they will have an `event_target` which determines the `Entity` being targeted.
+In the previous chapter we learned about `Events` and how they allow us to run code in the `World` or on a specific `Entity` in response to a trigger condition. 
+We can extend this concept by using **Lifecycle Events** to run code in response to altering a `Component` within an `Entity`.
+Lifecycle events are still `Events`, but specifically they are `EntityEvents` meaning that they will have an `event_target` which determines the `Entity` being targeted.
 
-Within Bevy we currently have access to five distinct lifecycle events: `Add`, `Insert`, `Replace`, `Remove`, and `Despawn`. We can split these into two categories: lifecycle events that trigger when a `Component` is *added* to an `Entity`, and lifecycle events that trigger when a `Component` is *removed* from an `Entity`.
+Within Bevy we currently have access to five distinct lifecycle events: `Add`, `Insert`, `Replace`, `Remove`, and `Despawn`.
+We can split these into two categories: lifecycle events that trigger when a `Component` is *added* to an `Entity`, and lifecycle events that trigger when a `Component` is *removed* from an `Entity`.
 
 On adding a `Component`:
 
@@ -23,7 +26,9 @@ On removing/altering a `Component`:
 - [`Remove`] triggers when a component is removed from an `Entity` *and not replaced*. (This also happens before the component is actually removed.)
 - [`Despawn`] triggered on *each* component on an `Entity` when the `Entity` is *despawned*.
 
-It's also important to know that lifecycle events have an order in which they are evaluated. When both `Add` and `Insert` occur, `Add` hooks are evaluated before `Insert` hooks. `Replace` hooks are evaluated before `Remove` hooks, and `Despawn` hooks are evaluated last.
+It's also important to know that lifecycle events have an order in which they are evaluated.
+When both `Add` and `Insert` occur, `Add` hooks are evaluated before `Insert` hooks.
+`Replace` hooks are evaluated before `Remove` hooks, and `Despawn` hooks are evaluated last.
 
 [`Add`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Add.html
 [`Insert`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Insert.html
@@ -33,7 +38,8 @@ It's also important to know that lifecycle events have an order in which they ar
 
 ## Component Hooks
 
-The most common way of interacting with lifecycle events is by using [`ComponentHooks`]. We have a couple ways to use `ComponentHooks`, the first of which is through the [`World::register_component_hook`] method.
+The most common way of interacting with lifecycle events is by using [`ComponentHooks`].
+We have a couple ways to use `ComponentHooks`, the first of which is through the [`World::register_component_hook`] method.
 
 ```rust
 // Create a ComponentHook with the `World` method:
@@ -47,7 +53,9 @@ world.register_component_hooks::<MyComponent>().on_add(|add| {
 });
 ```
 
-This method allows us to enable the `ComponentHook` within a system at any point. It's especially helpful if we only need to add a `ComponentHook` to a `Component` after a certain point in time or under certain conditions. However, if we know that every time a `Component` is modified we want to run a `ComponentHook`, then we can use the `component` attribute:
+This method allows us to enable the `ComponentHook` within a system at any point.
+It's especially helpful if we only need to add a `ComponentHook` to a `Component` after a certain point in time or under certain conditions.
+However, if we know that every time a `Component` is modified we want to run a `ComponentHook`, then we can use the `component` attribute:
 
 ```rust
 // Create a ComponentHook with an attribute:
@@ -61,7 +69,8 @@ fn hook_function(world: DeferredWorld, component_hook: HookContext) {
 }
 ```
 
-By deriving the `component` attribute on `MyComponent` and pointing to the function that should be run when `MyComponent` is modified, we can ensure that our lifecycle event is ran every time `MyComponent` is added. Using an attribute can also be further extended through closures if we want to avoid repeating similar code:
+By deriving the `component` attribute on `MyComponent` and pointing to the function that should be run when `MyComponent` is modified, we can ensure that our lifecycle event is ran every time `MyComponent` is added.
+Using an attribute can also be further extended through closures if we want to avoid repeating similar code:
 
 ```rust
 // Multiple ComponentHooks with a closure:
@@ -102,7 +111,11 @@ impl MyComponent {
 
 ## Lifecycle Observers
 
-We can also use regular `Observers` to react to lifecycle events. Like we mentioned above, lifecycle events are `EntityEvents` which means they will carry an `event_target` identifying what `Entity` is being targeted. However, we don't have to specify it like we do with regular `EntityEvents`. Instead, by including the target `Component` inside of the `Trigger` we are telling the `Observer` to run whenever our target `Component` is altered on any `Entity`. When this happens, the `event_target` of the `EntityEvent` is filled by the `Entity` with the target `Component` being altered.
+We can also use regular `Observers` to react to lifecycle events.
+Like we mentioned above, lifecycle events are `EntityEvents` which means they will carry an `event_target` identifying what `Entity` is being targeted.
+However, we don't have to specify it like we do with regular `EntityEvents`.
+Instead, by including the target `Component` inside of the `Trigger` we are telling the `Observer` to run whenever our target `Component` is altered on any `Entity`.
+When this happens, the `event_target` of the `EntityEvent` is filled by the `Entity` with the target `Component` being altered.
 
 ```rust
 #[derive(Component)]
@@ -116,9 +129,12 @@ world.add_observer(|add: On<Add, MyComponent>| {
 
 ### Observers Vs ComponentHooks
 
-While it is possible to interact with lifecycle events through `Observers`, it might not always be the smoothest way. Since lifecycle events exclusively deal with `Components`, it is usually more intuitive to use `ComponentHooks` instead.
+While it is possible to interact with lifecycle events through `Observers`, it might not always be the smoothest way.
+Since lifecycle events exclusively deal with `Components`, it is usually more intuitive to use `ComponentHooks` instead.
 
-Consider the following use case. We want to spawn an `Entity` with a `PlayerName` component and print the value inside `PlayerName` to the console upon creation. Using `Observers`, we'd have to structure our code like such:
+Consider the following use case.
+We want to spawn an `Entity` with a `PlayerName` component and print the value inside `PlayerName` to the console upon creation.
+Using `Observers`, we'd have to structure our code like such:
 
 ```rust
 // First we create our Component.
@@ -138,9 +154,12 @@ commands.spawn((
 ));
 ```
 
-Note that we have to explicitly add the `Observer` before we could print out the value inside `PlayerName`. While this seems obvious in this context, it becomes easy to overlook if our `Observer` isn't added in the same `System` that our `PlayerName` component is spawned in. If our `Observer` wasn't added to the `World`, or was despawned for some reason, we wouldn't get the `PlayerName` value printed out like we want.
+Note that we have to explicitly add the `Observer` before we could print out the value inside `PlayerName`.
+While this seems obvious in this context, it becomes easy to overlook if our `Observer` isn't added in the same `System` that our `PlayerName` component is spawned in.
+If our `Observer` wasn't added to the `World`, or was despawned for some reason, we wouldn't get the `PlayerName` value printed out like we want.
 
-`ComponentHooks` can fix this issue by tying `PlayerName` to an `Add` lifecycle event (or any other lifecycle event). Instead of relying on an `Observer` to be present and to react to our lifecycle event, the `World` will react for us whenever it sees the `Component` we specify being modified in some way.
+`ComponentHooks` can fix this issue by tying `PlayerName` to an `Add` lifecycle event (or any other lifecycle event).
+Instead of relying on an `Observer` to be present and to react to our lifecycle event, the `World` will react for us whenever it sees the `Component` we specify being modified in some way.
 
 ```rust
 // First we create our Component.
@@ -181,13 +200,17 @@ world.register_component_hooks::<PlayerName>().on_add(|mut world, context| {
 
 ## Other Lifecycle Interactions
 
-In earlier chapters, we went over several lifecycle event interactions without specifically naming them as lifecycle events. This is because they aren't used in the same manner as we've been using them so far. However they are still lifecycle event interactions, so we will briefly return to them to show the differences between them and the tools introduced in this chapter.
+In earlier chapters, we went over several lifecycle event interactions without specifically naming them as lifecycle events.
+This is because they aren't used in the same manner as we've been using them so far.
+However they are still lifecycle event interactions, so we will briefly return to them to show the differences between them and the tools introduced in this chapter.
 
 ### Removed Components Parameter
 
-The [`RemovedComponents`] system parameter can be used to access a list of `Entities` that had a specific `Component` removed. Notably this includes `Entities` that were also *despawned* with the target `Component`, meaning that any `Entity` included in `RemovedComponents` might not exist in the `World` when accessed.
+The [`RemovedComponents`] system parameter can be used to access a list of `Entities` that had a specific `Component` removed.
+Notably this includes `Entities` that were also *despawned* with the target `Component`, meaning that any `Entity` included in `RemovedComponents` might not exist in the `World` when accessed.
 
-The biggest difference when using `RemovedComponents` is that you cannot access or see any of the data that was removed. Instead, this system parameter acts like a [`MessageReader`], displaying which `Entities` were despawned with or had the target `Component` removed.
+The biggest difference when using `RemovedComponents` is that you cannot access or see any of the data that was removed.
+Instead, this system parameter acts like a [`MessageReader`], displaying which `Entities` were despawned with or had the target `Component` removed.
 
 ```rust
 // This system can print out each Entity in `removed`, but we can't access the 
@@ -206,7 +229,8 @@ world.register_component_hooks::<MyComponent>().on_remove(|mut world, remove| {
 });
 ```
 
-By default, `RemovedComponents` is automatically cleared on every `World` update. We can also manually clear `RemovedComponents` by using the [`World::clear_trackers`] method.
+By default, `RemovedComponents` is automatically cleared on every `World` update.
+We can also manually clear `RemovedComponents` by using the [`World::clear_trackers`] method.
 
 [`RemovedComponents`]: https://docs.rs/bevy/latest/bevy/prelude/struct.RemovedComponents.html
 [`MessageReader`]: https://docs.rs/bevy/latest/bevy/prelude/struct.MessageReader.html
@@ -214,7 +238,10 @@ By default, `RemovedComponents` is automatically cleared on every `World` update
 
 ### Added Query Filter
 
-The [`Added`] query filter can be used to see `Entities` that have had a new instance of a specific `Component` added to them for the first time. Much like `RemovedComponents` though, `Added` can only be accessed after the lifecycle event occurs. Additionally `Added` is less precise, returning `Entities` that had a target `Component` added for the first time and `Entities` that had a target `Component` reinserted, even if the component already existed. In effect, this combines both the `Add` and `Insert` lifecycle events, which can be an important distinction depending on the functionality you want to run.
+The [`Added`] query filter can be used to see `Entities` that have had a new instance of a specific `Component` added to them for the first time.
+Much like `RemovedComponents` though, `Added` can only be accessed after the lifecycle event occurs.
+Additionally `Added` is less precise, returning `Entities` that had a target `Component` added for the first time and `Entities` that had a target `Component` reinserted, even if the component already existed.
+In effect, this combines both the `Add` and `Insert` lifecycle events, which can be an important distinction depending on the functionality you want to run.
 
 To show the differences, lets imagine we are building a networked multiplayer game where we want to track the following:
 

--- a/content/learn/book/control-flow/lifecycle-events.md
+++ b/content/learn/book/control-flow/lifecycle-events.md
@@ -8,7 +8,7 @@ status = 'hidden'
 
 <!-- TBW -->
 
-In the previous chapter we learned about `Events` and how they allow us to run code in the `World` or on a specific `Entity` in response to a trigger condition. 
+In the previous chapter we learned about `Events` and how they allow us to run code in the `World` or on a specific `Entity` in response to a trigger condition.
 We can extend this concept by using **Lifecycle Events** to run code in response to altering a `Component` within an `Entity`.
 Lifecycle events are still `Events`, but specifically they are `EntityEvents` meaning that they will have an `event_target` which determines the `Entity` being targeted.
 

--- a/content/learn/book/control-flow/run-conditions.md
+++ b/content/learn/book/control-flow/run-conditions.md
@@ -1,73 +1,70 @@
 +++
-title = "Skipping systems"
+title = "Skipping Systems"
 insert_anchor_links = "right"
 [extra]
 weight = 1
 status = 'hidden'
 +++
 
-Instead of simply returning early from a system, you can simply skip it entirely.
-This can simplify the logic of your systems, by separating concerns of "what a system does" from "should it run".
-
-In addition, because systems are run in parallel, skipping a system entirely can reduce the overhead involved,
-as they are cancelled before they are dispatched.
+Instead of returning early from a system, you could choose to skip it entirely.
+This can reduce the complexity of using your systems by separating concerns of _"what a system does"_ from _"should it run"_.
+Skipping a system entirely can also reduce the overhead involved since it would be cancelled before being dispatched.
+Systems are run in parallel by default, so skipping a system means your application would do less work overall if a system is skipped.
 
 Bevy offers two complementary ways to skip systems: **run conditions** and **fallible system parameters**.
 
-## Run conditions
+## Run Conditions
 
-Run conditions are functions that can be attached to systems via `.run_if` at the time that they are added to a schedule.
-Any read-only system which returns `bool` can be used as a run condition,
-allowing you to access information about the [`World`] and even store local state.
+Run conditions are functions that can be attached to systems via the [`.run_if()`] method at the time that they are added to a schedule.
+More specifically, any read-only system which returns `bool` can be used as a run condition.
+This allows you to access information about the [`World`] and even store local state when determining if a system should be run.
 
-For your convenience, Bevy comes with a set of premade run conditions,
-which can be found by searching for [common conditions] in the Bevy docs.
-Because these are domain-specific, they are defined as needed by various Bevy subcrates.
-They might allow you to [only run a system when a button is pressed],
-[run a system on a timer], or [run a system only when in a certain game state].
+For your convenience, Bevy comes with a set of premade run conditions, which can be found by searching for [common conditions] in the Bevy docs.
+These run conditions are domain-specific, thus they are defined as needed by various Bevy subcrates.
+They might allow you to [only run a system based on input being received], [run a system on a timer], or [run a system when in a certain game state].
 
-Most of these methods are not run conditions themselves:
-instead, they work by accepting a value, and then returning a function that can be used as a run condition.
+Most of these premade run conditions won't run on their own.
+Instead you'll have to provide them with a value which will then return a function that can be then be used as a run condition.
 
-Run conditions can be composed: by default, chaining multiple `.run_if` calls are composed via AND logic,
-but various boolean operations are provided by the [`SystemCondition`] trait.
+Run conditions can also be composed.
+You can chain multiple `.run_if()` calls using AND logic, but there are also various boolean operations provided by the [`SystemCondition`] trait.
 
-Run conditions can also be applied to multiple systems at once, using [system sets].
-If a system set is given a run condition, it will be evaluated once per frame for that system set,
-and the systems inside of it will be skipped if it returns true.
+Run conditions can also be applied to multiple systems at once by using a [`SystemSet`].
+If a system set is given a run condition, it will be evaluated once per frame for that system set and the systems inside of it will be skipped if it returns true.
 
-As a result, run conditions can be useful when working with systems that you do not own:
-they can be used to configure if (or under what conditions) these systems run
-as long as the crate author has publicly exposed either the system function or a system set that contains it.
+As a result, run conditions can be useful when working with systems that you do not own.
+They can be used to configure if (or under what conditions) these foreign systems should run as long as the crate author has publicly exposed either the system function or a system set that contains it.
 
+[`.run_if()`]: https://docs.rs/bevy/latest/bevy/prelude/trait.IntoScheduleConfigs.html#method.run_if
 [`World`]: https://docs.rs/bevy/latest/bevy/ecs/world/struct.World.html
+[common conditions]: https://docs.rs/bevy/latest/bevy/prelude/index.html?search=common_conditions
+[only run a system based on input being received]: https://docs.rs/bevy/latest/bevy/input/common_conditions/index.html
+[run a system on a timer]: https://docs.rs/bevy/latest/bevy/time/common_conditions/index.html
+[run a system when in a certain game state]: https://docs.rs/bevy/latest/bevy/ecs/schedule/common_conditions/index.html
 [`SystemCondition`]: https://docs.rs/bevy/latest/bevy/ecs/schedule/trait.SystemCondition.html
-[system sets]: https://docs.rs/bevy/latest/bevy/ecs/schedule/trait.SystemSet.html
+[`SystemSet`]: https://docs.rs/bevy/latest/bevy/ecs/schedule/trait.SystemSet.html
 
-## Fallible system parameters
+## Fallible System Parameters
 
-Every system parameter requires specific data:
-for example, `Res<T>` requires that `T` has been initialized as a resource.
+Every system parameter requires that some specific data is available in the `World`.
+For example, `Res<T>` requires that `T` has been initialized as a resource.
+If that data is not found, [`SystemParam`] authors can choose how to proceed:
 
-If that data is not found, [`SystemParam`] authors have a choice for how to proceed:
-they can either fail, or be gracefully skipped.
+- The system can fail and cause a panic,
+- Or the system can be gracefully skipped.
 
-The behavior when system params fail can be configured,
-as detailed in the [handling errors] section of this chapter,
-but by default, failed system parameters will cause a panic.
+You aren't locked into either panicking or skipping though.
+When system params fail the resulting behavior can be configured (as detailed in the [handling errors] section), but by default failed system parameters will cause a panic.
 
 Alternatively, system params can cause the system that they are part of to be skipped when validation fails.
 This represents an unusual but expected state of the application, which should be handled silently without issue.
 
-For example, the [`Single`] system parameter works like [`Query`],
-except that it only succeeds if the query matches exactly one entity,
-conveniently unwrapping it for you.
+For example, the [`Single`] system parameter works like [`Query`] except that it only succeeds if the query matches exactly one entity.
+If only a single entity matches, the returned value is provided and conveniently unwrapped.
 If either zero or more than one entity matches, the system is not run.
 
-This logic can be useful when, for example, dealing with a player character,
-who may have died.
-We don't need to update their statistics while waiting for them to respawn,
-but we certainly don't want to panic!
+This logic can be useful when, for example, dealing with a player character who may have died.
+We don't need to update their statistics while waiting for them to respawn, but we certainly don't want to panic!
 
 If you are writing your own [`SystemParam`], this behavior can be configured via the [`SystemParam::validate_param`] method.
 

--- a/content/learn/book/control-flow/states.md
+++ b/content/learn/book/control-flow/states.md
@@ -5,28 +5,24 @@ insert_anchor_links = "right"
 weight = 2
 +++
 
-Virtually all games are presented as a series of interactive "modes". Take for example a classic
-arcade game such as _Space Invaders_ or _Pac-Man_: First you have an "intro" mode, which catches the
-player's interest and teaches them about how the game works. The competition doesn't actually start until
-we enter the "play" mode, where the user is presented with various interactive challenges. At some
-point the game level will end, and the player will be presented with a "Congratulations, you Won!"
-or "Sorry, you Lost!" screen.
+Virtually all games are presented as a series of interactive "modes".
+Take for example a classic arcade game such as _Space Invaders_ or _Pac-Man_:
 
-Each of these modes entails a different set of graphics as well as a different configuration
-of input controls. During the intro mode, for example, all you can do is start the game, or perhaps
-get help or view the game's credits screen. You can't start controlling your ship or character
-until after you have left the "intro" mode and entered "play" mode.
+- First you have an "intro" mode, which catches the player's interest and teaches them about how the game works.
+- Then we enter the "play" mode, where the game actually begins and the user is presented with various interactive challenges.
+- Finally at some point we'll have a "game end" mode, where the game level ends and the player will be presented with a "Congratulations, you Won!" or "Sorry, you Lost!" screen.
 
-How shall we organize all of these different modal states in code? We could have separate variables for each
-of the modes, and write a bunch of logic for all the various entities involved, but there's an
-easier way: _game states_.
+Each of these modes entails a different set of graphics as well as a different configuration of input controls.
+During the intro mode (for example) all you can do is start the game, or perhaps get help, or maybe even view the game's credits screen.
+You can't start controlling your ship or character until after you have left the "intro" mode and entered "play" mode.
 
-Bevy's [`States`] trait lets you define one or more [finite-state
-machines](https://en.wikipedia.org/wiki/Finite-state_machine) (FSMs) that can be used to orchestrate
-changes to the Bevy world. You can configure your ECS systems to only run during certain states, or
-only on when transitioning between certain states. You can create entities that only exist
-within particular states as well. For example, you might have a HUD (heads-up display) entity which
-only exists during "play" mode.
+How shall we organize all of these different modal states in code?
+We could have separate variables for each of the modes and write a bunch of logic for all the various entities involved, but there's an easier way: **game states**.
+
+Bevy's [`States`] trait lets you define one or more [finite-state machines](https://en.wikipedia.org/wiki/Finite-state_machine) (FSMs) that can be used to orchestrate changes to the Bevy world.
+You can configure your ECS systems to only run during certain states, or only when transitioning between certain states.
+You can create entities that will only exist within specific states as well.
+For example, you might have a HUD (heads-up display) entity which only exists during "play" mode.
 
 [`States`]: https://docs.rs/bevy/latest/bevy/state/state/trait.States.html
 
@@ -50,15 +46,13 @@ pub enum GameState {
 }
 ```
 
-Here we derive from the `States` trait to define an enum with three variants, representing our
-three states. The `Default` defines the starting state.
+Here we derive from the `States` trait to define an enum with three variants, representing our three states.
+The `Default` defines the starting state.
 
 {% callout(type="info") %}
-The `States` trait is used to define _global_ states: that is, states that have influence over
-the entire Bevy `World`. However, while `States` models a finite-state machine, it is not the
-only possible use for FSMs within games. Animation and character behavior are also frequently
-modeled as FSMs, but since these only control a single entity, they are outside of the scope of what
-the `States` trait is intended for.
+The `States` trait is used to define _global_ states: that is, states that have influence over the entire Bevy `World`.
+However, while `States` models a finite-state machine, it is not the only possible use for FSMs within games.
+Animation and character behavior are also frequently modeled as FSMs, but since these only control a single entity, they are outside of the scope of what the `States` trait is intended for.
 {% end %}
 
 To use `GameState` we'll first need to register it with the `App`:
@@ -67,21 +61,18 @@ To use `GameState` we'll first need to register it with the `App`:
 app.init_state::<GameState>();
 ```
 
-You can define more than one set of states; these are independent (but see sub-states, below).
+You can define more than one set of states and have multiple state sets running in your application at a given time.
+The different state sets will be independent of each other, however we can also indicate a set of states that exist within another set of states. These are sub-states, and we'll dive into them in next.
 
-## SubStates: States within States
+## SubStates: States Within States
 
 For our arcade game, the `GameState::Playing` state is actually more complex than it appears.
-When a level starts, the action doesn't begin immediately - instead there is a brief
-interval where we display an animation of the ship arriving, or "warping in". Similarly, when
-the player's ship is destroyed, we show an animation of the ship exploding in all its glory.
-During these times, the player is unable to move their ship or fire, but other entities, such
-as enemies, terrain, or the HUD are able to function normally. We may also want to have a special
-"pause" state which freezes both the player and enemies, but which does not interrupt other
-aspects of the game like background music.
+When a level starts, the action doesn't begin immediately - instead there is a brief interval where we display an animation of the ship arriving, or "warping in".
+Similarly, when the player's ship is destroyed, we show an animation of the ship exploding in all its glory.
+During these times, the player is unable to move their ship or fire, but other entities, such as enemies, terrain, or the HUD are able to function normally.
+We may also want to have a special "pause" state which freezes both the player and enemies, but which does not interrupt other aspects of the game like background music.
 
-We can model this as a _sub-state_ of `GameState::Playing`, meaning that these states only exist
-while we are in the "playing" state.
+We can model this as a **sub-state** of `GameState::Playing`, meaning that these states only exist while we are in the "playing" state.
 
 ```rust,hide_lines=1-2
 # use bevy::ecs::prelude::*;
@@ -109,53 +100,54 @@ app
     .init_state::<ActionState>();
 ```
 
-{% callout(type="info") %} It might be reasonable to ask why we chose to model these different modes
-as sub-states: why not just have a single flat list of all the states? One reason is that all of
-these action states have a lot in common: they all have a HUD, they all have enemies which need to
-be spawned, and so on. By making them sub-states, we can tie the existence of, say, the HUD to the
-top-level state, while using the sub-states to control things like enemy and player movement. {% end
-%}
+{% callout(type="info") %}
+It might be reasonable to ask why we chose to model these different modes as sub-states: why not just have a single flat list of all the states?
+One reason is that all of these action states have a lot in common: they all have a HUD, they all have enemies which need to be spawned, and so on.
+By making them sub-states, we can tie the existence of, say, the HUD to the top-level state, while using the sub-states to control things like enemy and player movement.
+{% end %}
 
-## Switching between States
+## Switching Between States
 
-You can access the current state of type `T` with the [`State<T>`] resource. To trigger a transition
-between states, update the [`NextState<T>`] resource with the state you want to transition to.
+You can access the current state of type `T` with the [`State<T>`] resource.
+To trigger a transition between states, update the [`NextState<T>`] resource with the state you want to transition to.
 
-In our example arcade game, we start in the `Intro` state. When the player indicates they are ready to
-begin, we transition to the `Playing` state. If the player clears the level, we go to the
-`LevelComplete` state. This state only lasts a few seconds, at which point the next level begins -
-which means we go back to the `Playing` state. We continue to alternate between `Playing` and
-`LevelComplete` states until the player runs out of lives.
-
-(TBW: Example that transitions to "Playing" when a button is pressed).
+In our example arcade game, we start in the `Intro` state.
+When the player indicates they are ready to begin, we transition to the `Playing` state.
+If the player clears the level, we go to the `LevelComplete` state.
+This state only lasts a few seconds, at which point the next level begins (which means we go back to the `Playing` state).
+We continue to alternate between `Playing` and `LevelComplete` states until the player runs out of lives.
 
 [`State<T>`]: https://docs.rs/bevy/latest/bevy/state/state/struct.State.html
 [`NextState<T>`]: https://docs.rs/bevy/latest/bevy/state/state/enum.NextState.html
 
 ## States and Systems
 
-States can be used to determine which ECS systems get run. For example, say we only want enemy units
-to move and attack while in the `Playing` state:
+States can be used to determine which ECS systems get run.
+For example, say we only want enemy units to move and attack while in the `Playing` state:
 
 ```rs
 // Only run the enemy behavior while playing
 app.add_systems(Update, update_enemies.run_if(in_state(GameState::Playing)));
 ```
 
-The `in_state` function is a run condition which evaluates to `true` if we are in that state.
+The [`in_state`] function is a run condition which evaluates to `true` if we are in that state.
 
-We can also configure systems to run when entering or exiting a state, using `OnEnter` and
-`OnExit`. For example, we might want to play a sound when we begin a new level:
+We can also configure systems to run when entering or exiting a state, using [`OnEnter`] and [`OnExit`].
+For example, we might want to play a sound when we begin a new level:
 
 ```rs
 // Runs the `start_level_sound` system when we enter the `Playing` state.
 app.add_systems(OnEnter(GameState::Playing), start_level_sound);
 ```
 
+[`in_state`]: https://docs.rs/bevy/latest/bevy/prelude/fn.in_state.html
+[`OnEnter`]: https://docs.rs/bevy/latest/bevy/prelude/struct.OnEnter.html
+[`OnExit`]: https://docs.rs/bevy/latest/bevy/prelude/struct.OnExit.html
+
 ## States and Entities
 
-The `DespawnOnExit` component can be added to an entity to indicate that the entity should only
-exist in a particular state. When we exit that state, the entity will automatically be despawned.
+The [`DespawnOnExit`] component can be added to an entity to indicate that the entity should only exist in a particular state.
+When we exit that state, the entity will automatically be despawned.
 
 For example, if we wanted to despawn all remaining enemies at the end of a level:
 
@@ -168,6 +160,8 @@ fn spawn_enemy(mut commands: Commands) {
 }
 ```
 
+[`DespawnOnExit`]: https://docs.rs/bevy/latest/bevy/prelude/struct.DespawnOnExit.html
+
 ## ComputedState
 
 <!-- TBW -->
@@ -176,4 +170,3 @@ fn spawn_enemy(mut commands: Commands) {
 
 <!-- TBW -->
 
-[`DespawnOnExit`]: https://docs.rs/bevy/latest/bevy/state/state_scoped/struct.DespawnOnExit.html

--- a/content/learn/book/control-flow/states.md
+++ b/content/learn/book/control-flow/states.md
@@ -169,4 +169,3 @@ fn spawn_enemy(mut commands: Commands) {
 ## States and Schedules
 
 <!-- TBW -->
-

--- a/content/learn/book/control-flow/systems.md
+++ b/content/learn/book/control-flow/systems.md
@@ -68,13 +68,12 @@ fn register_players_system(mut player_parameter: PlayerSystemParameter) {
 }
 ```
 
-There are some additional caveats and restrictions that come with the `SystemParam` trait, but those are beyond the scope of this section. 
+There are some additional caveats and restrictions that come with the `SystemParam` trait, but those are beyond the scope of this section.
 If you're interested, you can check the [`SystemParam`] page for more details.
 
 [cache locality]: https://en.wikipedia.org/wiki/Locality_of_reference
 [`World`]: https://docs.rs/bevy/latest/bevy/prelude/struct.World.html
 
-[`World`]: https://docs.rs/bevy/latest/bevy/ecs/prelude/struct.World.html
 [`System`]: https://docs.rs/bevy/latest/bevy/ecs/prelude/trait.System.html
 [`SystemParam`]: https://docs.rs/bevy/latest/bevy/ecs/system/trait.SystemParam.html
 [`Query`]: https://docs.rs/bevy/latest/bevy/ecs/prelude/struct.Query.html
@@ -88,12 +87,12 @@ If you're interested, you can check the [`SystemParam`] page for more details.
 ## Accessing Data In Systems
 
 One of the major benefits of Bevy's system abstraction is that it easily and efficiently ["splits the borrow"] of a `World`.
-When a system is ran, the requested data is automatically fetched from the `World`. 
-Other systems are prevented from accessing the requested data if their access would violate the rules of the borrow checker. 
+When a system is ran, the requested data is automatically fetched from the `World`.
+Other systems are prevented from accessing the requested data if their access would violate the rules of the borrow checker.
 The prime directive of Rust still applies: accessing `World` data can be mutable *or* shared, but never both at once.
 
 We can see this in action when using multiple systems.
-If two systems access non-overlapping parts of the world they can run at the same time. 
+If two systems access non-overlapping parts of the world they can run at the same time.
 In the example below, both systems would be able to run in parallel since they do not access the same data.
 
 ```rust
@@ -174,19 +173,8 @@ This system state is used for performance optimizations (e.g. for queries), but 
 See the section on [local system state] for more details.
 
 ["splits the borrow"]: https://doc.rust-lang.org/nomicon/borrow-splitting.html
-[`MultiThreadedExecutor`]: https://docs.rs/bevy/latest/bevy/ecs/schedule/struct.MultiThreadedExecutor.html
-[`SystemParam`]: https://docs.rs/bevy/latest/bevy/ecs/system/trait.SystemParam.html
-[`Query`]: https://docs.rs/bevy/latest/bevy/ecs/system/struct.Query.html
-[`Res`]: https://docs.rs/bevy/latest/bevy/ecs/system/struct.Res.html
-[`ResMut`]: https://docs.rs/bevy/latest/bevy/ecs/system/struct.ResMut.html
-[`MessageReader`]: https://docs.rs/bevy/latest/bevy/ecs/message/struct.MessageReader.html
-[`MessageWriter`]: https://docs.rs/bevy/latest/bevy/ecs/message/struct.MessageWriter.html
-[`Local`]: https://docs.rs/bevy/latest/bevy/ecs/system/struct.Local.html
-[`Commands`]: https://docs.rs/bevy/latest/bevy/ecs/system/struct.Commands.html
-
 
 [local system state]: ../storing-data/local-system-param
-[Queries book section]: ../storing-data/queries
 
 ## Running Systems In Schedules
 
@@ -225,8 +213,9 @@ This is an extremely flexible tool, allowing you to execute arbitrary logic on t
 One-shot systems are particularly useful for testing, handling callbacks in UI, or creating scripted events.
 
 We have two means of running one-shot systems:
+
 - Register and invoke a system's [`SystemId`].
-- Access a System by name, caching it in a [`CachedSystemId`]. 
+- Access a System by name, caching it in a [`CachedSystemId`].
 
 Both means involve accessing the *state* of a particular system.
 When working with one-shot systems, entities are spawned to store this information.
@@ -281,8 +270,8 @@ fn one_shot_system(mut local_value: Local<usize>) {
 }
 ```
 
-Be aware that it's possible for these systems to *not* run successfully. 
-`World::run_system`, `World::run_system_with`, and `World::run_system_cached` (along with other methods for running systems) return a `Result`, although if you aren't receiving any values you might not notice any failures. 
+Be aware that it's possible for these systems to *not* run successfully.
+`World::run_system`, `World::run_system_with`, and `World::run_system_cached` (along with other methods for running systems) return a `Result`, although if you aren't receiving any values you might not notice any failures.
 For example, if you attempt to run a system by id that hasn't been registered, you'll receive a `Result` carrying a [`RegisteredSystemError`] enum with a `SystemIdNotRegistered` variant.
 
 ```rust
@@ -387,7 +376,7 @@ fn one_shot_system_with_input(In(input): In<usize>) -> usize {
 }
 ```
 
-We can call [`World::run_system_once_with`] like we would normally, except we pass in an input value and receive an output value wrapped in a `Result`. 
+We can call [`World::run_system_once_with`] like we would normally, except we pass in an input value and receive an output value wrapped in a `Result`.
 Remember, one-shot systems can potentially fail if the conditions of the system parameters weren't met.
 The type of the output is always inferred, but when using system input the first parameter must be [`In<T>`], where `T` is any type of input that you want to pass in.
 


### PR DESCRIPTION
Another editing pass at the whole of the Control Flow section of the book. Biggest thing is editing and adjusting the Change Detection, Skipping Systems, and States pages (as I haven't gone through them to rewrite them and add examples yet). I also touched the rest of the chapter pages to enforce a one-sentence-per-line structure which should make suggestions and editing easier.