### PR TITLE
improve book content on release builds

### DIFF
--- a/content/learn/book/releasing-projects/release-builds.md
+++ b/content/learn/book/releasing-projects/release-builds.md
@@ -72,7 +72,7 @@ this can improve dead code detection, reducing binary size.
 Setting `lto = "thin"` for release builds is a good default as it provides performance gains similar to `lto = "fat"` while
 taking substantially less time due to being parallelizable. In Cargo `lto = true` and `lto = "fat"` are the same thing.
 
-By default, release builds will use `lto = false` which is "thin local LTO", performing LTO with the crate.
+By default, release builds will use `lto = false` which is "thin local LTO", performing LTO within the crate.
 This level of LTO is there to offset
 the losses incurred by codegen units above 1. This level of LTO is skipped if codegen units is 1.
 

--- a/content/learn/book/releasing-projects/release-builds.md
+++ b/content/learn/book/releasing-projects/release-builds.md
@@ -69,14 +69,22 @@ by allowing the linker to take a more global view.
 In addition to performance gains,
 this can improve dead code detection, reducing binary size.
 
-Setting `lto = "fat"` enables better optimization than the basic "thin" LTO provided by `lto = true`.
+For release builds `lto = "thin"` is a good default as it provides performance gains similar to `lto = "fat"` while
+taking substantially less time due to being parallelizable. In Cargo `lto = true` and `lto = "fat"` are the same thing.
+
+By default, release builds will use `lto = false` which is "thin local LTO". This level of LTO is there to offset
+the losses incurred by codegen units above 1. This level of LTO is skipped if codegen units is 1.
+
+You may wish to experiment with full/"fat" LTO for final published builds, but be prepared for much longer builds and
+a higher peak memory usage during compilation.
 
 Modifying this setting will slow down compilation.
 
 ### Code-Gen Units
 
-Similarly, we can eliminate parallelism during compilation by setting `codegen-units = 1`.
-This will allow the compiler to find additional optimizations in much the same way.
+Similarly, we can eliminate intra-crate parallelism during compilation by setting `codegen-units = 1`.
+Spreading crate compilation across multiple codegen units speeds up compilation at the cost of increased
+build size and lost optimisation opportunities.
 
 Modifying this setting will slow down compilation.
 

--- a/content/learn/book/releasing-projects/release-builds.md
+++ b/content/learn/book/releasing-projects/release-builds.md
@@ -69,10 +69,11 @@ by allowing the linker to take a more global view.
 In addition to performance gains,
 this can improve dead code detection, reducing binary size.
 
-For release builds `lto = "thin"` is a good default as it provides performance gains similar to `lto = "fat"` while
+Setting `lto = "thin"` for release builds is a good default as it provides performance gains similar to `lto = "fat"` while
 taking substantially less time due to being parallelizable. In Cargo `lto = true` and `lto = "fat"` are the same thing.
 
-By default, release builds will use `lto = false` which is "thin local LTO". This level of LTO is there to offset
+By default, release builds will use `lto = false` which is "thin local LTO", performing LTO with the crate.
+This level of LTO is there to offset
 the losses incurred by codegen units above 1. This level of LTO is skipped if codegen units is 1.
 
 You may wish to experiment with full/"fat" LTO for final published builds, but be prepared for much longer builds and

--- a/content/learn/book/releasing-projects/release-builds.md
+++ b/content/learn/book/releasing-projects/release-builds.md
@@ -74,7 +74,7 @@ taking substantially less time due to being parallelizable. In Cargo `lto = true
 
 By default, release builds will use `lto = false` which is "thin local LTO", performing LTO within the crate.
 This level of LTO is there to offset
-the losses incurred by codegen units above 1. This level of LTO is skipped if codegen units is 1.
+the losses incurred by codegen units above 1. It is skipped if codegen units is 1.
 
 You may wish to experiment with full/"fat" LTO for final published builds, but be prepared for much longer builds and
 a higher peak memory usage during compilation.


### PR DESCRIPTION
Touched up lto and codegen units section in release builds. The previous information about `lto = true` being "thin" was incorrect.

You can reference the Cargo [lto docs](https://doc.rust-lang.org/cargo/reference/profiles.html#lto) for more info