### PR TITLE
Remove references to RFCs in Contributing Guide

### DIFF
--- a/content/learn/contribute/helping-out/opening-pull-requests.md
+++ b/content/learn/contribute/helping-out/opening-pull-requests.md
@@ -39,10 +39,10 @@ Individual contributors often lead major new features and reworks. However these
 
 1. A need or opportunity is identified and an issue is made, laying out the general problem.
 2. As needed, this is discussed further on that issue thread, in cross-linked [GitHub Discussions] threads, or on [Discord] in the Engine Development channels.
-3. Either a Draft Pull Request or an RFC is made. As discussed in the [RFC repo](https://github.com/bevyengine/rfcs), complex features need RFCs, but these can be submitted before or after prototyping work has been started.
+3. Either a Draft Pull Request or a design doc is made. As discussed in the [Goals](../project-information/project-goals.md) section of this guide, particularly involved or controversial work may want a goal with a working group.
 4. If feasible, parts that work on their own (even if they're only useful once the full complex change is merged) get split out into individual PRs to make them easier to review.
-5. The community as a whole helps improve the Draft PR and/or RFC, leaving comments, making suggestions, and submitting pull requests to the original branch.
-6. Once the RFC is merged and/or the Draft Pull Request is transitioned out of draft mode, the [normal change process outlined in the previous section](#making-changes-to-bevy) can begin.
+5. The community as a whole helps improve the Draft PR and/or design doc, leaving comments, making suggestions, and submitting pull requests to the original branch.
+6. Once there's a semblance of consensus on the design, the [normal change process outlined in the previous section](#making-changes-to-bevy) can begin.
 
 ## Contributing Code
 

--- a/content/learn/contribute/helping-out/reviewing-pull-requests.md
+++ b/content/learn/contribute/helping-out/reviewing-pull-requests.md
@@ -47,15 +47,14 @@ With the large number of contributors and reviewers collectively building a comp
 
 ## What to review
 
-There are three main places you can check for things to review:
+There are two main places you can check for things to review:
 
 1. Pull requests which are ready and in need of more reviews on the [`bevy` repository](https://github.com/bevyengine/bevy/pulls?q=is%3Aopen+is%3Apr+-label%3AS-Ready-For-Final-Review+-draft%3A%3Atrue+-label%3AS-Needs-RFC+-reviewed-by%3A%40me+-author%3A%40me).
 2. Pull requests on the [`bevy`](https://github.com/bevyengine/bevy/pulls) and the [`bevy-website`](https://github.com/bevyengine/bevy-website/pulls) repositories.
-3. [RFCs](https://github.com/bevyengine/rfcs), which need extensive thoughtful community input on their design.
 
-Not even our Project Lead and Maintainers are exempt from reviews and RFCs! By giving feedback on this work (and related supporting work), you can help us make sure our releases are both high-quality and timely.
+Not even our Project Lead and Maintainers are exempt from reviews! By giving feedback on this work (and related supporting work), you can help us make sure our releases are both high-quality and timely.
 
-Finally, if nothing brings you more satisfaction than seeing every last issue labeled and all resolved issues closed, feel free to message @alice-i-cecile or @cart for a Bevy Org role to help us keep things tidy.
+Finally, if nothing brings you more satisfaction than seeing every last issue labeled and all resolved issues closed, feel free to message `@alice-i-cecile` or `@cart` for a Bevy Org role to help us keep things tidy.
 
 As discussed in our page on [The Bevy Organization](@/learn/contribute/project-information/bevy-organization.md), this role only requires good faith and a basic understanding of our development process.
 

--- a/content/learn/contribute/helping-out/reviewing-pull-requests.md
+++ b/content/learn/contribute/helping-out/reviewing-pull-requests.md
@@ -49,8 +49,8 @@ With the large number of contributors and reviewers collectively building a comp
 
 There are two main places you can check for things to review:
 
-1. Pull requests which are ready and in need of more reviews on the [`bevy` repository](https://github.com/bevyengine/bevy/pulls?q=is%3Aopen+is%3Apr+-label%3AS-Ready-For-Final-Review+-draft%3A%3Atrue+-label%3AS-Needs-RFC+-reviewed-by%3A%40me+-author%3A%40me).
-2. Pull requests on the [`bevy`](https://github.com/bevyengine/bevy/pulls) and the [`bevy-website`](https://github.com/bevyengine/bevy-website/pulls) repositories.
+1. Pull requests on the [`bevy` repository](https://github.com/bevyengine/bevy/pulls?q=is%3Aopen+is%3Apr+-draft%3A%3Atrue+-reviewed-by%3A%40me+-author%3A%40me+label%3AS-Needs-Review).
+2. Pull requests on the [`bevy-website` repository](https://github.com/bevyengine/bevy-website/pulls).
 
 Not even our Project Lead and Maintainers are exempt from reviews! By giving feedback on this work (and related supporting work), you can help us make sure our releases are both high-quality and timely.
 

--- a/content/learn/contribute/helping-out/writing-docs.md
+++ b/content/learn/contribute/helping-out/writing-docs.md
@@ -13,7 +13,7 @@ This is incredibly valuable, and easily distributed, work that requires a bit of
 * Code documentation (doc examples and in the examples folder) is easier to maintain because the compiler will tell us when it breaks.
 * Inline documentation should be technical and to the point. Link relevant examples or other explanations if broader context is useful.
 * The Bevy Book is hosted on the `bevy-website` repository and targeted towards beginners who are just getting to know Bevy (and perhaps even Rust!).
-* Accepted RFCs are not documentation; they serve only as a record of accepted decisions.
+* Accepted design docs are not documentation; they serve only as a record of accepted decisions and a blueprint for what to build.
 
 ## Documentation Sources
 

--- a/content/learn/contribute/helping-out/writing-docs.md
+++ b/content/learn/contribute/helping-out/writing-docs.md
@@ -13,7 +13,7 @@ This is incredibly valuable, and easily distributed, work that requires a bit of
 * Code documentation (doc examples and in the examples folder) is easier to maintain because the compiler will tell us when it breaks.
 * Inline documentation should be technical and to the point. Link relevant examples or other explanations if broader context is useful.
 * The Bevy Book is hosted on the `bevy-website` repository and targeted towards beginners who are just getting to know Bevy (and perhaps even Rust!).
-* Accepted design docs are not documentation; they serve only as a record of accepted decisions and a blueprint for what to build.
+* Accepted design docs are not a substitute for end user documentation; they serve only as a record of accepted decisions and a blueprint for what to build.
 
 ## Documentation Sources
 

--- a/content/learn/contribute/project-information/bevy-organization.md
+++ b/content/learn/contribute/project-information/bevy-organization.md
@@ -54,7 +54,7 @@ SMEs are responsible for:
 - Managing their [Area Project Board](/learn/contribute/project-information/areas)
 - Being a point of contact for contributors interested in an Area
 
-SME approvals count as "votes" on controversial PRs (provided the PR is in their "subject area"). This includes [RFCs](https://github.com/bevyengine/rfcs) and working groups design documents. If a controversial PR has two votes from Subject Matter Experts in that PR's area, it can be merged without Project Lead approval. If a SME creates a PR in their subject area, this does count as a vote.
+SME approvals count as "votes" on controversial PRs (provided the PR is in their "subject area"). This includes working groups design documents. If a controversial PR has two votes from Subject Matter Experts in that PR's area, it can be merged without Project Lead approval. If a SME creates a PR in their subject area, this does count as a vote.
 
 However, the Project Lead has the right to revert changes merged this way, so it is each SME's responsibility to ensure they have synced up with the Project Lead's vision. Additionally, when approving a design, consensus between SMEs and the Project Lead (and ideally most of the wider Bevy community) is heavily encouraged. Merging without consensus risks fractured project vision and/or ping-ponging between designs. The "larger" the impact of a design, the more critical it is to establish consensus.
 


### PR DESCRIPTION
These are, in practice, [dead letter](https://en.wikipedia.org/wiki/Unenforced_law). The last one merged was two years ago, experienced contributors ignore them, and they have been deliberately supplanted by the design docs in the Goals workflow.

We should avoid pointing hapless new contributors there: it wastes their time, and it wastes our time reviewing them.

Once this PR is merged, I'll update the RFCs repo with a note to this effect in the README and archive it.

## Note to reviewers

This was done by searching for RFC in the website repo: the only references that remain are old release notes, which should stay.