### PR TITLE
Small fixes for 0.19 release notes and migration guide

### DIFF
--- a/content/learn/migration-guides/0.18-to-0.19.md
+++ b/content/learn/migration-guides/0.18-to-0.19.md
@@ -38,12 +38,22 @@ If you run into a problem while migrating that was not covered by this migration
 
 In 0.19, `Resource` is a subtrait of `Component` and `#[derive(Resource)]` implements both `Resource` as well as `Component`.
 This means it's no longer possible to doubly derive both `Component` and `Resource`.
-Instead, you should split them up:
+
+Types can no longer meaningfully be used as both resources and components.
+This was a [deliberate change](https://github.com/bevyengine/bevy/pull/24594):
+ensuring that "resource" always ensures uniqueness, regardless of how the type is used.
+
+Inserting new copies of any type which implements `Resource`, even as a component,
+will despawn other copies of that component on other entities.
+Similarly, data of type `T` stored as a resource will show up in queries for e.g. `&T`,
+leading to confusing new bugs.
+
+To migrate, you should split these types into distinct resource and component types:
 
 ```rust
 // 0.18
 #[derive(Component, Resource)]
-struct Dual
+struct MyData(f32);
 ```
 
 becomes
@@ -51,13 +61,15 @@ becomes
 ```rust
 // 0.19
 #[derive(Component)]
-struct DualComp;
+struct MyDataComp(f32);
 
 #[derive(Resource)]
-struct DualRes;
+struct MyDataRes(f32);
 ```
 
-Consequently, `UiDebugOverlay` is split into `GlobalUiDebugOverlay` (resource) and `UiDebugOverlay` (component), and `UiDebugOptions` is split into `GlobalUiDebugOptions` (resource) and `UiDebugOptions` (component).
+We had a few types that were both resources and components inside of Bevy itself, for a "global fallback" pattern.
+`UiDebugOverlay` is split into `GlobalUiDebugOverlay` (resource) and `UiDebugOverlay` (component), and `UiDebugOptions` is split into `GlobalUiDebugOptions` (resource) and `UiDebugOptions` (component).
+
 
 #### `#[reflect(Resource)]` Changes
 

--- a/content/news/2026-06-14-bevy-0.19/index.md
+++ b/content/news/2026-06-14-bevy-0.19/index.md
@@ -524,7 +524,7 @@ For more details, read [JMS55's blog post](https://jms55.github.io/posts/2026-04
 
 ## More Feathers Widgets
 
-{{ heading_metadata(authors=["@viridia", "@jordanhalase"] prs=[23645, 23707, 23788, 23787, 23804, 23817, 23842, 23744, 23820, 23830, 23869, 23883, 23890, 23993]) }}
+{{ heading_metadata(authors=["@viridia", "@jordanhalase"] prs=[23645, 23707, 23788, 23787, 23804, 23817, 23842, 23744, 23820, 23830, 23869, 23883, 23890, 23993, 24092]) }}
 
 ![feathers widgets](feathers.jpg)
 
@@ -536,6 +536,7 @@ Bevy Feathers, our opinionated UI widget collection designed with the Bevy edito
 - Disclosure toggle (chevron expand/collapse)
 - Icon and label (display primitives)
 - Pane, subpane, and group (decorative frames for editors)
+- List view, with a scrollbar that can be used seperately
 
 We've improved the existing widgets! For full usage and an interactive demo, try out the [`feathers_gallery`] example.
 
@@ -999,13 +1000,13 @@ We've also fixed two important correctness bugs in the process:
 
 Benchmarked on Bistro Exterior (698 materials) we saw significant frame time improvements (and sometimes memory improvements) across many hardware configurations:
 
-| GPU                      | Frame Time Speedup         | Memory      |
-| ------------------------ | ------------------- | ----------- |
-| Apple M2 Max (Metal)     | +15%                | −57 MB RAM  |
-| NVIDIA 5060 Ti           | +46%                | Same        |
-| AMD Vega 8 / Ryzen 4800U | Same                | −88 MB VRAM |
-| Intel i360P              | +14%                | Same        |
-| Intel Iris XE            | Same                | Same        |
+| GPU                      | Frame Time Speedup | Memory      |
+| ------------------------ | ------------------ | ----------- |
+| Apple M2 Max (Metal)     | +15%               | −57 MB RAM  |
+| NVIDIA 5060 Ti           | +46%               | Same        |
+| AMD Vega 8 / Ryzen 4800U | Same               | −88 MB VRAM |
+| Intel i360P              | +14%               | Same        |
+| Intel Iris XE            | Same               | Same        |
 
 [Bistro] is a demanding, fairly realistic scene.
 While bindless limitations remain frustrating, especially on Mac where Vulkan isn't an option,

--- a/content/news/2026-06-14-bevy-0.19/index.md
+++ b/content/news/2026-06-14-bevy-0.19/index.md
@@ -967,13 +967,13 @@ The standard fix is parallax correction: each reflection probe gets its own boun
 Bevy now applies this automatically for light probes, using the probe's influence bounding box as the correction volume.
 This is a reasonable default for a cubemap capturing a rectangular room interior, and matches Blender's approach.
 
-Parallax correction is enabled by default. To opt out on a specific probe, add `NoParallaxCorrection`:
+Parallax correction is enabled by default. To opt out on a specific probe, add `ParallaxCorrection::None`:
 
 ```rust
 commands.spawn((
     LightProbe,
     EnvironmentMapLight { .. },
-    NoParallaxCorrection,
+    ParallaxCorrection::None,
 ));
 ```
 

--- a/content/news/2026-06-14-bevy-0.19/index.md
+++ b/content/news/2026-06-14-bevy-0.19/index.md
@@ -1025,7 +1025,7 @@ Bevy's diagnostics have always been easy to dump to the terminal, but displaying
 
 ```rust
 commands.spawn(DiagnosticsOverlay::fps());
-commands.spawn(DiagnosticsOverlay::mesh_and_standard_materials());
+commands.spawn(DiagnosticsOverlay::mesh_and_standard_material());
 ```
 
 You can also build a custom overlay from any [`DiagnosticPath`](https://dev-docs.bevy.org/bevy/diagnostic/struct.DiagnosticPath.html) list:

--- a/content/news/2026-06-14-bevy-0.19/index.md
+++ b/content/news/2026-06-14-bevy-0.19/index.md
@@ -1264,7 +1264,7 @@ commands.spawn((Mesh3d(mesh), TransformGizmoFocus));
 ```
 
 The plugin is deliberately not connected to user input.
-This keeps the gizmo composable for editor authors who already have opinions about input handling. Sensitivity, snapping, and screen-space scaling are all configurable via `TransformGizmoConfig`,
+This keeps the gizmo composable for editor authors who already have opinions about input handling. Sensitivity, snapping, and screen-space scaling are all configurable via `TransformGizmoSettings`,
 while modes are controlled via the `TransformGizmoMode` resource.
 
 Much of the math and implementation strategy for this widget comes from the [`bevy_transform_gizmo`](https://github.com/fslabs/bevy_transform_gizmo) crate.

--- a/content/news/2026-06-14-bevy-0.19/index.md
+++ b/content/news/2026-06-14-bevy-0.19/index.md
@@ -536,7 +536,7 @@ Bevy Feathers, our opinionated UI widget collection designed with the Bevy edito
 - Disclosure toggle (chevron expand/collapse)
 - Icon and label (display primitives)
 - Pane, subpane, and group (decorative frames for editors)
-- List view, with a scrollbar that can be used seperately
+- List view, with a scrollbar that can be used separately
 
 We've improved the existing widgets! For full usage and an interactive demo, try out the [`feathers_gallery`] example.
 


### PR DESCRIPTION
Fixes #2480. Fixes #2482. Fixes #2486. Fixes #2487. Fixes #2488. 

I verified that each of these are real problems in 0.19 by checking against [docs.rs for the release candidate](https://docs.rs/bevy/0.19.0-rc.3/bevy/). It's easy to get confused about main vs the 0.19 branch, but all of the reported problems were confirmed real.