### PR TITLE
Book Page Link Fixes

### DIFF
--- a/content/learn/book/assets/bevy's-asset-framework.md
+++ b/content/learn/book/assets/bevy's-asset-framework.md
@@ -95,7 +95,7 @@ A version of the same functionality (without playing a separate screen) can be s
 
 {% callout(type="info") %}
 
-While loading data as an asset is more complex than simply hardcoding it, doing so unlocks [asset hot reloading](../development-practices/hot-reloading.md).
+While loading data as an asset is more complex than simply hardcoding it, doing so unlocks [asset hot reloading](/learn/book/development-practices/hot-reloading).
 This allows us to change the asset file during testing and see those changes reflected in real time.
 
 {% end %}

--- a/content/learn/book/assets/lifetimes.md
+++ b/content/learn/book/assets/lifetimes.md
@@ -147,7 +147,7 @@ impl EnemyAssets {
 ```
 
 Now, all we need is to prevent our `enemy_spawner` system from running until `EnemyAssets` is loaded.
-A straight-forward approach is to use a [state](learn/book/control-flow/states/) to control for if our gameplay systems should run.
+A straight-forward approach is to use a [state](/learn/book/control-flow/states/) to control for if our gameplay systems should run.
 
 ```rust
 fn main() {

--- a/content/learn/book/assets/processing.md
+++ b/content/learn/book/assets/processing.md
@@ -112,7 +112,7 @@ processor.
 
 ### AssetLoader
 
-This is exactly the same asset loader as discussed in [`Custom Assets`](custom_assets.md). Note that
+This is exactly the same asset loader as discussed in [Custom Assets](/learn/book/assets/custom-assets). Note that
 `LoadTransformAndSave` can only use your asset loader if it is registered.
 
 ### AssetTransformer
@@ -188,7 +188,7 @@ impl AssetSaver for MySaver {
 
 Just as with [`AssetLoader`]s, your type needs to be "encoded" somehow, whether through [`serde`] or
 whatever else. It may be necessary to create a "serializable" version of your asset. This is
-described in more detail in [`Custom Assets`](custom_assets.md).
+described in more detail in [Custom Assets](/learn/book/assets/custom-assets).
 
 ## Meta Files
 

--- a/content/learn/book/control-flow/change-detection.md
+++ b/content/learn/book/control-flow/change-detection.md
@@ -195,10 +195,10 @@ When a system calls `.is_changed()`, it compares the tick count of the component
 One thing to beware of is potential 1-frame delay, if the system that is causing the change runs after the system that is checking for changes.
 You may need to pay attention to how you [run schedules] or use [explicit system ordering] to prevent this.
 
-[states]: ../states
-[run conditions]: ../run-conditions#run-conditions
-[run schedules]: ../../the-game-loop/schedules
-[explicit system ordering]: ../run-conditions
+[states]: /learn/book/control-flow/states
+[run conditions]: /learn/book/control-flow/run-conditions#run-conditions
+[run schedules]: /learn/book/the-game-loop/schedules
+[explicit system ordering]: /learn/book/control-flow/run-conditions
 
 [`set_if_neq()`]: https://docs.rs/bevy/latest/bevy/ecs/change_detection/trait.DetectChangesMut.html#method.set_if_neq
 [`ResMut`]: https://docs.rs/bevy/latest/bevy/ecs/system/struct.ResMut.html

--- a/content/learn/book/control-flow/commands.md
+++ b/content/learn/book/control-flow/commands.md
@@ -295,4 +295,4 @@ fn some_system(mut commands: Commands) {
 }
 ```
 
-[`Events` and `Observers`]: ../events
+[`Events` and `Observers`]: /learn/book/control-flow/events

--- a/content/learn/book/control-flow/handling-errors.md
+++ b/content/learn/book/control-flow/handling-errors.md
@@ -121,7 +121,7 @@ Each hex parse result value is wrapped in either `Result::Ok` or `Result::Err`.
 A common way to get the interior value is to [`unwrap`](https://doc.rust-lang.org/std/result/enum.Result.html#method.unwrap) the `Result`, but remember that in the case of an `Err`, `unwrap` will crash the program!
 With this in mind `unwrap` is best used when you know the value will be a success, and an `Err` value would indicate a bug in your application.
 
-This is notably true when [writing tests](/learn/book/development-practices/testing.md), which can use panicking macros like `assert_eq!` to fail a test!
+This is notably true when [writing tests](/learn/book/development-practices/testing), which can use panicking macros like `assert_eq!` to fail a test!
 
 #### Default Values
 

--- a/content/learn/book/control-flow/handling-errors.md
+++ b/content/learn/book/control-flow/handling-errors.md
@@ -121,7 +121,7 @@ Each hex parse result value is wrapped in either `Result::Ok` or `Result::Err`.
 A common way to get the interior value is to [`unwrap`](https://doc.rust-lang.org/std/result/enum.Result.html#method.unwrap) the `Result`, but remember that in the case of an `Err`, `unwrap` will crash the program!
 With this in mind `unwrap` is best used when you know the value will be a success, and an `Err` value would indicate a bug in your application.
 
-This is notably true when [writing tests](../development-practices/testing.md), which can use panicking macros like `assert_eq!` to fail a test!
+This is notably true when [writing tests](/learn/book/development-practices/testing.md), which can use panicking macros like `assert_eq!` to fail a test!
 
 #### Default Values
 
@@ -285,7 +285,7 @@ Since systems require certain data to be available to function, there are two wa
 - SystemParam validation
 - Run conditions
 
-Run conditions and fallible system parameters are covered in [run conditions](run-conditions.md)
+Run conditions and fallible system parameters are covered in [run conditions](/learn/book/control-flow/run-conditions)
 
 ## Errors in Bevy Apps
 
@@ -421,7 +421,7 @@ Use a feature flag for this, so you can decide on error policies for development
 ### Per-system error handling
 
 If you want to handle errors returned from a system in more complex ways, system piping can pass the return value of one system to another.
-More details on system piping can be found in [systems](./systems.md).
+More details on system piping can be found in [systems](/learn/book/control-flow/systems).
 
 In this case, the program can use the default global error handler and handle the error using a second system instead.
 The second system in this case takes Bevy's `Result` as a system input using [`In`], and the value can be piped from `update` to `handle_error`.

--- a/content/learn/book/control-flow/messages.md
+++ b/content/learn/book/control-flow/messages.md
@@ -95,7 +95,7 @@ fn main() {
 [`Messages<M>`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Messages.html
 [`MessageWriter`]: https://docs.rs/bevy/latest/bevy/prelude/struct.MessageWriter.html
 [`MessageReader`]: https://docs.rs/bevy/latest/bevy/prelude/struct.MessageReader.html
-[`App::add_message<M>`]: https://docs.rs/bevy/*/bevy/app/struct.App.html#method.add_message
+[`App::add_message<M>`]: https://docs.rs/bevy/latest/bevy/prelude/struct.App.html#method.add_message
 [`message_update_system`]: https://docs.rs/bevy/latest/bevy/ecs/message/fn.message_update_system.html
 [`First`]: https://docs.rs/bevy/latest/bevy/prelude/struct.First.html
 [`Messages::update`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Messages.html#method.update

--- a/content/learn/book/control-flow/run-conditions.md
+++ b/content/learn/book/control-flow/run-conditions.md
@@ -68,7 +68,7 @@ We don't need to update their statistics while waiting for them to respawn, but 
 
 If you are writing your own [`SystemParam`], this behavior can be configured via the [`SystemParam::validate_param`] method.
 
-[Handling Errors]: ../handling-errors
+[Handling Errors]: /learn/book/control-flow/handling-errors
 [`SystemParam`]: https://docs.rs/bevy/latest/bevy/ecs/system/trait.SystemParam.html
 [`Single`]: https://docs.rs/bevy/latest/bevy/ecs/system/struct.Single.html
 [`Query`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Query.html

--- a/content/learn/book/control-flow/systems.md
+++ b/content/learn/book/control-flow/systems.md
@@ -179,7 +179,7 @@ See the section on [local system state] for more details.
 
 ["splits the borrow"]: https://doc.rust-lang.org/nomicon/borrow-splitting.html
 
-[local system state]: ../storing-data/local-system-param
+[local system state]: /learn/book/storing-data/local-system-param
 
 ## Running Systems In Schedules
 
@@ -204,7 +204,7 @@ You can read more about schedules in the dedicated [Schedules section], but for 
 - Each of the standard schedules are evaluated *once per frame*.
 - There are also [`Fixed`] schedules which run at a consistent interval.
 
-[Schedules section]: ../the-game-loop/schedules
+[Schedules section]: /learn/book/the-game-loop/schedules
 
 [`Schedule`]: https://docs.rs/bevy/latest/bevy/ecs/schedule/struct.Schedule.html
 [`App::add_system`]: https://docs.rs/bevy/latest/bevy/app/struct.App.html#method.add_systems
@@ -317,8 +317,8 @@ struct FooSchedule;
 commands.run_schedule(FooSchedule);
 ```
 
-[locals]: ../storing-data/local-system-param
-[change detection]: ../control-flow/change-detection
+[locals]: /learn/book/storing-data/local-system-param
+[change detection]: /learn/book/control-flow/change-detection
 
 [`Entity`]: https://docs.rs/bevy/latest/bevy/ecs/entity/struct.Entity.html
 [`SystemId`]: https://docs.rs/bevy/latest/bevy/ecs/system/struct.SystemId.html
@@ -417,7 +417,7 @@ This can be repeated indefinitely, but branching is not supported.
 System piping is mostly useful for composing fragments of logic in a modular, reusable way.
 System output is also used when returning errors from systems, as explained in the [Handling Errors] section of this chapter.
 
-[Handling Errors]: ../control-flow/handling-errors
+[Handling Errors]: /learn/book/control-flow/handling-errors
 
 [`In`]: https://docs.rs/bevy/latest/bevy/prelude/trait.System.html#associatedtype.In
 [`Out`]: https://docs.rs/bevy/latest/bevy/prelude/trait.System.html#associatedtype.Out

--- a/content/learn/book/development-practices/fast-compiles.md
+++ b/content/learn/book/development-practices/fast-compiles.md
@@ -170,4 +170,4 @@ To enable `sccache`, install it and update your Cargo configuration.
 More code means more time to compile.
 If there are parts of Bevy (or your other dependencies) that you simply don't need,
 you can improve compilation times substantially by removing them.
-For advice on how to navigate Bevy's collection of feature flags, see [Compiling Less Code](../releasing-projects/compiling-less-code.md).
+For advice on how to navigate Bevy's collection of feature flags, see [Compiling Less Code](/learn/book/releasing-projects/compiling-less-code).

--- a/content/learn/book/development-practices/hot-reloading.md
+++ b/content/learn/book/development-practices/hot-reloading.md
@@ -11,7 +11,7 @@ Unfortunately, recompiling can be slow, and requires you to close the game, losi
 To make this easier, Bevy supports **hot reloading**, which allows you to modify your game's assets and automatically load these changes into a running instance of the game.
 
 While hot-reloading is useful during development time, it's usually not something you want to ship in a production game.
-Unless you're deliberately using this for modding support, you should turn these settings off when [releasing projects](../releasing-projects/_index.md).
+Unless you're deliberately using this for modding support, you should turn these settings off when [releasing projects](/learn/book/releasing-projects/_index).
 
 ## Hot Reloading Assets
 

--- a/content/learn/book/development-practices/testing.md
+++ b/content/learn/book/development-practices/testing.md
@@ -111,13 +111,13 @@ Take advantage of existing developer tools, make your own, and make it easy to j
 
 You should create a dedicated `devtools` feature flag for your application (and enable it by default) which will turn on all of the testing and debugging utilities that your project might need.
 Reproducing tricky bugs can be incredibly time-consuming; you don't want to have to recompile your game to turn on these tools.
-Then when you are [building for release](../releasing-projects/release-builds.md), turn your `devtools` feature flag off.
+Then when you are [building for release](/learn/book/releasing-projects/release-builds), turn your `devtools` feature flag off.
 
 Rust's examples are a surprisingly powerful testing tool, letting you create secondary binaries with customized setups.
 You might configure one to open the game with the settings menu open, another to take a command line argument to jump you to the supplied level, and a third to start a new run of the game using a prebuilt character.
 
 Adding systems to these examples can be fairly straightforward.
-A useful pattern is to directly mutate the desired [state](../control-flow/states.md) to bring you to a specific point in your game.
+A useful pattern is to directly mutate the desired [state](/learn/book/control-flow/states) to bring you to a specific point in your game.
 The [`run_once`] run condition can also be particularly useful to avoid surprising behavior once setup is complete.
 You can even add asserts to verify that your setup steps have done what you wanted.
 
@@ -282,7 +282,7 @@ You get full data access and Bevy's ECS ergonomics, but you still control exactl
 ### Running Entire Schedules
 
 When the behavior you care about comes from the interaction *between* systems, you can build up a [`Schedule`] and run it against a `World`.
-This lets you verify [system ordering](../control-flow/systems#running-systems-in-schedules) and [run conditions](../control-flow/run-conditions.md), which you can't do with `run_system_once`.
+This lets you verify [system ordering](/learn/book/control-flow/systems#running-systems-in-schedules) and [run conditions](/learn/book/control-flow/run-conditions), which you can't do with `run_system_once`.
 
 ```rust
 fn regenerate(mut query: Query<&mut Life>) {
@@ -319,7 +319,7 @@ Individually test systems first where you can, and save schedule-level tests for
 Taking this one step further, you can even construct an [`App`], add your plugins, and step it forward with [`app.update()`].
 Each call to `update` runs a full frame: `Startup` (on the first call), then `PreUpdate`, `Update`, `PostUpdate`, and so on.
 
-The reason to reach for this over a raw `Schedule` is [plugins](../../modular-architecture/plugins.md).
+The reason to reach for this over a raw `Schedule` is [plugins](/learn/book/modular-architecture/plugins).
 Suppose your game has a `CombatPlugin` that registers the `PoisonStrength` resource and the `apply_poison` system.
 You can test the plugin as a whole, without manually recreating its internals:
 
@@ -449,7 +449,7 @@ Inside of your own code, be careful to never introduce a gameplay logic dependen
 This is reasonable practice in any case to avoid surprising bugs.
 Splitting your code into multiple crates can be useful to enforce this invariant as Cargo will help you catch cyclic dependencies, but doing so can seriously slow down iteration for small projects.
 
-[Compiling Less Code]: ../releasing-projects/compiling-less-code.md
+[Compiling Less Code]: /learn/book/releasing-projects/compiling-less-code
 
 ## Testing Graphical Output
 

--- a/content/learn/book/intro/_index.md
+++ b/content/learn/book/intro/_index.md
@@ -32,14 +32,14 @@ but don't be afraid: it'll click soon enough.
 This book is [explanatory documentation](https://diataxis.fr/) covering Bevy's core ideas.
 You can read it cover to cover, or skip ahead to the sections that interest you.
 
-If you are new to Bevy, [read the first chapter] before proceeding.
+If you are new to Bevy, [read the first chapter](/learn/book/intro/the-three-letters) before proceeding.
 It introduces the ECS vocabulary and core terms you'll need for the rest of this book.
 After that, use the sidebar to jump to any chapter you need.
 We've attempted to arrange them in a useful order, but they do not assume you have read previous chapters.
 
-If you want a broader map of Bevy's documentation ecosystem (quick start guide, examples, API docs, and more), see [Further Reading](../further-reading).
+If you want a broader map of Bevy's documentation ecosystem (quick start guide, examples, API docs, and more), see [Further Reading](/learn/book/further-reading).
 
-If you're evaluating whether Bevy is the right fit for your project, read [Is Bevy Right for Your Project?](../is-bevy-right-for-your-project).
+If you're evaluating whether Bevy is the right fit for your project, read [Is Bevy Right for Your Project?](/learn/book/is-bevy-right-for-your-project).
 
 {% callout(type="info") %}
 ### Corrections and Extensions
@@ -50,5 +50,3 @@ If you spot a typo, [submit a quick PR](https://github.com/bevyengine/bevy-websi
 The files used to create the book are just Markdown; you can find them in `content/learn/book`.
 If you'd like to refactor something or add a new section, read our [Contributing Guide](https://bevyengine.org/learn/contribute/introduction/) and we'd be happy to welcome you to the flock!
 {% end %}
-
-[read the first chapter]: ./the-three-letters

--- a/content/learn/book/intro/apps-worlds.md
+++ b/content/learn/book/intro/apps-worlds.md
@@ -20,7 +20,7 @@ It is possible to have multiple worlds, and it's also possible to run a world co
 
 ## The App
 
-Bevy provides a modular multi-threaded runtime called an [`App`](../../the-game-loop/app). If you have used web servers before, the basic ideas of an app will probably be familiar: you configure your app with settings and logic, then `run()` it to enter an update loop. It tends to look something like this:
+Bevy provides a modular multi-threaded runtime called an [`App`](/learn/book/the-game-loop/app). If you have used web servers before, the basic ideas of an app will probably be familiar: you configure your app with settings and logic, then `run()` it to enter an update loop. It tends to look something like this:
 
 ```rust
 use bevy::prelude::*;
@@ -35,7 +35,7 @@ fn main() {
 In most cases, your world will be contained within your app.
 The app is responsible for scheduling and executing your systems, and passing the data in and out of them appropriately.
 
-Apps can be used to combine code that's been broken down into modular, reusable pieces, called [plugins](../modular-architecture/plugins).
+Apps can be used to combine code that's been broken down into modular, reusable pieces, called [plugins](/learn/book/modular-architecture/plugins).
 
 ## Next Steps
 

--- a/content/learn/book/intro/the-next-three-letters.md
+++ b/content/learn/book/intro/the-next-three-letters.md
@@ -12,7 +12,7 @@ These concepts are core to Bevy's ECS (so much so that they're used in the previ
 ## Resources
 
 **Resources** are global state singletons.
-Unlike [components](../the-three-letters#the-c-components), which are reused across multiple entities, resources are unique. For any given resource type (like `Score` in the example below), there can only be one instance in your game world at a time.
+Unlike [components](/learn/book/intro/the-three-letters#the-c-components), which are reused across multiple entities, resources are unique. For any given resource type (like `Score` in the example below), there can only be one instance in your game world at a time.
 
 Like components, resources in Bevy are also "just Rust structs" (or enums).
 
@@ -67,7 +67,7 @@ fn tick_down_poison(mut query: Query<&mut Poison>) {
 }
 ```
 
-Then, when systems are run as part of a Bevy [app](../../the-game-loop/app), the engine automatically fetches the requested data, parallelizing work between systems wherever possible:
+Then, when systems are run as part of a Bevy [app](/learn/book/the-game-loop/app), the engine automatically fetches the requested data, parallelizing work between systems wherever possible:
 
 ```rs
 fn main() {
@@ -85,7 +85,7 @@ Going back to our database analogy, a query is a lot like a [SQL `SELECT` statem
 
 Queries have a lot more functionality than what's shown here.
 You can request optional components, fetch the `Entity` associated with each item, add query filters, and much more!
-Queries are covered in more detail in the [Queries](../../storing-data/queries) chapter.
+Queries are covered in more detail in the [Queries](/learn/book/storing-data/queries) chapter.
 
 ## Commands
 
@@ -104,4 +104,4 @@ fn spawn_entities(mut commands: Commands) {
 
 A wide range of built-in commands are provided,
 but you can also write custom commands to queue up any ECS logic you might desire.
-You can read about these in more detail in the [Commands](../../control-flow/commands) chapter.
+You can read about these in more detail in the [Commands](/learn/book/control-flow/commands) chapter.

--- a/content/learn/book/intro/the-three-letters.md
+++ b/content/learn/book/intro/the-three-letters.md
@@ -86,12 +86,12 @@ fn spawn_entities(mut commands: Commands) {
 }
 ```
 
-Entities are usually spawned using [Commands](../control-flow/commands), which queue up complex work to be done later.
+Entities are usually spawned using [Commands](/learn/book/control-flow/commands), which queue up complex work to be done later.
 
 ## The S: Systems
 
 Systems interact with and update the data in the ECS.
-Each system is run every frame by default, and repeats in a loop (specifically, in a [Schedule](../the-game-loop/schedules)).
+Each system is run every frame by default, and repeats in a loop (specifically, in a [Schedule](/learn/book/the-game-loop/schedules)).
 In Bevy, systems are "just Rust functions".
 These can fetch data from the ECS, make updates, call external APIs, and anything else that a function can do.
 
@@ -105,12 +105,12 @@ fn my_system(entities: Query<&mut Location>) {
 ```
 
 {% callout(type="info") %}
-Bevy systems use a technique called [dependency injection](https://en.wikipedia.org/wiki/Dependency_injection) to access data about the Bevy world. By declaring your function parameters wrapped in special types like [Query](../intro/the-next-three-letters#queries) or [Res](../intro/the-next-three-letters#resources), the data for those parameters will be filled in for you automatically — without you having to actually call the system.
+Bevy systems use a technique called [dependency injection](https://en.wikipedia.org/wiki/Dependency_injection) to access data about the Bevy world. By declaring your function parameters wrapped in special types like [Query](/learn/book/intro/the-next-three-letters#queries) or [Res](/learn/book/intro/the-next-three-letters#resources), the data for those parameters will be filled in for you automatically — without you having to actually call the system.
 
 Another cool feature of Bevy systems is automatic parallelism: by inspecting the function parameter types, Bevy can automatically determine if it's safe to run two systems concurrently. For example, if you have a system which regenerates character health by modifying a `Health` component, and a different system that manages the characters' mana pool (say, via a `Mana` component), then Bevy knows that these two data sets are *disjoint* and can be updated at the same time. This is particularly important for optimal utilization of multiple CPU cores.
 {% end %}
 
-Systems usually access entities and their components via [Queries](../intro/the-next-three-letters#queries), which will be covered in the next chapter.
+Systems usually access entities and their components via [Queries](/learn/book/intro/the-next-three-letters#queries), which will be covered in the next chapter.
 
 ## Why ECS?
 
@@ -132,9 +132,9 @@ you can:
   - Plus it helps support a thriving, heavily interoperable [ecosystem of third-party libraries](https://bevy.org/assets/).
 - Build consistent, universal abstractions on a common base of data structures.
   - Shared data structures mean that improvements and bug fixes trickle down automatically.
-  - Use the same powerful patterns for [control flow](../control-flow/) everywhere.
-  - Structure your application using a uniform, flexible [modular architecture](../modular-architecture).
-  - Debug and inspect every part of your game using the same [dev tools](../development-practices).
+  - Use the same powerful patterns for [control flow](/learn/book/control-flow/) everywhere.
+  - Structure your application using a uniform, flexible [modular architecture](/learn/book/modular-architecture).
+  - Debug and inspect every part of your game using the same [dev tools](/learn/book/development-practices).
 
 Learning to take advantage of everything a modern ECS has to offer will take time:
 if you want to be able to tackle any data modelling problem that games have to throw at you,

--- a/content/learn/book/modular-architecture/plugins.md
+++ b/content/learn/book/modular-architecture/plugins.md
@@ -55,7 +55,7 @@ App::new().add_plugins(PlayerPlugin);
 ```
 
 Because our plugin is so simple (it doesn't take any config, and only uses the `build` method),
-we could instead choose to use [the blanket impl for functions that take a &mut App]:
+we could instead choose to use [the blanket impl for all functions that take a &mut App]:
 
 ```rust,hide_lines=1-4
 # use bevy::prelude::*;
@@ -149,12 +149,12 @@ Then, when the app is run, a few other plugin life-cycle functions are called, a
 
 In most cases, this complexity can be completely ignored, but when working with subsystems that require deferred initialization it can be helpful.
 
-[apps]: ../the-game-loop/app
+[apps]: /learn/book/the-game-loop/app
 [`App`]: https://docs.rs/bevy/latest/bevy/app/struct.App.html
 [`App::add_systems`]: https://docs.rs/bevy/latest/bevy/app/struct.App.html?search=add#method.add_systems
 [`App::add_plugins`]: https://docs.rs/bevy/latest/bevy/app/struct.App.html?search=add#method.add_plugins
 [`World`]: https://docs.rs/bevy/latest/bevy/ecs/prelude/struct.World.html
-[the blanket for all functions that take a &mut App]: https://docs.rs/bevy/latest/bevy/app/trait.Plugin.html#impl-Plugin-for-T
+[the blanket impl for all functions that take a &mut App]: https://docs.rs/bevy/latest/bevy/app/trait.Plugin.html#impl-Plugin-for-T
 [`PluginGroup`]: https://docs.rs/bevy/latest/bevy/app/trait.PluginGroup.html
 [`DefaultPlugins`]: https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html
 [`PluginGroup::set`]: https://docs.rs/bevy/latest/bevy/prelude/trait.PluginGroup.html#method.set

--- a/content/learn/book/modular-architecture/project-organization.md
+++ b/content/learn/book/modular-architecture/project-organization.md
@@ -24,7 +24,7 @@ Thankfully, the Bevy community has answers to these questions:
   - placing these at the top of your files can act as a simple, consistent "table of contents"
 
 [orphan rules]: https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules
-[plugin]: ./plugins.md
+[plugin]: /learn/book/modular-architecture/plugins
 
 ## Modules
 
@@ -66,9 +66,9 @@ and use the cached compilation results for everything else.
 
 [crates]: https://doc.rust-lang.org/book/ch07-01-packages-and-crates.html
 [workspaces]: https://doc.rust-lang.org/cargo/reference/workspaces.html
-[creating libraries]: ../releasing-projects/libraries-for-bevy.md
+[creating libraries]: /learn/book/releasing-projects/libraries-for-bevy
 [Rust parallelizes compilation at the crate level]: https://www.feldera.com/blog/cutting-down-rust-compile-times-from-30-to-2-minutes-with-one-thousand-crates
-[setup tips for faster compilations]: ../development-practices/fast-compiles.md
+[setup tips for faster compilations]: /learn/book/development-practices/fast-compiles
 [`cargo build --timings`]: https://doc.rust-lang.org/cargo/reference/timings.html
 
 ## Item Visibility

--- a/content/learn/book/releasing-projects/libraries-for-bevy.md
+++ b/content/learn/book/releasing-projects/libraries-for-bevy.md
@@ -192,7 +192,7 @@ We have a few additional setup suggestions:
   type_complexity = "allow"
   ```
 
-Take a look at our chapter on [Testing](../development-practices/testing.md):
+Take a look at our chapter on [Testing](/learn/book/development-practices/testing):
 this advice is particularly useful for library authors.
 
 ### Configuring Github repo settings

--- a/content/learn/book/storing-data/_index.md
+++ b/content/learn/book/storing-data/_index.md
@@ -8,4 +8,4 @@ status = 'hidden'
 +++
 
 Bevy's ECS (Entity-Component-System) is the central, unified way we store data.
-While the most fundamental concepts were introduced in the [Introduction](../intro), this chapter dives deeper into the various ways we can store and access data within the ECS.
+While the most fundamental concepts were introduced in the [Introduction](/learn/book/intro), this chapter dives deeper into the various ways we can store and access data within the ECS.

--- a/content/learn/book/storing-data/entities-components.md
+++ b/content/learn/book/storing-data/entities-components.md
@@ -53,7 +53,7 @@ fn spawning_system(mut commands: Commands){
 }
 ```
 
-[exclusive system]: ../../control-flow/systems/#exclusive-systems
+[exclusive system]: /learn/book/control-flow/systems/#exclusive-systems
 [`World`]: https://docs.rs/bevy/latest/bevy/ecs/world/struct.World.html
 [`Commands`]: https://docs.rs/bevy/latest/bevy/ecs/system/struct.Commands.html
 
@@ -71,7 +71,7 @@ To make a basic cube, you'd probably need to add:
 - A [`StandardMaterial`] to define how that mesh should be rendered (in practice, actually a [`Handle`] to a [`StandardMaterial`])
 - Etc.
 
-[introduction section on components]: ../../intro/the-three-letters#the-c-components
+[introduction section on components]: /learn/book/intro/the-three-letters#the-c-components
 [`Transform`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Transform.html
 [`Mesh`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Mesh.html
 [`Handle`]: https://docs.rs/bevy/latest/bevy/asset/enum.Handle.html

--- a/content/learn/book/storing-data/queries.md
+++ b/content/learn/book/storing-data/queries.md
@@ -10,7 +10,7 @@ Queries are your primary tool for interacting with the Bevy world, allowing you 
 Queries create a filtered "view" into the metaphorical database that makes up our ECS.
 With that view you can iterate over the requested components, ask what the "row number" (`Entity`) is for each element, or fetch the matching components for a particular `Entity` value.
 
-We briefly covered queries in our [introduction](../intro/) to Bevy, so make sure to review that section if you haven't read it yet.
+We briefly covered queries in our [introduction](/learn/book/intro/) to Bevy, so make sure to review that section if you haven't read it yet.
 If you're entirely brand new to Bevy or ECS, we would recommend you to start there before continuing on this page.
 
 ## Anatomy of a Query
@@ -156,7 +156,7 @@ You can avoid this by ensuring that your access is provably disjoint: [`Without`
 If you run into this you'll be pointed to the [B0002] error page, which has advice on how to fix and avoid this problem.
 
 [mutable aliasing]: https://doc.rust-lang.org/rust-by-example/scope/borrow/alias.html
-[`Access`]: https://dev-docs.bevy.org/bevy/ecs/query/struct.Access.html
+[`Access`]: https://docs.rs/bevy/latest/bevy/ecs/query/struct.Access.html
 [`Without`]: https://docs.rs/bevy/latest/bevy/ecs/prelude/struct.Without.html
 [B0002]: https://bevy.org/learn/errors/b0002/
 {% end %}
@@ -170,8 +170,8 @@ This [smart pointer] wraps a `&mut T` and allows Bevy to automatically detect ch
 While this is talked about in more depth in the chapter on [change detection], it's helpful to know that [`Changed`] and [`Added`] are both query filters.
 
 [reference]: https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html
-[query item]: https://dev-docs.bevy.org/bevy/ecs/query/trait.QueryData.html#associatedtype.Item
-[`Mut<Life>`]: https://dev-docs.bevy.org/bevy/ecs/change_detection/struct.Mut.html
+[query item]: https://docs.rs/bevy/latest/bevy/ecs/query/trait.QueryData.html#associatedtype.Item
+[`Mut<Life>`]: https://docs.rs/bevy/latest/bevy/ecs/change_detection/struct.Mut.html
 [smart pointer]: https://doc.rust-lang.org/book/ch15-00-smart-pointers.html
 [change detection]: /learn/book/control-flow/change-detection
 [`Changed`]: https://docs.rs/bevy/latest/bevy/ecs/query/struct.Changed.html

--- a/content/learn/book/storing-data/resources.md
+++ b/content/learn/book/storing-data/resources.md
@@ -26,7 +26,7 @@ If you might need multiple instances, then consider using [entities and componen
 Bevy uses resources for many of the built-in features of the engine.
 For example, Bevy's [`AssetServer`] is a resource.
 
-[entities and components]: ../entities-components
+[entities and components]: /learn/book/storing-data/entities-components
 [`World`]: https://docs.rs/bevy/latest/bevy/ecs/world/struct.World.html
 [`AssetServer`]: https://docs.rs/bevy/latest/bevy/asset/struct.AssetServer.html
 

--- a/content/learn/book/the-game-loop/schedules.md
+++ b/content/learn/book/the-game-loop/schedules.md
@@ -82,8 +82,6 @@ and then evaluate some complex condition inside of a system to determine if and 
 This can be very helpful for turn-based games, simulations, networked servers and more.
 Bevy itself uses this pattern for both the [`Main`] schedule and our built-in [fixed time] solution.
 
-For even more control over your game loop, read the [custom loops] chapter!
-
 [`Schedule`]: https://docs.rs/bevy/latest/bevy/ecs/schedule/struct.Schedule.html
 [`StateTransition`]: https://docs.rs/bevy/latest/bevy/state/state/struct.StateTransition.html
 [`PreStartup`]: https://docs.rs/bevy/latest/bevy/app/struct.PreStartup.html
@@ -100,10 +98,9 @@ For even more control over your game loop, read the [custom loops] chapter!
 [plugins]: /learn/book/modular-architecture/plugins
 [state machine abstraction]: /learn/book/control-flow/states
 [fixed update loop]: /learn/book/the-game-loop/time-and-timers#fixing-your-timestep
-[custom loops]: /learn/book/the-game-loop/custom-loops
 [`ScheduleRunnerPlugin`]: https://docs.rs/bevy/latest/bevy/app/struct.ScheduleRunnerPlugin.html
 [`MinimalPlugins`]: https://docs.rs/bevy/latest/bevy/struct.MinimalPlugins.html
 [`DefaultPlugins`]: https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html
 [`MainScheduleOrder`]: https://docs.rs/bevy/latest/bevy/app/struct.MainScheduleOrder.html
 [`World::run_schedule`]: https://docs.rs/bevy/latest/bevy/prelude/struct.World.html#method.run_schedule
-[fixed time]: ./fixed-time.md
+[fixed time]: /learn/book/the-game-loop/time-and-timers#frame-rate-independence-and-delta-time

--- a/content/learn/book/the-game-loop/time-and-timers.md
+++ b/content/learn/book/the-game-loop/time-and-timers.md
@@ -99,8 +99,8 @@ If your systems uniformly rely on [`Time`], this will affect your entire game:
 halting, slowing or speeding up animations, movement, projectiles, physics and so on.
 Alternatively, [states] and [run conditions] can be used to skip systems while the game is paused.
 
-[states]: ../control-flow/states.md
-[run conditions]: ../control-flow/run-conditions.md
+[states]: /learn/book/control-flow/states
+[run conditions]: /learn/book/control-flow/run-conditions
 
 ## Fixing your timestep
 
@@ -327,7 +327,7 @@ within a single frame, or spawn an async task which you periodically poll for co
 
 [`Timer`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Timer.html
 [`Duration`]: https://doc.rust-lang.org/std/time/struct.Duration.html
-[relationship]: ../storing-data/relations.md
+[relationship]: /learn/book/storing-data/relations
 [`on_timer`]: https://docs.rs/bevy/latest/bevy/time/common_conditions/fn.on_timer.html
 
 ## Delaying Commands


### PR DESCRIPTION
Several of the book pages had incorrect or broken links due to the shifting of pages we've done over the last couple of months. I went through the whole book and fixed them, plus I standardized the format so that every link is formatted consistently.