### PR TITLE
don't run oxipng without screenshots

### DIFF
--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -69,7 +69,11 @@ jobs:
 
       - name: Optimize PNGs
         run: |
-          oxipng --opt max --strip safe --recursive screenshots
+          if [ -d screenshots ]; then
+            oxipng --opt max --strip safe --recursive screenshots
+          else
+            echo "No screenshots produced for this page, skipping optimization"
+          fi
 
       - name: Upload Generated Files
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
CI to update screenshots fails if no screenshots are produced by one of the matrix job: https://github.com/bevyengine/bevy-website/actions/runs/27730743163/job/82037070751

This can happens because the number of matrix jobs is from the number of examples, but some are filtered because they can't run in ci / are headless / ... so ci ends up with more jobs than needed