### PR TITLE
Swap Location demo component to be grid-based to reduce Transform confusion

### DIFF
--- a/content/learn/book/intro/the-three-letters.md
+++ b/content/learn/book/intro/the-three-letters.md
@@ -50,12 +50,11 @@ A **component** is a modular piece of data that can be reused across entities in
 In Bevy, components are "just Rust structs" (or enums).
 
 ```rs
-/// The location of a player, creature, or object in our game.
+/// The grid-based location of a player, creature, or object in our game.
 #[derive(Component)]
 struct Location {
-    x: f32,
-    y: f32,
-    z: f32,
+    x: u32,
+    y: u32,
 }
 
 /// The color of an object in our game.


### PR DESCRIPTION
Prompted by https://bsky.app/profile/sphinxc0re.dev/post/3mivjvmnr422f

You do sometimes want a 3d f32-based version of this for gameplay purposes and then sync up, but frankly that's just getting distracting.

Swap it to a simple 2d quantized form to reduce distracting overlap.