### PR TITLE
Narrow down getrandom troubleshooting fix to be target-dependent

### DIFF
--- a/content/learn/quick-start/troubleshooting.md
+++ b/content/learn/quick-start/troubleshooting.md
@@ -68,7 +68,8 @@ Since you cannot specify two dependencies with the same name, and since cargo do
 dependency:
 
 ```toml
-# under the [dependencies] section of `Cargo.toml`
+# in `Cargo.toml`:
+[target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom_a = { package = "getrandom", version = "0.3.4", features = ["wasm_js"] }
 getrandom_b = { package = "getrandom", version = "0.4.2", features = ["wasm_js"] }
 ```

--- a/content/learn/quick-start/troubleshooting.md
+++ b/content/learn/quick-start/troubleshooting.md
@@ -87,7 +87,7 @@ creating a name conflict in your dependency table:
 
 ```toml
 # in `Cargo.toml`:
-[target.'cfg(target_arch = "wasm32")'.dependencies]
+[target.'cfg(all(target_family = "wasm", any(target_os = "unknown", target_os = "none")))'.dependencies]
 getrandom_a = { package = "getrandom", version = "0.3.4", features = ["wasm_js"] }
 getrandom_b = { package = "getrandom", version = "0.4.2", features = ["wasm_js"] }
 ```

--- a/content/learn/quick-start/troubleshooting.md
+++ b/content/learn/quick-start/troubleshooting.md
@@ -51,21 +51,39 @@ Or for `codelldb`:
 
 ## Unable to compile `getrandom` when building for web
 
+Bevy binaries tend to depend on `getrandom` through the `uuid` crate among
+others, and the standard getrandom implementation does not work for (some)
+web/wasm targets.
+
 ```txt
    Compiling getrandom v0.3.4
    Compiling getrandom v0.4.2
 error: The wasm32-unknown-unknown targets are not supported by default; you may need to enable the "wasm_js" crate feature.
 ```
 
-If you have only one tree dependency on `getrandom`, then adding
-`getrandom = { version = "*", features = ["wasm_js"] }` might solve the issue.
+If you only had one tree dependency on `getrandom`, then adding
+`getrandom = { version = "*", features = ["wasm_js"] }` would solve the issue
+like
+[`getrandom`](https://docs.rs/getrandom/latest/getrandom/#webassembly-support)
+suggests.
 
-However, if your crate depends on multiple versions of `getrandom`, then this will not be enough:
-The wildcard version pattern still ends up reflecting only a single version of the crate you want to add a feature for.
+However, if your crate depends on multiple versions of `getrandom` (which it
+likely will indirectly), this will not be enough: The wildcard version pattern
+still ends up reflecting only a single version of the crate you want to add a
+feature for.
 
-Since you cannot specify two dependencies with the same name, and since cargo does not know that you want the feature to apply to every instance of the crate
-(what if a cargo feature only exists for some versions of the dependency?), you might have to use this workaround sometimes referred to as 'renaming' the
-dependency:
+Going through `cargo tree --invert getrandom` you can find crates in your
+dependency tree that use `getrandom` (e.g. `uuid` and `ahash`), and figure out
+if they have a [solution](https://docs.rs/uuid/latest/uuid/#webassembly) that
+applies the fix for you. This can feel a little indirect and fragile though,
+since you might notice that a lot of crates share the same getrandom version,
+and you just want that crate to change its implementation.
+
+If you want to directly enforce a feature for multiple versions of a crate, you
+have to "rename" them. Cargo does not know that you want a feature to apply to
+every instance of the crate (what if a cargo feature only exists for some
+versions of the dependency?), so it has to be stated multiple times without
+creating a name conflict in your dependency table:
 
 ```toml
 # in `Cargo.toml`:


### PR DESCRIPTION
When I wrote #2465, I hadn't looked at how you could make it fit inside a `Cargo.toml` used for multiple targets. The code block now explicitly mentions `[target.'cfg(target_arch = "wasm32"'.dependencies]`, instead of just implying some sort of `[dependencies]` entry in a comment.

According to [`getrandom` docs](https://docs.rs/getrandom/latest/getrandom/#webassembly-support), it is not ideal to enable this feature unless you A) are only making (wasm[^1]) binaries, B) unconditionally depend on a relevant WASM crates `wasm-bindgen` or `js-sys`.

I like this change because it more specifically solves the issue documented, and should only be applied where it is needed (aka does not change the other builds when they don't have an issue), and lets you discover the target-dependent dependencies option, which is otherwise hard to discover despite presumably being used in practice. I personally also use this to add the `webgpu` feature to web, or `wayland` only to linux targets.

I cannot speak for implementations across wasm/non-wasm backends of `getrandom` having perfect parity in output (in terms of cross-platform determinism), but I assume they would document state that more clearly if it wasn't the case.

Edit: I also changed some of the surrounding wording to be clearer and more useful.

[^1]: Worth noting that they do not explicitly say here that it is a bad idea to use for multi-platform binary crates, but it is implied that you want to avoid it unless you need to use it for bloat reasons, and it is stated just above it that it could potentially break builds for non-web platforms.