### PR TITLE
Document common WASM-related dependency compilation error

### DIFF
--- a/content/learn/quick-start/troubleshooting.md
+++ b/content/learn/quick-start/troubleshooting.md
@@ -61,10 +61,10 @@ If you have only one tree dependency on `getrandom`, then adding
 `getrandom = { version = "*", features = ["wasm_js"] }` might solve the issue.
 
 However, if your crate depends on multiple versions of `getrandom`, then this will not be enough:
-The wilcard version pattern still ends up reflecting only a single version of the crate you want to add a feature for.
+The wildcard version pattern still ends up reflecting only a single version of the crate you want to add a feature for.
 
 Since you cannot specify two dependencies with the same name, and since cargo does not know that you want the feature to apply to every instance of the crate
-(what if a cargo feature only exists for some versions of the dependency?), you might have to use this workaround sometimes refered to as 'renaming' the
+(what if a cargo feature only exists for some versions of the dependency?), you might have to use this workaround sometimes referred to as 'renaming' the
 dependency:
 
 ```toml

--- a/content/learn/quick-start/troubleshooting.md
+++ b/content/learn/quick-start/troubleshooting.md
@@ -48,3 +48,27 @@ Or for `codelldb`:
     // Switch `nightly` to `stable` if you're using Rust stable
 },
 ```
+
+## Unable to compile `getrandom` when building for web
+
+```txt
+   Compiling getrandom v0.3.4
+   Compiling getrandom v0.4.2
+error: The wasm32-unknown-unknown targets are not supported by default; you may need to enable the "wasm_js" crate feature.
+```
+
+If you have only one tree dependency on `getrandom`, then adding
+`getrandom = { version = "*", features = ["wasm_js"] }` might solve the issue.
+
+However, if your crate depends on multiple versions of `getrandom`, then this will not be enough:
+The wilcard version pattern still ends up reflecting only a single version of the crate you want to add a feature for.
+
+Since you cannot specify two dependencies with the same name, and since cargo does not know that you want the feature to apply to every instance of the crate
+(what if a cargo feature only exists for some versions of the dependency?), you might have to use this workaround sometimes refered to as 'renaming' the
+dependency:
+
+```toml
+# under the [dependencies] section of `Cargo.toml`
+getrandom_a = { package = "getrandom", version = "0.3.4", features = ["wasm_js"] }
+getrandom_b = { package = "getrandom", version = "0.4.2", features = ["wasm_js"] }
+```


### PR DESCRIPTION
I kept running into this problem in various contexts (also outside of bevy, but often in this exact format when doing WASM things).

It seems to be considered a "known issue", but where the solution is easily forgotten. Since we want bevy to be accessible, this makes a good candidate for a troubleshooting note for this part of the quick learn section.

The solution here doesn't just repeat the written fix of adding "wasm_js" as a feature, but shows how to apply this fix in a larger dependency tree like you typically have with bevy games.

I think the voice could maybe use simpler words, but I feel like it does the job.