### PR TITLE
Start assets chapter for Book

### DIFF
--- a/content/learn/book/assets/_index.md
+++ b/content/learn/book/assets/_index.md
@@ -1,0 +1,21 @@
++++
+title = "Assets"
+template = "docs.html"
+insert_anchor_links = "right"
+[extra]
+weight = 15
+status = 'hidden'
++++
+
+A complete game needs to load and use all sorts of files.
+Most of these are tangible pieces of art that you may be familiar with: sounds, sprites, models, or fonts.
+But the same machinery can be used for more abstract bits of data loaded from disk:
+level layouts, enemy statistics, or even scripts.
+
+In game development, these are called **assets.**
+This chapter covers the underlying machinery of assets in Bevy,
+helping you structure your game to work with them effectively.
+
+At the scale of a hobbyist who is just starting out, this is quite simple:
+simply drop files in an `assets` folder.
+The initial [`Bevy's Asset Framework`](./bevy's-asset-framework.md) section of this chapter focus on the basics needed to form a useful mental model and get started with real projects.

--- a/content/learn/book/assets/_index.md
+++ b/content/learn/book/assets/_index.md
@@ -15,7 +15,3 @@ level layouts, enemy statistics, or even scripts.
 In game development, these are called **assets.**
 This chapter covers the underlying machinery of assets in Bevy,
 helping you structure your game to work with them effectively.
-
-At the scale of a hobbyist who is just starting out, this is quite simple:
-simply drop files in an `assets` folder.
-The initial [`Bevy's Asset Framework`](./bevy's-asset-framework.md) section of this chapter focus on the basics needed to form a useful mental model and get started with real projects.

--- a/content/learn/book/assets/bevy's-asset-framework.md
+++ b/content/learn/book/assets/bevy's-asset-framework.md
@@ -108,12 +108,12 @@ Should you change the handle that your sprite holds, or the asset that the handl
 
 Both approaches will change what your sprite looks like, and are valid to do, but the effects differ in an important way:
 
-- mutating the handle changes the [`Image`] asset your sprite entity is pointing to
-  - this only affects the entity in question
-  - this is analogous to replacing a `&` reference
-- mutating the asset changes the underlying data that the handle is pointing to
-  - this affects *all* entities that point to the same asset
-  - this is analogous to mutating the data that your `&` reference is pointing to
+- mutating the handle changes the [`Image`] asset your sprite entity is pointing to.
+  - this only affects the entity you specify.
+  - you can think of it as replacing one `&` reference with a different `&` reference.
+- mutating the asset changes the underlying data that the handle is pointing to.
+  - this affects *all* entities that point to the same asset.
+  - this is like changing the actual data that a `&` reference is pointing to.
 
 To mutate a handle (90% of cases):
 

--- a/content/learn/book/assets/bevy's-asset-framework.md
+++ b/content/learn/book/assets/bevy's-asset-framework.md
@@ -12,7 +12,7 @@ status = 'hidden'
 2. They are often very large: multiple megabytes, when typical data-storing components are measured in bytes.
 
 The first point means that we need tools to dynamically load (and unload) them at runtime.
-This is handled by the [`AssetServer`], 
+This is handled by the [`AssetServer`], which handles the surprisingly complex process of turning a path to an asset we want to use into bytes in RAM that we can stick in a Rust struct.
 
 The second point means that we really don't want to be storing multiple copies of the same asset: RAM and VRAM usage is often a critical limitation for game performance.
 In Bevy, the canonical version of every asset of a type `A` is stored in a matching resource: [`Assets<A>`].
@@ -107,17 +107,17 @@ This allows us to change the asset file during testing and see those changes ref
 
 ## Mutating handles vs mutating assets
 
-Understanding the [`Handle<A>`] / [`Assets<A>`] distinction becomes quite important when when you want to mutate assets.
+Understanding the [`Handle<A>`] / [`Assets<A>`] distinction becomes quite important when you want to mutate assets.
 Should you change the handle that your sprite holds, or the asset that the handle points to?
 
-Both appraoches will change what your sprite looks like, and are valid to do, but the effects differ in an important way:
+Both approaches will change what your sprite looks like, and are valid to do, but the effects differ in an important way:
 
 - mutating the handle changes the [`Image`] asset your sprite entity is pointing to
   - this only affects the entity in question
-  - this is analagous to replacing a `&` reference
+  - this is analogous to replacing a `&` reference
 - mutating the asset changes the underlying data that the handle is pointing to
   - this affects *all* entities that point to the same asset
-  - this is analagous to mutating the data that your `&` reference is pointing to
+  - this is analogous to mutating the data that your `&` reference is pointing to
 
 To mutate a handle (90% of cases):
 
@@ -168,7 +168,7 @@ This behavior is quite useful, as it allows you to dynamically spawn and despawn
 that rely on different asset data without holding onto all of their assets forever.
 That would be, in effect, a memory leak.
 
-However, this behavior can be frustrating when trying to pre-load asssets.
+However, this behavior can be frustrating when trying to pre-load assets.
 Loading all of your assets ahead of time simply won't work if you immediately drop the handles.
 Instead, you need to hold onto them somehow.
 Resources can work well for this, as can "zoos" of loaded entities or scenes that you quickly clone into your game as needed.
@@ -180,7 +180,7 @@ Resources can work well for this, as can "zoos" of loaded entities or scenes tha
 
 {% callout(type="warning") %}
 
-Rendering is one of the most important consumers of assets in Bevy: consuming
+Rendering is one of the most important consumers of assets in Bevy: using the images and models that we load to make pretty pixels.
 However, when rendering data, we need to load it into VRAM on the GPU;
 not ordinary RAM on the CPU.
 As a result, Bevy is configured to unload [`RenderAsset`] data from the CPU by default,

--- a/content/learn/book/assets/bevy's-asset-framework.md
+++ b/content/learn/book/assets/bevy's-asset-framework.md
@@ -156,8 +156,8 @@ fn fade_enemy_image_asset(
 Rendering is one of the most important consumers of assets in Bevy: using the images and models that we load to make pretty pixels.
 In order to do so, we need to load it into VRAM on the GPU;
 not ordinary RAM on the CPU.
-As a result, Bevy is configured to unload [`RenderAsset`] data from the CPU by default,
-in order to save significant amounts of RAM.
+Because of this, some [`RenderAsset`]s may be configured to unload their CPU data,
+saving significant amounts of RAM.
 
 This can present issues when attempting to mutate asset data,
 as the actual data (like the pixel data of an image) is moved to the GPU, even though the asset remains loaded.

--- a/content/learn/book/assets/bevy's-asset-framework.md
+++ b/content/learn/book/assets/bevy's-asset-framework.md
@@ -42,7 +42,7 @@ But before that: let's load our first assets!
 [`Handle<A>`]: https://docs.rs/bevy/latest/bevy/asset/struct.Handle.html
 [`AssetPath`]: https://docs.rs/bevy/latest/bevy/asset/struct.AssetPath.html
 
-## The basics of loading assets
+## The Basics of Loading Assets
 
 Loading an asset is pretty simple:
 
@@ -101,7 +101,7 @@ This allows us to change the asset file during testing and see those changes ref
 [`AssetServer::load_state`]: https://docs.rs/bevy/latest/bevy/asset/struct.AssetServer.html#method.load_state
 [`Handle::id`]: https://docs.rs/bevy/latest/bevy/asset/struct.Handle.html#method.id
 
-## Mutating handles vs mutating assets
+## Mutating Handles vs Mutating Assets
 
 Understanding the [`Handle<A>`] / [`Assets<A>`] distinction becomes quite important when you want to mutate assets.
 Should you change the handle that your sprite holds, or the asset that the handle points to?
@@ -168,7 +168,7 @@ This behavior can be configured by setting [`RenderAssetUsages`] when loading as
 
 {% end %}
 
-## Handles are reference-counted
+## Handles are Reference-Counted
 
 The [`Handle`] type can be thought of as a [smart pointer] with two key properties:
 

--- a/content/learn/book/assets/bevy's-asset-framework.md
+++ b/content/learn/book/assets/bevy's-asset-framework.md
@@ -12,7 +12,7 @@ status = 'hidden'
 2. They are often very large: multiple megabytes, when typical data-storing components are measured in bytes.
 
 The first point means that we need tools to dynamically load (and unload) them at runtime.
-This is handled by the [`AssetServer`], which handles the surprisingly complex process of turning a path to an asset we want to use into bytes in RAM that we can stick in a Rust struct.
+This is handled by the [`AssetServer`], which handles the surprisingly complex process of turning a path of an asset we want to use, into usable data in memory.
 
 The second point means that we really don't want to be storing multiple copies of the same asset: RAM and VRAM usage is often a critical limitation for game performance.
 In Bevy, the single, authoritative version of every asset of a type `A` is stored in a matching resource: [`Assets<A>`].
@@ -80,7 +80,7 @@ in the same folder as the `Cargo.toml` of your binary crate.
 When shipping your game, this should be an `assets` folder in the same folder as the final binary.
 
 This behavior is a reasonable choice for most projects.
-However, this behavior can be overridden by setting the `BEVY_ASSET_ROOT` environment variable for your program. 
+However, this behavior can be overridden by setting the `BEVY_ASSET_ROOT` environment variable for your program or setting `AssetPlugin::file_path`.
 
 {% end %}
 
@@ -88,15 +88,7 @@ Asset loading is, by default, done asynchronously.
 This means that, while `AssetServer::load("bevy_bird.png")` will give you a [`Handle<Image>`]
 that you can use to set up your [`Sprite`], the program will not block and wait for the image to actually load.
 
-If your asset is large enough (or you are loading many assets at once),
-this can take long enough for it to be noticeable.
-Objects will look like they "didn't spawn" or look "invisible",
-only for them to suddenly "pop in".
-
-You can check the progress of asset loading using [`AssetServer::load_state`],
-looking up the asset identifier to provide by calling [`Handle::id`].
-As your project grows, you will probably want to use this method to create a loading screen (or something more sophisticated);
-waiting for all of your assets to load in before allowing the player to actually play the game.
+Because of asynchronous loading, using the handles immediately can result in objects not rendering, sounds not playing, etc. Most games handle this by creating a loading screen while their assets load. Bevy is no different! You can check the progress of asset loading using [`AssetServer::load_state`]. This can be used to create a loading screen (or something more sophisticated).
 
 {% callout(type="info") %}
 
@@ -175,8 +167,8 @@ This behavior is quite useful, as it allows you to dynamically spawn and despawn
 that rely on different asset data without holding onto all of their assets forever.
 That would be, in effect, a memory leak.
 
-However, this behavior can be frustrating when trying to pre-load assets.
-Loading all of your assets ahead of time simply won't work if you immediately drop the handles.
+However, this behavior needs to be considered when trying to pre-load assets.
+Loading all of your assets ahead of time simply won't work if you immediately drop the handles, since this tells the asset system you don't need the assets anymore!
 Instead, you need to hold onto them somehow.
 A resource storing something like a `HashMap<String, Handle<Image>>` can work well for this, but some games choose to create a collection of hidden, loaded entities or scenes that they can quickly clone into your game as needed.
 

--- a/content/learn/book/assets/bevy's-asset-framework.md
+++ b/content/learn/book/assets/bevy's-asset-framework.md
@@ -8,7 +8,7 @@ status = 'hidden'
 
 **Assets** have two defining qualities that shape Bevy's architecture for working with them:
 
-1. Their values are not compiled into the program. Typically, this means they're stored in the file system on the user's hard drive.
+1. They can be loaded and unloaded at runtime (as opposed to being part of your game's code). Typically, assets are stored in the file system on the user's hard drive.
 2. They are often very large: multiple megabytes, when typical data-storing components are measured in bytes.
 
 The first point means that we need tools to dynamically load (and unload) them at runtime.

--- a/content/learn/book/assets/bevy's-asset-framework.md
+++ b/content/learn/book/assets/bevy's-asset-framework.md
@@ -159,6 +159,23 @@ fn fade_enemy_image_asset(
 
 [`Image`]: https://docs.rs/bevy/latest/bevy/render/texture/struct.Image.html
 
+{% callout(type="warning") %}
+
+Rendering is one of the most important consumers of assets in Bevy: using the images and models that we load to make pretty pixels.
+In order to do so, we need to load it into VRAM on the GPU;
+not ordinary RAM on the CPU.
+As a result, Bevy is configured to unload [`RenderAsset`] data from the CPU by default,
+in order to save significant amounts of RAM.
+
+This can present issues when attempting to mutate asset data,
+as the actual info things like "pixel data" is moved to the GPU, even though the asset remains loaded.
+This behavior can be configured by setting [`RenderAssetUsages`] when loading assets.
+
+[`RenderAsset`]: https://docs.rs/bevy/latest/bevy/render/render_asset/trait.RenderAsset.html
+[`RenderAssetUsages`]: https://docs.rs/bevy/latest/bevy/asset/struct.RenderAssetUsages.html
+
+{% end %}
+
 ## Handles are reference-counted
 
 The [`Handle`] type can be thought of as a [smart pointer] with two key properties:
@@ -184,22 +201,3 @@ A resource storing something like a `HashMap<String, Handle<Image>>` can work we
 [`AssetId`]: https://docs.rs/bevy/latest/bevy/asset/enum.AssetId.html
 [smart pointer]: https://doc.rust-lang.org/book/ch15-00-smart-pointers.html
 [reference-counted]: https://doc.rust-lang.org/std/rc/index.html
-
-{% callout(type="warning") %}
-
-If you are trying and failing to access asset data, but are *confident* that your handles have not been dropped, you may be running into a different gotcha.
-
-Rendering is one of the most important consumers of assets in Bevy: using the images and models that we load to make pretty pixels.
-However, when rendering data, we need to load it into VRAM on the GPU;
-not ordinary RAM on the CPU.
-As a result, Bevy is configured to unload [`RenderAsset`] data from the CPU by default,
-in order to save significant amounts of RAM.
-
-This can make assets look like they have been dropped, when they've in fact been moved to the GPU,
-removing things like "pixel data" while leaving asset metadata behind.
-This behavior can be configured by setting [`RenderAssetUsages`] when loading assets.
-
-[`RenderAsset`]: https://docs.rs/bevy/latest/bevy/render/render_asset/trait.RenderAsset.html
-[`RenderAssetUsages`]: https://docs.rs/bevy/latest/bevy/asset/struct.RenderAssetUsages.html
-
-{% end %}

--- a/content/learn/book/assets/bevy's-asset-framework.md
+++ b/content/learn/book/assets/bevy's-asset-framework.md
@@ -8,14 +8,14 @@ status = 'hidden'
 
 **Assets** have two defining qualities that shape Bevy's architecture for working with them:
 
-1. Their values are not compiled into the program. Typically, this means the file system on the user's hard drive.
+1. Their values are not compiled into the program. Typically, this means they're stored in the file system on the user's hard drive.
 2. They are often very large: multiple megabytes, when typical data-storing components are measured in bytes.
 
 The first point means that we need tools to dynamically load (and unload) them at runtime.
 This is handled by the [`AssetServer`], which handles the surprisingly complex process of turning a path to an asset we want to use into bytes in RAM that we can stick in a Rust struct.
 
 The second point means that we really don't want to be storing multiple copies of the same asset: RAM and VRAM usage is often a critical limitation for game performance.
-In Bevy, the canonical version of every asset of a type `A` is stored in a matching resource: [`Assets<A>`].
+In Bevy, the single, authoritative version of every asset of a type `A` is stored in a matching resource: [`Assets<A>`].
 Components (like [`Mesh3d`] or [`Sprite`]) which want to reference this data store a [`Handle<A>`],
 which point to this canonical version.
 
@@ -45,20 +45,23 @@ But before that: let's load our first assets!
 ## The basics of loading assets
 
 Loading an asset is pretty simple:
-call `AssetServer::load("bevy_bird.png")`, it gives you a handle to the asset,
-you put that handle inside of the component that needed asset data to control appearance, behavior or sounds.
+
+1. Call `AssetServer::load("bevy_bird.png")`
+2. It gives you a handle to the asset,
+3. You put that handle inside of the component that needed asset data to control appearance, behavior or sounds.
 
 ```rust
 // Breaking the steps down for clarity
 fn spawn_bevy_bird_verbose(mut commands: Commands, asset_server: Res<AssetServer>) {
-	// AssetServer::load takes a path: the "/" means that we're looking in the "branding" folder
-	// for the file named "bevy_bird_dark.png"
+    // AssetServer::load takes a relative path:
+    // we're looking inside the "assets" folder for the "branding" subdirectory,
+    // then looking for the file named "bevy_bird_dark.png"
     let handle_to_bevy_bird_image: Handle<Image> = asset_server.load("branding/bevy_bird_dark.png");
 
-	commands.spawn(Sprite {
-		image: handle_to_bevy_bird_image,
-		..default()
-	});
+    commands.spawn(Sprite {
+        image: handle_to_bevy_bird_image,
+        ..default()
+    });
 }
 
 // In practice, you'd use something more like this
@@ -78,7 +81,6 @@ When shipping your game, this should be an `assets` folder in the same folder as
 
 This behavior is a reasonable choice for most projects.
 However, this behavior can be overridden by setting the `BEVY_ASSET_ROOT` environment variable for your program. 
-You should be careful to only modify this locally, rather than globally, to avoid interfering with other Bevy programs.
 
 {% end %}
 
@@ -129,7 +131,7 @@ fn swap_player_image(
     asset_server: Res<AssetServer>,
 ) {
     // Only this entity's appearance changes;
-	// other sprites are unaffected
+    // other sprites are unaffected
     sprite.image = asset_server.load("new_image.png");
 }
 ```
@@ -176,7 +178,7 @@ That would be, in effect, a memory leak.
 However, this behavior can be frustrating when trying to pre-load assets.
 Loading all of your assets ahead of time simply won't work if you immediately drop the handles.
 Instead, you need to hold onto them somehow.
-Resources can work well for this, as can "zoos" of loaded entities or scenes that you quickly clone into your game as needed.
+A resource storing something like a `HashMap<String, Handle<Image>>` can work well for this, but some games choose to create a collection of hidden, loaded entities or scenes that they can quickly clone into your game as needed.
 
 [`Handle`]: https://docs.rs/bevy/latest/bevy/asset/struct.Handle.html
 [`AssetId`]: https://docs.rs/bevy/latest/bevy/asset/enum.AssetId.html
@@ -185,6 +187,8 @@ Resources can work well for this, as can "zoos" of loaded entities or scenes tha
 
 {% callout(type="warning") %}
 
+If you are trying and failing to access asset data, but are *confident* that your handles have not been dropped, you may be running into a different gotcha.
+
 Rendering is one of the most important consumers of assets in Bevy: using the images and models that we load to make pretty pixels.
 However, when rendering data, we need to load it into VRAM on the GPU;
 not ordinary RAM on the CPU.
@@ -192,7 +196,7 @@ As a result, Bevy is configured to unload [`RenderAsset`] data from the CPU by d
 in order to save significant amounts of RAM.
 
 This can make assets look like they have been dropped, when they've in fact been moved to the GPU,
-leaving only the asset metadata behind.
+removing things like "pixel data" while leaving asset metadata behind.
 This behavior can be configured by setting [`RenderAssetUsages`] when loading assets.
 
 [`RenderAsset`]: https://docs.rs/bevy/latest/bevy/render/render_asset/trait.RenderAsset.html

--- a/content/learn/book/assets/bevy's-asset-framework.md
+++ b/content/learn/book/assets/bevy's-asset-framework.md
@@ -182,7 +182,7 @@ If this causes the number of handles referencing the asset to hit zero, the data
 
 This behavior is quite useful, as it allows you to dynamically spawn and despawn entities
 that rely on different asset data without holding onto all of their assets forever.
-That would be, in effect, a memory leak.
+If unused asset data was never unloaded, it would be, in effect, a memory leak.
 
 However, this behavior needs to be considered when trying to pre-load assets.
 Loading all of your assets ahead of time simply won't work if you immediately drop the handles, since this tells the asset system you don't need the assets anymore!

--- a/content/learn/book/assets/bevy's-asset-framework.md
+++ b/content/learn/book/assets/bevy's-asset-framework.md
@@ -46,9 +46,9 @@ But before that: let's load our first assets!
 
 Loading an asset is pretty simple:
 
-1. Call `AssetServer::load("bevy_bird.png")`
-2. It gives you a handle to the asset,
-3. You put that handle inside of the component that needed asset data to control appearance, behavior or sounds.
+1. Call `AssetServer::load("bevy_bird.png")`.
+2. It will give you a handle to the asset.
+3. Place that handle inside of a component that needs the asset data to control its appearance, behavior, or sounds.
 
 ```rust
 // Breaking the steps down for clarity

--- a/content/learn/book/assets/bevy's-asset-framework.md
+++ b/content/learn/book/assets/bevy's-asset-framework.md
@@ -31,7 +31,7 @@ look up the asset they're pointing to, and then use that information to
 do things like "render them" or "determine collisions".
 
 While this explanation serves as an excellent mental model for the core data flow of assets in Bevy,
-there are a few subtleties that are worth getting into in this chapter.
+there are a few subtleties that are worth getting into in this chapter (how to mutate assets and the fact that handles are reference counted).
 
 But before that: let's load our first assets!
 
@@ -44,13 +44,15 @@ But before that: let's load our first assets!
 
 ## The basics of loading assets
 
-The basic approach to loading an asset is pretty simple:
+Loading an asset is pretty simple:
 call `AssetServer::load("bevy_bird.png")`, it gives you a handle to the asset,
 you put that handle inside of the component that needed asset data to control appearance, behavior or sounds.
 
 ```rust
 // Breaking the steps down for clarity
 fn spawn_bevy_bird_verbose(mut commands: Commands, asset_server: Res<AssetServer>) {
+	// AssetServer::load takes a path: the "/" means that we're looking in the "branding" folder
+	// for the file named "bevy_bird_dark.png"
     let handle_to_bevy_bird_image: Handle<Image> = asset_server.load("branding/bevy_bird_dark.png");
 
 	commands.spawn(Sprite {

--- a/content/learn/book/assets/bevy's-asset-framework.md
+++ b/content/learn/book/assets/bevy's-asset-framework.md
@@ -160,7 +160,7 @@ As a result, Bevy is configured to unload [`RenderAsset`] data from the CPU by d
 in order to save significant amounts of RAM.
 
 This can present issues when attempting to mutate asset data,
-as the actual info things like "pixel data" is moved to the GPU, even though the asset remains loaded.
+as the actual data (like the pixel data of an image) is moved to the GPU, even though the asset remains loaded.
 This behavior can be configured by setting [`RenderAssetUsages`] when loading assets.
 
 [`RenderAsset`]: https://docs.rs/bevy/latest/bevy/render/render_asset/trait.RenderAsset.html

--- a/content/learn/book/assets/bevy's-asset-framework.md
+++ b/content/learn/book/assets/bevy's-asset-framework.md
@@ -1,0 +1,196 @@
++++
+title = "Bevy's Asset Framework"
+insert_anchor_links = "right"
+[extra]
+weight = 1
+status = 'hidden'
++++
+
+**Assets** have two defining qualities that shape Bevy's architecture for working with them:
+
+1. Their values are not compiled into the program. Typically, this means the file system on the user's hard drive.
+2. They are often very large: multiple megabytes, when typical data-storing components are measured in bytes.
+
+The first point means that we need tools to dynamically load (and unload) them at runtime.
+This is handled by the [`AssetServer`], 
+
+The second point means that we really don't want to be storing multiple copies of the same asset: RAM and VRAM usage is often a critical limitation for game performance.
+In Bevy, the canonical version of every asset of a type `A` is stored in a matching resource: [`Assets<A>`].
+Components (like [`Mesh3d`] or [`Sprite`]) which want to reference this data store a [`Handle<A>`],
+which point to this canonical version.
+
+{% callout(type="info") %}
+
+Loading an asset from the same path does not create a new copy of the data from disk by loading it again;
+these calls are deduplicated by [`AssetPath`].
+
+{% end %}
+
+Various systems then read these component-storing handles,
+look up the asset they're pointing to, and then use that information to 
+do things like "render them" or "determine collisions".
+
+While this explanation serves as an excellent mental model for the core data flow of assets in Bevy,
+there are a few subtleties that are worth getting into in this chapter.
+
+But before that: let's load our first assets!
+
+[`AssetServer`]: https://docs.rs/bevy/latest/bevy/asset/struct.AssetServer.html
+[`Assets<A>`]: https://docs.rs/bevy/latest/bevy/asset/struct.Assets.html
+[`Mesh3d`]: https://docs.rs/bevy/latest/bevy/pbr/struct.Mesh3d.html
+[`Sprite`]: https://docs.rs/bevy/latest/bevy/sprite/struct.Sprite.html
+[`Handle<A>`]: https://docs.rs/bevy/latest/bevy/asset/struct.Handle.html
+[`AssetPath`]: https://docs.rs/bevy/latest/bevy/asset/struct.AssetPath.html
+
+## The basics of loading assets
+
+The basic approach to loading an asset is pretty simple:
+call `AssetServer::load("bevy_bird.png")`, it gives you a handle to the asset,
+you put that handle inside of the component that needed asset data to control appearance, behavior or sounds.
+
+```rust
+// Breaking the steps down for clarity
+fn spawn_bevy_bird_verbose(mut commands: Commands, asset_server: Res<AssetServer>) {
+    let handle_to_bevy_bird_image: Handle<Image> = asset_server.load("branding/bevy_bird_dark.png");
+
+	commands.spawn(Sprite {
+		image: handle_to_bevy_bird_image,
+		..default()
+	});
+}
+
+// In practice, you'd use something more like this
+fn spawn_bevy_bird_idiomatic(mut commands: Commands, asset_server: Res<AssetServer>) {
+    commands.spawn(Sprite::from_image(
+        asset_server.load("branding/bevy_bird_dark.png"),
+    ));
+}
+```
+
+{% callout(type="info") %}
+
+Bevy looks for assets inside of the `assets` folder.
+During development, this should be located inside your project folder,
+in the same folder as the `Cargo.toml` of your binary crate.
+When shipping your game, this should be an `assets` folder in the same folder as the final binary.
+
+This behavior is a reasonable choice for most projects.
+However, this behavior can be overridden by setting the `BEVY_ASSET_ROOT` environment variable for your program. 
+You should be careful to only modify this locally, rather than globally, to avoid interfering with other Bevy programs.
+
+{% end %}
+
+Asset loading is, by default, done asynchronously.
+This means that, while `AssetServer::load("bevy_bird.png")` will give you a [`Handle<Image>`]
+that you can use to set up your [`Sprite`], the program will not block and wait for the image to actually load.
+
+If your asset is large enough (or you are loading many assets at once),
+this can take long enough for it to be noticeable.
+Objects will look like they "didn't spawn" or look "invisible",
+only for them to suddenly "pop in".
+
+You can check the progress of asset loading using [`AssetServer::load_state`],
+looking up the asset identifier to provide by calling [`Handle::id`].
+As your project grows, you will probably want to use this method to create a loading screen (or something more sophisticated);
+waiting for all of your assets to load in before allowing the player to actually play the game.
+
+{% callout(type="info") %}
+
+While loading data as an asset is more complex than simply hardcoding it, doing so unlocks [asset hot reloading](../development-practices/hot-reloading.md).
+This allows us to change the asset file during testing and see those changes reflected in real time.
+
+{% end %}
+
+[`Handle<Image>`]: https://docs.rs/bevy/latest/bevy/asset/struct.Handle.html
+[`AssetServer::load_state`]: https://docs.rs/bevy/latest/bevy/asset/struct.AssetServer.html#method.load_state
+[`Handle::id`]: https://docs.rs/bevy/latest/bevy/asset/struct.Handle.html#method.id
+
+## Mutating handles vs mutating assets
+
+Understanding the [`Handle<A>`] / [`Assets<A>`] distinction becomes quite important when when you want to mutate assets.
+Should you change the handle that your sprite holds, or the asset that the handle points to?
+
+Both appraoches will change what your sprite looks like, and are valid to do, but the effects differ in an important way:
+
+- mutating the handle changes the [`Image`] asset your sprite entity is pointing to
+  - this only affects the entity in question
+  - this is analagous to replacing a `&` reference
+- mutating the asset changes the underlying data that the handle is pointing to
+  - this affects *all* entities that point to the same asset
+  - this is analagous to mutating the data that your `&` reference is pointing to
+
+To mutate a handle (90% of cases):
+
+```rust
+fn swap_player_image(
+    mut sprite: Single<&mut Sprite, With<Player>>,
+    asset_server: Res<AssetServer>,
+) {
+    // Only this entity's appearance changes;
+	// other sprites are unaffected
+    sprite.image = asset_server.load("new_image.png");
+}
+```
+
+To mutate the underlying asset (10% of cases):
+
+```rust
+fn invert_enemy_image_asset(
+    sprite: Single<&Sprite, With<EnemyToInvert>>,
+    mut images: ResMut<Assets<Image>>,
+) {
+    if let Some(image) = images.get_mut(&sprite.image) {
+        // Every entity using this image will be affected!
+        if let Some(data) = image.data.as_mut() {
+            for byte in data.iter_mut() {
+                *byte = 255 - *byte;
+            }
+        }
+    }
+}
+```
+
+[`Image`]: https://docs.rs/bevy/latest/bevy/render/texture/struct.Image.html
+
+## Handles are reference-counted
+
+The [`Handle`] type can be thought of as a [smart pointer] with two key properties:
+
+1. It uses an [`AssetId`] to reference the asset it's pointing to, rather than a true pointer.
+2. It is [reference-counted]: when all of the handles to a given asset are dropped, the asset will be unloaded.
+
+Whenever a handle is created (or cloned), the counter of "how many handles reference this asset" goes up by one.
+When it is dropped (via replacement, despawning or removing a component, or deleting a resource that stores the handle),
+the counter decreases by one.
+If this causes the number of handles referencing the asset to hit zero, the data is unloaded.
+
+This behavior is quite useful, as it allows you to dynamically spawn and despawn entities
+that rely on different asset data without holding onto all of their assets forever.
+That would be, in effect, a memory leak.
+
+However, this behavior can be frustrating when trying to pre-load asssets.
+Loading all of your assets ahead of time simply won't work if you immediately drop the handles.
+Instead, you need to hold onto them somehow.
+Resources can work well for this, as can "zoos" of loaded entities or scenes that you quickly clone into your game as needed.
+
+[`Handle`]: https://docs.rs/bevy/latest/bevy/asset/struct.Handle.html
+[`AssetId`]: https://docs.rs/bevy/latest/bevy/asset/enum.AssetId.html
+[smart pointer]: https://doc.rust-lang.org/book/ch15-00-smart-pointers.html
+[reference-counted]: https://doc.rust-lang.org/std/rc/index.html
+
+{% callout(type="warning") %}
+
+Rendering is one of the most important consumers of assets in Bevy: consuming
+However, when rendering data, we need to load it into VRAM on the GPU;
+not ordinary RAM on the CPU.
+As a result, Bevy is configured to unload [`RenderAsset`] data from the CPU by default,
+in order to save significant amounts of RAM.
+
+This can make assets look like they have been dropped, when they've in fact been moved to the GPU,
+leaving only the asset metadata behind.
+This behavior can be configured by setting [`RenderAssetUsages`] when loading assets.
+
+[`RenderAsset`]: https://docs.rs/bevy/latest/bevy/render/render_asset/trait.RenderAsset.html
+[`RenderAssetUsages`]: https://docs.rs/bevy/latest/bevy/asset/struct.RenderAssetUsages.html
+
+{% end %}

--- a/content/learn/book/assets/bevy's-asset-framework.md
+++ b/content/learn/book/assets/bevy's-asset-framework.md
@@ -85,8 +85,8 @@ However, this behavior can be overridden by setting the `BEVY_ASSET_ROOT` enviro
 {% end %}
 
 Asset loading is, by default, done asynchronously.
-This means that, while `AssetServer::load("bevy_bird.png")` will give you a [`Handle<Image>`]
-that you can use to set up your [`Sprite`], the program will not block and wait for the image to actually load.
+This means that the program will not block and wait for the image to actually load.
+You can call `AssetServer::load("bevy_bird.png")` and receive a [`Handle<Image>`] that can be used to set up a [`Sprite`], but you might not immediately see the `"bevy_bird.png"` image in your game.
 
 Because of asynchronous loading, using the handles immediately can result in objects not rendering, sounds not playing, etc. Most games handle this by creating a loading screen while their assets load. Bevy is no different! You can check the progress of asset loading using [`AssetServer::load_state`]. This can be used to create a loading screen (or something more sophisticated).
 

--- a/content/learn/book/assets/bevy's-asset-framework.md
+++ b/content/learn/book/assets/bevy's-asset-framework.md
@@ -135,15 +135,18 @@ fn swap_player_image(
 To mutate the underlying asset (10% of cases):
 
 ```rust
-fn invert_enemy_image_asset(
-    sprite: Single<&Sprite, With<EnemyToInvert>>,
+fn fade_enemy_image_asset(
+    sprite: Single<&Sprite, With<EnemyToFade>>,
     mut images: ResMut<Assets<Image>>,
 ) {
     if let Some(image) = images.get_mut(&sprite.image) {
         // Every entity using this image will be affected!
-        if let Some(data) = image.data.as_mut() {
-            for byte in data.iter_mut() {
-                *byte = 255 - *byte;
+        for y in 0..image.height() {
+            for x in 0..image.width() {
+                if let Ok(mut color) = image.get_color_at(x, y) {
+                    color.set_alpha(color.alpha() / 2.0);
+                    let _ = image.set_color_at(x, y, color);
+                }
             }
         }
     }


### PR DESCRIPTION
Just the introductory page for now, but I still think this is enough to be very useful!

In the future I would like to add:

1. A page on pre-loading assets.
2. A page on asset processing.
3. A page on automated quality control for assets.
4. A page on organizing your assets folder.
5. A page on asset version control.
6. A page on working with custom asset formats.

All of these things are very useful, practical things which only kind of have to do with Bevy at times, and so are a very natural fit for the book.

For now though, this PR should be a useful MVP of this chapter for newcomers to Bevy who don't read the bevy_assets crate docs that I wrote :p