### PR TITLE
Update `oxipng` to version 10.1.1

### DIFF
--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Install oxipng
         run: |
-          cargo install oxipng --version ^9.1.1
+          cargo install oxipng --version ^10.1.1
 
       - name: Take Screenshots
         run: |


### PR DESCRIPTION
This PR updates `oxipng` (which we use to compress website screenshots in a GitHub workflow) to the current stable version [`10.1.1`](https://github.com/oxipng/oxipng/releases/tag/v10.1.1).
