### PR TITLE
Fix state transition startup order

### DIFF
--- a/content/learn/book/control-flow/states.md
+++ b/content/learn/book/control-flow/states.md
@@ -109,7 +109,7 @@ All state transitions occur during the [`StateTransition`] schedule.
 
 The `StateTransition` schedule itself runs at two points:
 
-1. **During app startup**, after [`PreStartup`] but before [`Startup`]. This is when your initial states' [`OnEnter`] systems run.
+1. **During app startup**, before [`PreStartup`]. This is when your initial states' [`OnEnter`] systems run.
 2. **Each tick of the game loop**, after [`PreUpdate`] but before the fixed update loop and [`Update`].
 
 When you set a new state with [`NextState<T>`], the transition doesn't happen immediately.


### PR DESCRIPTION
a surprising (understandable imo) detail is that state transitions run *before* PreStartup (and Startup) in the startup order.

Relevant code: https://github.com/bevyengine/bevy/blob/main/crates/bevy_state/src/app.rs#L336

(The Schedules chapter lists them in the "correct" order, so I'm putting in this PR to make it consistent)