### PR TITLE
Mention enabling cranelift breaks variable inspection while debugging

### DIFF
--- a/content/learn/book/development-practices/fast-compiles.md
+++ b/content/learn/book/development-practices/fast-compiles.md
@@ -118,7 +118,10 @@ Notably, Wasm builds do not work yet.
 When shipping your game, you should still compile it with LLVM.
 
 {% callout(type="caution") %}
-Enabling cranelift is known to break variable inspection while debugging.
+Enabling cranelift is known to break local variable inspection while debugging.
+You can only inspect statics.
+This is caused by the fact that `rustc_codegen_cranelift` is missing DWARF support.
+Also see https://github.com/rust-lang/rustc_codegen_cranelift/issues/166
 {% end %}
 
 

--- a/content/learn/book/development-practices/fast-compiles.md
+++ b/content/learn/book/development-practices/fast-compiles.md
@@ -121,7 +121,7 @@ When shipping your game, you should still compile it with LLVM.
 Enabling cranelift is known to break local variable inspection while debugging.
 You can only inspect statics.
 This is caused by the fact that `rustc_codegen_cranelift` is missing DWARF support.
-Also see https://github.com/rust-lang/rustc_codegen_cranelift/issues/166
+See [`cranelift #166](https://github.com/rust-lang/rustc_codegen_cranelift/issues/166) for more information.
 {% end %}
 
 

--- a/content/learn/book/development-practices/fast-compiles.md
+++ b/content/learn/book/development-practices/fast-compiles.md
@@ -86,9 +86,6 @@ For more information, see [The rustup book: Overrides](https://rust-lang.github.
 
 ## Cranelift
 
-> [!WARNING]
-> Enabling cranelift is known to break variable inspection while debugging.
-
 This uses a new nightly-only codegen that is about 30% faster at compiling than LLVM.
 It currently works best on Linux.
 
@@ -119,6 +116,11 @@ While Cranelift is very fast to compile, the generated binaries are not optimize
 Notably, Wasm builds do not work yet.
 
 When shipping your game, you should still compile it with LLVM.
+
+{% callout(type="caution") %}
+Enabling cranelift is known to break variable inspection while debugging.
+{% end %}
+
 
 ## Generic Sharing
 

--- a/content/learn/book/development-practices/fast-compiles.md
+++ b/content/learn/book/development-practices/fast-compiles.md
@@ -86,6 +86,9 @@ For more information, see [The rustup book: Overrides](https://rust-lang.github.
 
 ## Cranelift
 
+> [!WARNING]
+> Enabling cranelift is known to break variable inspection while debugging.
+
 This uses a new nightly-only codegen that is about 30% faster at compiling than LLVM.
 It currently works best on Linux.
 

--- a/content/learn/quick-start/getting-started/setup.md
+++ b/content/learn/quick-start/getting-started/setup.md
@@ -376,10 +376,6 @@ This section explains how to speed up iterative compiles: the amount of time it 
 
   When shipping your game, you should still compile it with LLVM.
 
-  {% callout(type="caution") %}
-  Enabling cranelift is known to break variable inspection while debugging.
-  {% end %}
-
 </details>
 
 <details>

--- a/content/learn/quick-start/getting-started/setup.md
+++ b/content/learn/quick-start/getting-started/setup.md
@@ -375,6 +375,11 @@ This section explains how to speed up iterative compiles: the amount of time it 
   Notably, Wasm builds do not work yet.
 
   When shipping your game, you should still compile it with LLVM.
+
+  {% callout(type="caution") %}
+  Enabling cranelift is known to break variable inspection while debugging.
+  {% end %}
+
 </details>
 
 <details>


### PR DESCRIPTION
Hi, I just spent a few hours trying to figure out why I can't see any variables while debugging.
Turns out that enabling cranelift, as explained in fast-compiles, may improve compile times, but also breaks variable inspection.

There is even an issue open:
https://github.com/bevyengine/bevy/issues/19916

Therefore, it really should be documented that this has negative downsides, so other people won't run into the same issue.

This closes https://github.com/bevyengine/bevy/issues/19916