### PR TITLE
Add `max-width` to images to avoid overflow

### DIFF
--- a/sass/pages/_content.scss
+++ b/sass/pages/_content.scss
@@ -113,4 +113,8 @@ $content-font-size: 1.22rem;
     padding-left: 0px;
     padding-right: 0px;
   }
+
+  img {
+    max-width: 100%;
+  }
 }


### PR DESCRIPTION
If the image is bigger than the content column it overflows and the image is cut. Add max-width to `media-content` images to avoid this.

### BEFORE
<img width="2500"  alt="image" src="https://github.com/user-attachments/assets/75b0cb06-9529-42e4-a03c-1f6c6dfeee52" />

### AFTER
<img width="2500" alt="image" src="https://github.com/user-attachments/assets/f61e15ef-3dd6-4552-9c2f-3fe4a81a8118" />

---

Fixes #2528 