### PR TITLE
Add Events page section for Observer run_if functionality

### DIFF
--- a/content/learn/book/control-flow/events.md
+++ b/content/learn/book/control-flow/events.md
@@ -118,8 +118,8 @@ world.add_observer(|event: On<A>, mut commands: Commands| {
 
 ### Conditionally Triggering Observers
 
-The [Skipping Systems page] introduced conditional checks that can be used to control when a system should run.
-Observers can also be controlled with conditional checks using a similar [`.run_if`] pattern.
+The [Skipping Systems page] introduced run conditions, which can be used to control when a system should run.
+These work for observers too!
 `.run_if` can be used when you create your observer, as we can see in the example below:
 
 ```rust

--- a/content/learn/book/control-flow/events.md
+++ b/content/learn/book/control-flow/events.md
@@ -116,6 +116,47 @@ world.add_observer(|event: On<A>, mut commands: Commands| {
 
 [`Component`]: https://docs.rs/bevy/latest/bevy/prelude/trait.Component.html
 
+### Conditionally Triggering Observers
+
+The [Skipping Systems page] introduced conditional checks that can be used to control when a system should run.
+Observers can also be controlled with conditional checks using a similar [`.run_if`] pattern.
+`.run_if` can be used when you create your observer, as we can see in the example below:
+
+```rust
+#[derive(Resource)]
+struct GameActive(bool);
+
+// Global Observer
+app.add_observer(
+    on_damage.run_if(|paused: Res<GamePaused>| !paused.0)
+);
+
+// Entity Observer
+commands.spawn(Enemy).observe(
+    on_hit.run_if(|paused: Res<GamePaused>| !paused.0)
+);
+
+// Builder Pattern
+world.spawn(
+    Observer::new(DamageEvent)
+        .with_entity(Enemy)
+        .run_if(|paused: Res<GamePaused>| !paused.0)
+);
+```
+
+We also have the ability to chain multiple `.run_if` conditions together, although be aware that only `AND` logic can be established by using multiple `.run_if` conditions.
+
+```rust
+// Multiple conditions can be chained (AND semantics)
+world.add_observer(
+    on_damage
+        .run_if(|paused: Res<GamePaused>| !paused.0)
+        .run_if(resource_exists::<Player>)
+);
+```
+
+[`.run_if`]: https://docs.rs/bevy/latest/bevy/ecs/observer/struct.Observer.html#method.run_if
+
 ## Event Triggers
 
 Every `Event` requires a [`Trigger`], represented by default with the `On<Event>` syntax. It's best to think of a `Trigger` as the call which activates the `Event`, hence why we use `On`: our code will run `On` our `Event`.


### PR DESCRIPTION
Updated Events book page based on the addition of the [`run_if`](https://github.com/bevyengine/bevy/blob/main/_release-content/release-notes/observer_run_conditions.md) for Observers.