### PR TITLE
0.19 Blog Post Correction - Remove line referencing helmet and wood base model

### DIFF
--- a/content/news/2026-06-19-bevy-0.19/index.md
+++ b/content/news/2026-06-19-bevy-0.19/index.md
@@ -702,8 +702,6 @@ Bevy's screen space reflections now use a "physically based" algorithm, which im
 
 ![physical_reflections](physical_reflections.png)
 
-Note the rough specular reflections of the hose on the wood base, and overall occlusion improvements.
-
 ## Rectangular Area Lights
 
 {{ heading_metadata(authors=["@dylansechet"] prs=[23288]) }}


### PR DESCRIPTION
> The "Physically Based Screen Space Reflections" section seems to be referencing a flight helmet image that isn't in the section

So, removing the line!