### PR TITLE
`Font::try_from_bytes` 0.19 migration guide: Remove mention of family name

### DIFF
--- a/content/learn/migration-guides/0.18-to-0.19.md
+++ b/content/learn/migration-guides/0.18-to-0.19.md
@@ -333,8 +333,6 @@ let font = Font::try_from_bytes(bytes.to_vec()).unwrap();
 let font = Font::from_bytes(bytes.to_vec());
 ```
 
-Note that the family name is not part of this specific change, but is required in 0.19.
-
 ### `Skybox` `image` is now optional
 
 {{ heading_metadata(prs=[23691]) }}


### PR DESCRIPTION
From discord:
> Seems that https://github.com/bevyengine/bevy/pull/24362 made it into 0.19, but its migration guide didn't make it into the migration guide. Not a huge deal, but possible that others were missed? Can't poke any deeper right now.

Can’t speak to others that might be missed by #2475, but I found the last line in the migration note confusing.
I’ve double checked bevy 0.18 and 0.18.1 and verified that the migration between the two doesn’t have to mention family name at all.