### PR TITLE
Mention command that can install outdated version of Zola

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The Bevy website is built using the Zola static site engine. In our experience, 
 
 To check out any local changes you've made:
 
-1. [Install Zola](https://www.getzola.org/documentation/getting-started/installation/) version `0.19.2`.
+1. [Install Zola](https://www.getzola.org/documentation/getting-started/installation/) version `0.19.2`. [^1]
 2. Clone the Bevy Website git repo and enter that directory:
    1. `git clone https://github.com/bevyengine/bevy-website.git`
    2. `cd bevy-website`
@@ -25,3 +25,5 @@ These pages need to be generated in a separate step by running the shell scripts
 ## Contributing documentation
 
 If you want to contribute to Bevy's documentation found under `content/learn/`, we have a [style guide](content/learn/contribute/helping-out/writing-docs.md#contributors-style-guide) to help you.
+
+[^1]: This can be done using `cargo install --git https://github.com/getzola/zola --tag v0.19.2`

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ The Bevy website is built using the Zola static site engine. In our experience, 
 
 To check out any local changes you've made:
 
-1. [Install Zola](https://www.getzola.org/documentation/getting-started/installation/) version `0.19.2`. [^1]
+1. [Install Zola](https://www.getzola.org/documentation/getting-started/installation/)
+   version `0.19.2`.
+   - `cargo install --git https://github.com/getzola/zola --tag v0.19.2`
 2. Clone the Bevy Website git repo and enter that directory:
    1. `git clone https://github.com/bevyengine/bevy-website.git`
    2. `cd bevy-website`
@@ -26,4 +28,3 @@ These pages need to be generated in a separate step by running the shell scripts
 
 If you want to contribute to Bevy's documentation found under `content/learn/`, we have a [style guide](content/learn/contribute/helping-out/writing-docs.md#contributors-style-guide) to help you.
 
-[^1]: This can be done using `cargo install --git https://github.com/getzola/zola --tag v0.19.2`

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To check out any local changes you've made:
 
 1. [Install Zola](https://www.getzola.org/documentation/getting-started/installation/)
    version `0.19.2`.
-   - `cargo install --git https://github.com/getzola/zola --tag v0.19.2`
+   - `cargo install --git https://github.com/getzola/zola --tag v0.19.2` or from the [releases](https://github.com/getzola/zola/releases#release-v0.19.2)
 2. Clone the Bevy Website git repo and enter that directory:
    1. `git clone https://github.com/bevyengine/bevy-website.git`
    2. `cd bevy-website`

--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ The Bevy website is built using the Zola static site engine. In our experience, 
 
 To check out any local changes you've made:
 
-1. [Install Zola](https://www.getzola.org/documentation/getting-started/installation/)
-   version `0.19.2`.
+1. [Install Zola](https://www.getzola.org/documentation/getting-started/installation/) version `0.19.2`.
    - `cargo install --git https://github.com/getzola/zola --tag v0.19.2` or from the [releases](https://github.com/getzola/zola/releases#release-v0.19.2)
 2. Clone the Bevy Website git repo and enter that directory:
    1. `git clone https://github.com/bevyengine/bevy-website.git`


### PR DESCRIPTION
I wanted to look at changing some documentation, and needed to once again get zola 0.19.2 installed.

~~[Since we're waiting](https://github.com/bevyengine/bevy-website/pull/2425#issuecomment-4197113752) on zola 0.23 before being able to update it,~~ (update: no longer true!) I thought it'd be good to note down how to install a tool like zola that isn't on crates.io with a specific git tag version, without relying on a system level package manager that has an old version of the binary. This is especially relevant to people like me on systems that, excluding certain cargo installations, use a package manager that is rolling release without keeping old versions around (e.g. Arch Linux).

Avoiding `--locked` is intentional, since the old version of zola includes yanked dependencies, and did not compile for me when I initially used it.