### PR TITLE
docs: add ImageNode visual_box migration note (0.18→0.19)

### DIFF
--- a/content/learn/migration-guides/0.18-to-0.19.md
+++ b/content/learn/migration-guides/0.18-to-0.19.md
@@ -201,12 +201,12 @@ If you are calling these in a generic context and the resource is always mutable
 ```rust
 // 0.18
 fn my_generic_system<R: Resource>(mut res: ResMut<R>) {
-    â€¦
+    …
 }
 
 // 0.19
 fn my_generic_system<R: Resource<Mutability = Mutable>>(mut res: ResMut<R>) {
-    â€¦
+    …
 }
 ```
 
@@ -791,10 +791,10 @@ Parallel transform propagation is no longer tied to the `std` feature. It now
 requires the explicit `multi_threaded` feature:
 
 ```toml
-# 0.18 â€” parallel was enabled implicitly via std
+# 0.18 — parallel was enabled implicitly via std
 bevy_transform = { features = ["std"] }
 
-# 0.19 â€” opt in explicitly
+# 0.19 — opt in explicitly
 bevy_transform = { features = ["std", "multi_threaded"] }
 ```
 
@@ -1450,6 +1450,7 @@ Additionally, `ScrollbarThumb` nodes are now laid out after `ui_layout_system` b
 not have a `Node` component. The only layout options are for borders, which can be set using `ScrollbarThumb`'s new
 `border` and `border_radius` fields.
 
+
 ### `ImageNode` now draws in the content box by default
 
 {{ heading_metadata(prs=[24154]) }}
@@ -1476,7 +1477,6 @@ ImageNode {
 ```
 
 `OverflowClipMarginBox` was also renamed to `VisualBox` as part of this change.
-
 ### Lifecycle observers include old and new archetypes
 
 {{ heading_metadata(prs=[22828]) }}

--- a/content/learn/migration-guides/0.18-to-0.19.md
+++ b/content/learn/migration-guides/0.18-to-0.19.md
@@ -1477,6 +1477,7 @@ ImageNode {
 ```
 
 `OverflowClipMarginBox` was also renamed to `VisualBox` as part of this change.
+
 ### Lifecycle observers include old and new archetypes
 
 {{ heading_metadata(prs=[22828]) }}

--- a/content/learn/migration-guides/0.18-to-0.19.md
+++ b/content/learn/migration-guides/0.18-to-0.19.md
@@ -201,12 +201,12 @@ If you are calling these in a generic context and the resource is always mutable
 ```rust
 // 0.18
 fn my_generic_system<R: Resource>(mut res: ResMut<R>) {
-    …
+    â€¦
 }
 
 // 0.19
 fn my_generic_system<R: Resource<Mutability = Mutable>>(mut res: ResMut<R>) {
-    …
+    â€¦
 }
 ```
 
@@ -791,10 +791,10 @@ Parallel transform propagation is no longer tied to the `std` feature. It now
 requires the explicit `multi_threaded` feature:
 
 ```toml
-# 0.18 — parallel was enabled implicitly via std
+# 0.18 â€” parallel was enabled implicitly via std
 bevy_transform = { features = ["std"] }
 
-# 0.19 — opt in explicitly
+# 0.19 â€” opt in explicitly
 bevy_transform = { features = ["std", "multi_threaded"] }
 ```
 
@@ -1449,6 +1449,33 @@ let key = MeshPipelineKey::from_primitive_topology_and_strip_index(
 Additionally, `ScrollbarThumb` nodes are now laid out after `ui_layout_system` by `update_scrollbar_thumb`. `ScrollbarThumb` entities do
 not have a `Node` component. The only layout options are for borders, which can be set using `ScrollbarThumb`'s new
 `border` and `border_radius` fields.
+
+### `ImageNode` now draws in the content box by default
+
+{{ heading_metadata(prs=[24154]) }}
+
+In 0.18, `ImageNode` drew its image over the node's full border box.
+In 0.19, `ImageNode` gained a `visual_box: VisualBox` field that defaults to `VisualBox::ContentBox`, so the image is drawn only within the content box (inset by `border` and `padding`).
+
+This is a quiet visual break: nodes that combine `ImageNode` with nonzero `padding` or `border` (for example 9-sliced button backgrounds with padded labels) render differently after upgrading, with no compile error.
+
+To restore 0.18 layout behavior, set `visual_box` to `VisualBox::BorderBox`:
+
+```rust
+// 0.18 behavior: image fills the full node bounds (including padding/border)
+ImageNode {
+    visual_box: VisualBox::BorderBox,
+    ..default()
+}
+
+// 0.19 default: image is inset to the content box
+ImageNode {
+    visual_box: VisualBox::ContentBox, // or omit; this is the default
+    ..default()
+}
+```
+
+`OverflowClipMarginBox` was also renamed to `VisualBox` as part of this change.
 
 ### Lifecycle observers include old and new archetypes
 


### PR DESCRIPTION
## Summary
- Adds a migration-guide entry for the quiet `ImageNode` rendering change from bevyengine/bevy#24154.
- Documents the new default `visual_box: VisualBox::ContentBox` and how to restore `BorderBox` layout.

## Why
Upgrading from 0.18 to 0.19 changes how padded/bordered `ImageNode`s render (e.g. 9-slice buttons) with no compile error. The migration guide had no entry for this.

Fixes #2543

## Test plan
- [ ] Confirm PR number metadata `24154` matches the implementing engine PR
- [ ] Spot-check `VisualBox` / `ImageNode` field names against current Bevy 0.19 docs

---

— Felipe Fernandes · Systems & Agentic AI Engineer
https://github.com/felipeofdev-ai · https://felipeofdev-ai.github.io/