### PR TITLE
fix(book): correct tense of multiple uses of the verb "to run"

### DIFF
--- a/content/learn/book/control-flow/commands.md
+++ b/content/learn/book/control-flow/commands.md
@@ -10,7 +10,7 @@ When we want to make structural changes to our application, we require mutable a
 Since only one system can mutably access the `World` at a time, we need a way to organize that access.
 **Commands** allow us to do just that.
 Each [`Command`] represents an instruction for manipulations to be performed on the world, and when we call a `Command` it gets placed in the **Command Queue**.
-All [`Commands`] in this queue are then ran at a specific time when we're safely able to mutably access the `World`.
+All [`Commands`] in this queue are then run at a specific time when we're safely able to mutably access the `World`.
 
 Many operations in the ECS can *only* be done via exclusive world access, such as:
 
@@ -119,13 +119,13 @@ fn update_system(mut commands: Commands) {
 ```
 
 In the above example, we have two systems: `insert_observer_system` running in the `Startup` schedule, and `update_system` running in the `Update` schedule.
-Since the `Startup` schedule only runs once, the `add_observer()` command is only ran when our application is launched.
-However a `trigger()` command is queued everytime the `Update` schedule runs, meaning that a `trigger()` command is ran every time the `Update` schedule completes.
+Since the `Startup` schedule only runs once, the `add_observer()` command is only run when our application is launched.
+However a `trigger()` command is queued everytime the `Update` schedule runs, meaning that a `trigger()` command is run every time the `Update` schedule completes.
 
 We mentioned above that by default `Commands` are applied at the *end* of a `Schedule`.
 While correct, what really happens is that all of the `Commands` we queue are placed into a special `System` known as [`ApplyDeferred`].
 This system will run at the end of every `Schedule` that has a system which uses `Commands` as a `SystemParameter`.
-Since `ApplyDeferred` is ran after all of systems in a given schedule, all of the changes made by the `ApplyDeferred` system are able to be seen by the systems in other schedules.
+Since `ApplyDeferred` is run after all of systems in a given schedule, all of the changes made by the `ApplyDeferred` system are able to be seen by the systems in other schedules.
 
 In addition, if a system accessing `Commands` is ordered before another system also accessing `Commands` in the same `Schedule`, the second system will always see the effects of `Commands` run in the first system.
 Bevy ensures this occurs by dynamically inserting synchronization points, during which all `Commands` are applied.
@@ -187,8 +187,8 @@ player_commands.insert_if_new((Health(10)));
 ```
 
 Like `Commands`, `EntityCommands` aren't run immediately.
-This means that it is possible for the `Entity` you want to modify to have despawned before the `EntityCommand` can be ran.
-All `EntityCommands` will check whether the `Entity` exists when the `EntityCommand` is ran and will return an error if it doesn't.
+This means that it is possible for the `Entity` you want to modify to have despawned before the `EntityCommand` can be run.
+All `EntityCommands` will check whether the `Entity` exists when the `EntityCommand` is run and will return an error if it doesn't.
 
 [`EntityCommands`]: https://docs.rs/bevy/latest/bevy/prelude/struct.EntityCommands.html
 [`Commands::entity`]: https://docs.rs/bevy/latest/bevy/ecs/prelude/struct.Commands.html#method.entity

--- a/content/learn/book/control-flow/events.md
+++ b/content/learn/book/control-flow/events.md
@@ -105,7 +105,7 @@ world.add_observer(|event: On<DespawnEnemyUnits>, commands: Commands, enemy_unit
 
 In the above example, we've created an `Observer` that will run its `ObserverSystem` when a `DespawnEnemyUnits` event is triggered. Additionally, we've accessed `Commands` and `Query` as parameters to gain access to the data we need. Within the `ObserverSystem`, we use a `for` loop to despawn every `Enemy` entity that is given in the `enemy_units` query.
 
-It is also worth noting that we can trigger an `Event` within an `ObserverSystem`. Instead of triggering immediately (as is the case when using `World::trigger`), triggering an `Event` inside an `Observer` with `Commands::trigger` will run the newly triggered `ObserverSystem` at the end of the `Command` queue. Once all of the other `Observer` commands that are currently in the queue are ran, then the new `ObserverSystem` will be run. Be aware that these events are evaluated *recursively*, and will exit once there are no more events left.
+It is also worth noting that we can trigger an `Event` within an `ObserverSystem`. Instead of triggering immediately (as is the case when using `World::trigger`), triggering an `Event` inside an `Observer` with `Commands::trigger` will run the newly triggered `ObserverSystem` at the end of the `Command` queue. Once all of the other `Observer` commands that are currently in the queue are run, then the new `ObserverSystem` will be run. Be aware that these events are evaluated *recursively*, and will exit once there are no more events left.
 
 ```rust
 // When Event `A` is triggered, it in turn will trigger Event `B`.

--- a/content/learn/book/control-flow/lifecycle-events.md
+++ b/content/learn/book/control-flow/lifecycle-events.md
@@ -67,7 +67,7 @@ fn hook_function(world: DeferredWorld, component_hook: HookContext) {
 }
 ```
 
-By deriving the `component` attribute on `MyComponent` and pointing to the function that should be run when `MyComponent` is modified, we can ensure that our lifecycle event is ran every time `MyComponent` is added.
+By deriving the `component` attribute on `MyComponent` and pointing to the function that should be run when `MyComponent` is modified, we can ensure that our lifecycle event is run every time `MyComponent` is added.
 Using an attribute can also be further extended through closures if we want to avoid repeating similar code:
 
 ```rust

--- a/content/learn/book/control-flow/messages.md
+++ b/content/learn/book/control-flow/messages.md
@@ -179,7 +179,7 @@ fn read_scoreboard_update(
 ```
 
 Finally, we can add our systems into their respective schedules.
-Keep in mind that the system which updates our `ScoreboardUpdate` message resource is going to be ran in the `First` schedule, which is the first thing ran on every new frame.
+Keep in mind that the system which updates our `ScoreboardUpdate` message resource is going to be run in the `First` schedule, which is the first thing run on every new frame.
 As a result we'll want to schedule `read_scoreboard_update` *before* `write_scoreboard_update`, but after the `First` schedule completes.
 The `PreUpdate` schedule fits nicely for `read_scoreboard_update`, running before `Update` and well before `PostUpdate` which is where we'll place `write_scoreboard_update`.
 This prevents multiple `ScoreboardUpdate` messages being read at once and allows our gameplay systems to run with a freshly updated `Scoreboard` resource.
@@ -192,7 +192,7 @@ fn main() {
         // The `First` schedule runs before PreUpdate, which allows our messages to be 
         // updated.
         .add_systems(PreUpdate, read_scoreboard_update)
-        // Once all of our gameplay systems ran in Update, then we can accurately write
+        // Once all of our gameplay systems run in Update, then we can accurately write
         // a new ScoreboardUpdate message, which will be updated in the next frame.
         .add_systems(PostUpdate, write_scoreboard_update)
     ;
@@ -392,7 +392,7 @@ fn main() {
 }
 ```
 
-By placing `warn_tick_damage_update` in `Update`, it gets ran every frame. In contrast, `deal_tick_damage_update` is placed in `FixedUpdate`, meaning that it will run at a consistent interval instead of every frame.
+By placing `warn_tick_damage_update` in `Update`, it gets run every frame. In contrast, `deal_tick_damage_update` is placed in `FixedUpdate`, meaning that it will run at a consistent interval instead of every frame.
 
 [`FixedUpdate`]: https://docs.rs/bevy/latest/bevy/prelude/struct.FixedUpdate.html
 [`FixedMain`]: https://docs.rs/bevy/latest/bevy/app/struct.FixedMain.html

--- a/content/learn/book/control-flow/systems.md
+++ b/content/learn/book/control-flow/systems.md
@@ -91,7 +91,7 @@ If you're interested, you can check the [`SystemParam`] page for more details.
 ## Accessing Data In Systems
 
 One of the major benefits of Bevy's system abstraction is that it easily and efficiently ["splits the borrow"] of a `World`.
-When a system is ran, the requested data is automatically fetched from the `World`.
+When a system is run, the requested data is automatically fetched from the `World`.
 Other systems are prevented from accessing the requested data if their access would violate the rules of the borrow checker.
 The prime directive of Rust still applies: accessing `World` data can be mutable *or* shared, but never both at once.
 
@@ -183,7 +183,7 @@ See the section on [local system state] for more details.
 
 ## Running Systems In Schedules
 
-Systems are usually repeatedly ran throughout the life of your application.
+Systems are usually repeatedly run throughout the life of your application.
 We are able to control when systems run and how systems are ordered by placing them into a [`Schedule`].
 The [`App::add_system`] method is the simplest way to do this, allowing us to specify a `System` that we want to insert into a specific `Schedule` running in our application.
 
@@ -244,12 +244,12 @@ fn register_one_shot_systems(mut world: &mut World) {
 
 // System that runs on command.
 fn one_shot_system() {
-    println!("This is a one-shot system that is ran on demand.");
+    println!("This is a one-shot system that is run on demand.");
 }
 
 // System that runs on command and takes a usize input.
 fn one_shot_system_with_input(In(input): In<usize>) {
-    println!("This is a one-shot system ran on demand with input: {}", input);
+    println!("This is a one-shot system run on demand with input: {}", input);
 }
 ```
 
@@ -261,10 +261,10 @@ Any internal state (such as [locals] or [change detection] information) will be 
 ```rust
 fn run_one_shot_systems(mut world: &mut World) {
     // This will print a `local_value: 1` since this is the first time
-    // the system is ran.
+    // the system is run.
     world.run_system_cached(one_shot_system);
     // This will print a `local_value: 2` since this is the second time 
-    // the system is ran, and `local_value` is cached from the first run 
+    // the system is run, and `local_value` is cached from the first run 
     // of the system.
     world.run_system_cached(one_shot_system);
 }
@@ -304,7 +304,7 @@ commands.run_system(SystemId);
 commands.run_system_with(SystemId, SystemInput);
 ```
 
-Note that an entire [`Schedule`] can be ran on demand in much the same way,
+Note that an entire [`Schedule`] can be run on demand in much the same way,
 which can be valuable when trying to evaluate complex blocks of logic in response to specific triggers,
 or at a rate other than "once per frame".
 
@@ -348,7 +348,7 @@ fn exclusive_system(mut world: &mut World) {
     world.register_system(SystemdId);
     // This removes all entities from the World.
     world.clear_entities();
-    // This adds a custom schedule to be ran in the World.
+    // This adds a custom schedule to be run in the World.
     world.add_schedule(MySchedule);
 }
 ```
@@ -357,7 +357,7 @@ Exclusive systems are useful for operations that require making large or unique 
 Spawning large numbers of entities at once is one example of this, as there is no additional overhead incurred from *queueing* these changes like there is when using `Commands`.
 They are also extremely useful for unusually complex game logic or control flow and can be used to immediately run schedules and one-shot systems (including other exclusive systems).
 
-That said, exclusive systems are harder to schedule, both because they prevent any other system from running at the same time and because their scheduling order is ambiguous with any other systems in the same schedule. Remember that all systems in a specific `Schedule` are ran in parallel by default unless explicitly ordered.
+That said, exclusive systems are harder to schedule, both because they prevent any other system from running at the same time and because their scheduling order is ambiguous with any other systems in the same schedule. Remember that all systems in a specific `Schedule` are run in parallel by default unless explicitly ordered.
 
 ## System Input and Output
 

--- a/content/learn/book/intro/the-three-letters.md
+++ b/content/learn/book/intro/the-three-letters.md
@@ -91,7 +91,7 @@ Entities are usually spawned using [Commands](../control-flow/commands), which q
 ## The S: Systems
 
 Systems interact with and update the data in the ECS.
-Each system is ran every frame by default, and repeats in a loop (specifically, in a [Schedule](../the-game-loop/schedules)).
+Each system is run every frame by default, and repeats in a loop (specifically, in a [Schedule](../the-game-loop/schedules)).
 In Bevy, systems are "just Rust functions".
 These can fetch data from the ECS, make updates, call external APIs, and anything else that a function can do.
 

--- a/content/learn/book/the-game-loop/time-and-timers.md
+++ b/content/learn/book/the-game-loop/time-and-timers.md
@@ -345,7 +345,7 @@ fn delayed_spawn(mut commands: Commands) {
 ```
 
 `DelayedCommands` can be set using either seconds (using [`.secs`]) or a duration (using [`.duration`]), much like `Timer`s and `Stopwatch`s can.
-However, instead of needing to manually tick our `DelayedCommands`, Bevy will automatically tick them in a system ran in the `PreUpdate` schedule.
+However, instead of needing to manually tick our `DelayedCommands`, Bevy will automatically tick them in a system run in the `PreUpdate` schedule.
 All we have to do is provide the amount of time to delay our command by, and Bevy will handle the rest.
 
 [`Commands`]: https://docs.rs/bevy/latest/bevy/ecs/prelude/struct.Commands.html


### PR DESCRIPTION
Particularly with perfect and simple tenses where "ran" has been used incorrectly instead of "run".