### PR TITLE
Book: rename Replace lifecycle event to Discard

### DIFF
--- a/content/learn/book/control-flow/lifecycle-events.md
+++ b/content/learn/book/control-flow/lifecycle-events.md
@@ -10,7 +10,7 @@ In the previous chapter we learned about `Events` and how they allow us to run c
 We can extend this concept by using **Lifecycle Events** to run code in response to altering a `Component` within an `Entity`.
 Lifecycle events are still `Events`, but specifically they are `EntityEvents` meaning that they will have an `event_target` which determines the `Entity` being targeted.
 
-Within Bevy we currently have access to five distinct lifecycle events: `Add`, `Insert`, `Replace`, `Remove`, and `Despawn`.
+Within Bevy we currently have access to five distinct lifecycle events: `Add`, `Insert`, `Discard`, `Remove`, and `Despawn`.
 We can split these into two categories: lifecycle events that trigger when a `Component` is *added* to an `Entity`, and lifecycle events that trigger when a `Component` is *removed* from an `Entity`.
 
 On adding a `Component`:
@@ -20,17 +20,17 @@ On adding a `Component`:
 
 On removing/altering a `Component`:
 
-- [`Replace`] triggers when a component is removed from an `Entity`, *regardless of if it is replaced with a new value*.
+- [`Discard`] triggers when a component is removed from an `Entity`, *regardless of if it is replaced with a new value*.
 - [`Remove`] triggers when a component is removed from an `Entity` *and not replaced*. (This also happens before the component is actually removed.)
 - [`Despawn`] triggered on *each* component on an `Entity` when the `Entity` is *despawned*.
 
 It's also important to know that lifecycle events have an order in which they are evaluated.
 When both `Add` and `Insert` occur, `Add` hooks are evaluated before `Insert` hooks.
-`Replace` hooks are evaluated before `Remove` hooks, and `Despawn` hooks are evaluated last.
+`Discard` hooks are evaluated before `Remove` hooks, and `Despawn` hooks are evaluated last.
 
 [`Add`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Add.html
 [`Insert`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Insert.html
-[`Replace`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Replace.html
+[`Discard`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Discard.html
 [`Remove`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Remove.html
 [`Despawn`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Despawn.html
 


### PR DESCRIPTION
## Summary
Renames the Bevy lifecycle event `Replace` to `Discard` in the migration book to match the engine rename.

## Test plan
- [x] Spot-check book page renders locally / CI green
- [ ] Maintainer confirmation against current Bevy API docs


---

— Felipe Fernandes · Systems & Agentic AI Engineer
https://github.com/felipeofdev-ai · https://felipeofdev-ai.github.io/