### PR TITLE
Quick spelling fixes

### DIFF
--- a/content/learn/contribute/helping-out/creating-examples.md
+++ b/content/learn/contribute/helping-out/creating-examples.md
@@ -32,7 +32,7 @@ In addition, we have two additional categories which are treated as examples by 
 1. Stress tests: uses extreme entity counts or otherwise unrealistic settings to allow us to readily detect performance changes in particular performance-sensitive hot paths.
 2. Testbeds: designed to test features and scenes that rely on graphical rendering or interactivity, in both an automated and manual fashion.
 
-Unlike examples, stress tests and test beds should be configurable, allowing Bevy contriubtors (and curious users) to see the impact of changes.
+Unlike examples, stress tests and test beds should be configurable, allowing Bevy contributors (and curious users) to see the impact of changes.
 
 ## When should I add an example?
 

--- a/generate-release/src/main.rs
+++ b/generate-release/src/main.rs
@@ -49,7 +49,7 @@ struct Args {
 enum Commands {
     /// Gets all merged PRs with the `M-Migration-Guide` label or with a `Migration Guide` section in the body
     /// * For each PR generate a file with the migration guide and a frontmatter with metadata about the PR.
-    ///   This parses the markdown and generates valid makrdown that should pass markdownlint rules.
+    ///   This parses the markdown and generates valid markdown that should pass markdownlint rules.
     #[command(verbatim_doc_comment)]
     MigrationGuides {
         /// Use this if you want to overwrite existing files


### PR DESCRIPTION
Two simple spelling fixes that `typos` was throwing at me.