### PR TITLE
fix Res being mutably accessed

### DIFF
--- a/content/learn/book/control-flow/messages.md
+++ b/content/learn/book/control-flow/messages.md
@@ -77,7 +77,7 @@ fn setup_greeting(mut commands: Commands) {
 }
 
 // Update Messages<Greeting> to collect new messages.
-fn update_greeting_messages(greeting_res: Res<Messages<Greeting>>) {
+fn update_greeting_messages(greeting_res: ResMut<Messages<Greeting>>) {
     greeting_res.update();
 }
 


### PR DESCRIPTION
`greeting_res.update();` takes `&mut self` so `greeting_res` needs to be a `ResMut` like the other update systems later in the chapter