### PR TITLE
Clarify wgpu/metal bindless support

### DIFF
--- a/content/news/2026-06-19-bevy-0.19/index.md
+++ b/content/news/2026-06-19-bevy-0.19/index.md
@@ -1102,7 +1102,7 @@ A new `pccm` example demonstrates the effect, with parallax correction toggleabl
 
 Bindless rendering is how modern engines handle scenes with many different materials efficiently: shaders index into shared pools of textures and buffers rather than rebinding them each draw call.
 
-Metal (Apple's GPU API) has partial bindless support. They permit texture binding arrays but not buffer binding arrays.
+WGPU's backend for Metal (Apple's GPU API) has partial bindless support. It currently only permits texture binding arrays but not buffer binding arrays.
 
 Historically, Bevy required support for both features before it would use bindless, which excluded Metal entirely, even for materials that never use buffer arrays.
 


### PR DESCRIPTION
This is a wgpu limitation, but the way it's currently worded makes it sound like it's a metal limitation. There's a PR for adding support in wgpu https://github.com/gfx-rs/wgpu/pull/9081

MoltenVK and KosmicKrisp also both support using vulkan bindless buffers on metal.