### PR TITLE
Convert internal links to zola's `@/` syntax for content-relative paths.

### DIFF
--- a/content/learn/book/assets/bevy's-asset-framework.md
+++ b/content/learn/book/assets/bevy's-asset-framework.md
@@ -91,11 +91,11 @@ You can call `AssetServer::load("bevy_bird.png")` and receive a [`Handle<Image>`
 
 Most games get around this behavior by creating a loading screen that plays while their assets load.
 You can create this functionality in Bevy using [`AssetServer::load_state`], a method that allows you to check the load state of an asset, along with other [`AssetServer`] methods that provide similar functionality.
-A version of the same functionality (without playing a separate screen) can be seen in the [Loading Assets In Advance](/learn/book/assets/lifetimes#waiting-for-asset-loading) page.
+A version of the same functionality (without playing a separate screen) can be seen in the [Loading Assets In Advance](@/learn/book/assets/lifetimes.md#waiting-for-asset-loading) page.
 
 {% callout(type="info") %}
 
-While loading data as an asset is more complex than simply hardcoding it, doing so unlocks [asset hot reloading](/learn/book/development-practices/hot-reloading).
+While loading data as an asset is more complex than simply hardcoding it, doing so unlocks [asset hot reloading](@/learn/book/development-practices/hot-reloading.md).
 This allows us to change the asset file during testing and see those changes reflected in real time.
 
 {% end %}

--- a/content/learn/book/assets/lifetimes.md
+++ b/content/learn/book/assets/lifetimes.md
@@ -147,7 +147,7 @@ impl EnemyAssets {
 ```
 
 Now, all we need is to prevent our `enemy_spawner` system from running until `EnemyAssets` is loaded.
-A straight-forward approach is to use a [state](/learn/book/control-flow/states/) to control for if our gameplay systems should run.
+A straight-forward approach is to use a [state](@/learn/book/control-flow/states.md) to control for if our gameplay systems should run.
 
 ```rust
 fn main() {

--- a/content/learn/book/assets/processing.md
+++ b/content/learn/book/assets/processing.md
@@ -112,7 +112,7 @@ processor.
 
 ### AssetLoader
 
-This is exactly the same asset loader as discussed in [Custom Assets](/learn/book/assets/custom-assets). Note that
+This is exactly the same asset loader as discussed in [Custom Assets](@/learn/book/assets/custom_assets.md). Note that
 `LoadTransformAndSave` can only use your asset loader if it is registered.
 
 ### AssetTransformer
@@ -188,7 +188,7 @@ impl AssetSaver for MySaver {
 
 Just as with [`AssetLoader`]s, your type needs to be "encoded" somehow, whether through [`serde`] or
 whatever else. It may be necessary to create a "serializable" version of your asset. This is
-described in more detail in [Custom Assets](/learn/book/assets/custom-assets).
+described in more detail in [Custom Assets](@/learn/book/assets/custom_assets.md).
 
 ## Meta Files
 

--- a/content/learn/book/control-flow/change-detection.md
+++ b/content/learn/book/control-flow/change-detection.md
@@ -195,10 +195,10 @@ When a system calls `.is_changed()`, it compares the tick count of the component
 One thing to beware of is potential 1-frame delay, if the system that is causing the change runs after the system that is checking for changes.
 You may need to pay attention to how you [run schedules] or use [explicit system ordering] to prevent this.
 
-[states]: /learn/book/control-flow/states
-[run conditions]: /learn/book/control-flow/run-conditions#run-conditions
-[run schedules]: /learn/book/the-game-loop/schedules
-[explicit system ordering]: /learn/book/control-flow/run-conditions
+[states]: @/learn/book/control-flow/states.md
+[run conditions]: @/learn/book/control-flow/run-conditions.md#run-conditions
+[run schedules]: @/learn/book/the-game-loop/schedules.md
+[explicit system ordering]: @/learn/book/control-flow/run-conditions.md
 
 [`set_if_neq()`]: https://docs.rs/bevy/latest/bevy/ecs/change_detection/trait.DetectChangesMut.html#method.set_if_neq
 [`ResMut`]: https://docs.rs/bevy/latest/bevy/ecs/system/struct.ResMut.html

--- a/content/learn/book/control-flow/commands.md
+++ b/content/learn/book/control-flow/commands.md
@@ -87,7 +87,7 @@ fn add_twenty_five_to_counter_system(mut commands: Commands) {
 [`Commands`]: https://docs.rs/bevy/latest/bevy/ecs/prelude/struct.Commands.html
 [`Command`]: https://docs.rs/bevy/latest/bevy/prelude/trait.Command.html
 [`queue`]: https://docs.rs/bevy/latest/bevy/ecs/prelude/struct.Commands.html#method.queue
-[Custom Commands]: /learn/book/control-flow/commands#custom-commands
+[Custom Commands]: @/learn/book/control-flow/commands.md#custom-commands
 
 ## When Do Commands Take Effect?
 
@@ -295,4 +295,4 @@ fn some_system(mut commands: Commands) {
 }
 ```
 
-[`Events` and `Observers`]: /learn/book/control-flow/events
+[`Events` and `Observers`]: @/learn/book/control-flow/events.md

--- a/content/learn/book/control-flow/events.md
+++ b/content/learn/book/control-flow/events.md
@@ -348,7 +348,7 @@ struct Click {
 
 To see [`EntityEvent`] propagation in action, the [Bevy Examples Page] has an [Observer Propagation] example which showcases an `Attack` [`EntityEvent`] propagating up from a piece of armor to the entity that is wearing the armor.
 
-[Relations]: /learn/book/storing-data/relations
+[Relations]: @/learn/book/storing-data/relations.md
 [Bevy Examples Page]: https://bevy.org/examples
 [Observer Propagation]: https://bevy.org/examples/ecs-entity-component-system/observer-propagation/
 

--- a/content/learn/book/control-flow/handling-errors.md
+++ b/content/learn/book/control-flow/handling-errors.md
@@ -121,7 +121,7 @@ Each hex parse result value is wrapped in either `Result::Ok` or `Result::Err`.
 A common way to get the interior value is to [`unwrap`](https://doc.rust-lang.org/std/result/enum.Result.html#method.unwrap) the `Result`, but remember that in the case of an `Err`, `unwrap` will crash the program!
 With this in mind `unwrap` is best used when you know the value will be a success, and an `Err` value would indicate a bug in your application.
 
-This is notably true when [writing tests](/learn/book/development-practices/testing), which can use panicking macros like `assert_eq!` to fail a test!
+This is notably true when [writing tests](@/learn/book/development-practices/testing.md), which can use panicking macros like `assert_eq!` to fail a test!
 
 #### Default Values
 
@@ -285,7 +285,7 @@ Since systems require certain data to be available to function, there are two wa
 - SystemParam validation
 - Run conditions
 
-Run conditions and fallible system parameters are covered in [run conditions](/learn/book/control-flow/run-conditions)
+Run conditions and fallible system parameters are covered in [run conditions](@/learn/book/control-flow/run-conditions.md)
 
 ## Errors in Bevy Apps
 
@@ -421,7 +421,7 @@ Use a feature flag for this, so you can decide on error policies for development
 ### Per-system error handling
 
 If you want to handle errors returned from a system in more complex ways, system piping can pass the return value of one system to another.
-More details on system piping can be found in [systems](/learn/book/control-flow/systems).
+More details on system piping can be found in [systems](@/learn/book/control-flow/systems.md).
 
 In this case, the program can use the default global error handler and handle the error using a second system instead.
 The second system in this case takes Bevy's `Result` as a system input using [`In`], and the value can be piped from `update` to `handle_error`.

--- a/content/learn/book/control-flow/run-conditions.md
+++ b/content/learn/book/control-flow/run-conditions.md
@@ -68,7 +68,7 @@ We don't need to update their statistics while waiting for them to respawn, but 
 
 If you are writing your own [`SystemParam`], this behavior can be configured via the [`SystemParam::validate_param`] method.
 
-[Handling Errors]: /learn/book/control-flow/handling-errors
+[Handling Errors]: @/learn/book/control-flow/handling-errors.md
 [`SystemParam`]: https://docs.rs/bevy/latest/bevy/ecs/system/trait.SystemParam.html
 [`Single`]: https://docs.rs/bevy/latest/bevy/ecs/system/struct.Single.html
 [`Query`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Query.html

--- a/content/learn/book/control-flow/states.md
+++ b/content/learn/book/control-flow/states.md
@@ -134,7 +134,7 @@ For more details on where `StateTransition` fits into the broader game loop, see
 [`Startup`]: https://docs.rs/bevy/latest/bevy/app/struct.Startup.html
 [`PreUpdate`]: https://docs.rs/bevy/latest/bevy/app/struct.PreUpdate.html
 [`Update`]: https://docs.rs/bevy/latest/bevy/app/struct.Update.html
-[schedules]: /learn/book/the-game-loop/schedules
+[schedules]: @/learn/book/the-game-loop/schedules.md
 
 ## Cleaning Up Between States
 

--- a/content/learn/book/control-flow/systems.md
+++ b/content/learn/book/control-flow/systems.md
@@ -179,7 +179,7 @@ See the section on [local system state] for more details.
 
 ["splits the borrow"]: https://doc.rust-lang.org/nomicon/borrow-splitting.html
 
-[local system state]: /learn/book/storing-data/local-system-param
+[local system state]: @/learn/book/storing-data/local-system-param.md
 
 ## Running Systems In Schedules
 
@@ -204,7 +204,7 @@ You can read more about schedules in the dedicated [Schedules section], but for 
 - Each of the standard schedules are evaluated *once per frame*.
 - There are also [`Fixed`] schedules which run at a consistent interval.
 
-[Schedules section]: /learn/book/the-game-loop/schedules
+[Schedules section]: @/learn/book/the-game-loop/schedules.md
 
 [`Schedule`]: https://docs.rs/bevy/latest/bevy/ecs/schedule/struct.Schedule.html
 [`App::add_systems`]: https://docs.rs/bevy/latest/bevy/app/struct.App.html#method.add_systems
@@ -317,8 +317,8 @@ struct FooSchedule;
 commands.run_schedule(FooSchedule);
 ```
 
-[locals]: /learn/book/storing-data/local-system-param
-[change detection]: /learn/book/control-flow/change-detection
+[locals]: @/learn/book/storing-data/local-system-param.md
+[change detection]: @/learn/book/control-flow/change-detection.md
 
 [`Entity`]: https://docs.rs/bevy/latest/bevy/ecs/entity/struct.Entity.html
 [`SystemId`]: https://docs.rs/bevy/latest/bevy/ecs/system/struct.SystemId.html
@@ -417,7 +417,7 @@ This can be repeated indefinitely, but branching is not supported.
 System piping is mostly useful for composing fragments of logic in a modular, reusable way.
 System output is also used when returning errors from systems, as explained in the [Handling Errors] section of this chapter.
 
-[Handling Errors]: /learn/book/control-flow/handling-errors
+[Handling Errors]: @/learn/book/control-flow/handling-errors.md
 
 [`In`]: https://docs.rs/bevy/latest/bevy/prelude/trait.System.html#associatedtype.In
 [`Out`]: https://docs.rs/bevy/latest/bevy/prelude/trait.System.html#associatedtype.Out

--- a/content/learn/book/control-flow/time-controls.md
+++ b/content/learn/book/control-flow/time-controls.md
@@ -32,10 +32,10 @@ To understand how Bevy sets up time and its variants, see the dedicated [Time pa
 For more information on schedules, see the [Schedules page], also in the Game Loop chapter.
 It might also be handy to read the [Systems] and [Skipping Systems] pages that are further up in this chapter, as the [System Timer Conditions section] is closely aligned with those pages.
 
-[Time page]: /learn/book/the-game-loop/game-time
-[Systems]: /learn/book/control-flow/systems
-[Skipping Systems]: /learn/book/control-flow/run-conditions
-[Schedules page]: /learn/book/the-game-loop/schedules
+[Time page]: @/learn/book/the-game-loop/game-time.md
+[Systems]: @/learn/book/control-flow/systems.md
+[Skipping Systems]: @/learn/book/control-flow/run-conditions.md
+[Schedules page]: @/learn/book/the-game-loop/schedules.md
 [System Timer Conditions section]: #system-timer-conditions
 
 {% end %}
@@ -86,7 +86,7 @@ Sometimes the solution isn't that straightforward though.
 To read more about "time-step" and how Bevy handles time, we recommend reading the dedicated [Time page] in the Game Loop chapter.
 
 [delta time]: https://en.wikipedia.org/wiki/Delta_timing
-[Time page]: /learn/book/the-game-loop/game-time
+[Time page]: @/learn/book/the-game-loop/game-time.md
 
 [`Schedule`]: https://docs.rs/bevy/latest/bevy/ecs/prelude/struct.Schedule.html
 [`Update`]: https://docs.rs/bevy/latest/bevy/app/struct.Update.html
@@ -430,7 +430,7 @@ Instead, you should either split the work into bite-sized pieces that can safely
 [`Schedule`]: https://docs.rs/bevy/latest/bevy/ecs/prelude/struct.Schedule.html
 [`Time`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Time.html
 [`Time<Fixed>`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Fixed.html
-[Time page]: /learn/book/the-game-loop/game-time
+[Time page]: @/learn/book/the-game-loop/game-time.md
 
 ## Delaying Commands
 

--- a/content/learn/book/development-practices/fast-compiles.md
+++ b/content/learn/book/development-practices/fast-compiles.md
@@ -31,7 +31,7 @@ cargo add bevy -F dynamic_linking
 {% callout(type="warning") %}
 On Windows you must also enable the [performance optimizations] or you will get a ["too many exported symbols"](https://github.com/bevyengine/bevy/issues/1110#issuecomment-1312926923) error.
 
-[performance optimizations]: /learn/book/releasing-projects/release-builds
+[performance optimizations]: @/learn/book/releasing-projects/release-builds.md
 
 In order to run `cargo test --doc`, you must also add the path returned by `rustc --print target-libdir` to your `PATH` environment variable.
 {% end %}
@@ -170,4 +170,4 @@ To enable `sccache`, install it and update your Cargo configuration.
 More code means more time to compile.
 If there are parts of Bevy (or your other dependencies) that you simply don't need,
 you can improve compilation times substantially by removing them.
-For advice on how to navigate Bevy's collection of feature flags, see [Compiling Less Code](/learn/book/releasing-projects/compiling-less-code).
+For advice on how to navigate Bevy's collection of feature flags, see [Compiling Less Code](@/learn/book/releasing-projects/compiling-less-code.md).

--- a/content/learn/book/development-practices/hot-reloading.md
+++ b/content/learn/book/development-practices/hot-reloading.md
@@ -11,7 +11,7 @@ Unfortunately, recompiling can be slow, and requires you to close the game, losi
 To make this easier, Bevy supports **hot reloading**, which allows you to modify your game's assets and automatically load these changes into a running instance of the game.
 
 While hot-reloading is useful during development time, it's usually not something you want to ship in a production game.
-Unless you're deliberately using this for modding support, you should turn these settings off when [releasing projects](/learn/book/releasing-projects/_index).
+Unless you're deliberately using this for modding support, you should turn these settings off when [releasing projects](@/learn/book/releasing-projects/_index.md).
 
 ## Hot Reloading Assets
 

--- a/content/learn/book/development-practices/testing.md
+++ b/content/learn/book/development-practices/testing.md
@@ -111,13 +111,13 @@ Take advantage of existing developer tools, make your own, and make it easy to j
 
 You should create a dedicated `devtools` feature flag for your application (and enable it by default) which will turn on all of the testing and debugging utilities that your project might need.
 Reproducing tricky bugs can be incredibly time-consuming; you don't want to have to recompile your game to turn on these tools.
-Then when you are [building for release](/learn/book/releasing-projects/release-builds), turn your `devtools` feature flag off.
+Then when you are [building for release](@/learn/book/releasing-projects/release-builds.md), turn your `devtools` feature flag off.
 
 Rust's examples are a surprisingly powerful testing tool, letting you create secondary binaries with customized setups.
 You might configure one to open the game with the settings menu open, another to take a command line argument to jump you to the supplied level, and a third to start a new run of the game using a prebuilt character.
 
 Adding systems to these examples can be fairly straightforward.
-A useful pattern is to directly mutate the desired [state](/learn/book/control-flow/states) to bring you to a specific point in your game.
+A useful pattern is to directly mutate the desired [state](@/learn/book/control-flow/states.md) to bring you to a specific point in your game.
 The [`run_once`] run condition can also be particularly useful to avoid surprising behavior once setup is complete.
 You can even add asserts to verify that your setup steps have done what you wanted.
 
@@ -282,7 +282,7 @@ You get full data access and Bevy's ECS ergonomics, but you still control exactl
 ### Running Entire Schedules
 
 When the behavior you care about comes from the interaction *between* systems, you can build up a [`Schedule`] and run it against a `World`.
-This lets you verify [system ordering](/learn/book/control-flow/systems#running-systems-in-schedules) and [run conditions](/learn/book/control-flow/run-conditions), which you can't do with `run_system_once`.
+This lets you verify [system ordering](@/learn/book/control-flow/systems.md#running-systems-in-schedules) and [run conditions](@/learn/book/control-flow/run-conditions.md), which you can't do with `run_system_once`.
 
 ```rust
 fn regenerate(mut query: Query<&mut Life>) {
@@ -319,7 +319,7 @@ Individually test systems first where you can, and save schedule-level tests for
 Taking this one step further, you can even construct an [`App`], add your plugins, and step it forward with [`app.update()`].
 Each call to `update` runs a full frame: `Startup` (on the first call), then `PreUpdate`, `Update`, `PostUpdate`, and so on.
 
-The reason to reach for this over a raw `Schedule` is [plugins](/learn/book/modular-architecture/plugins).
+The reason to reach for this over a raw `Schedule` is [plugins](@/learn/book/modular-architecture/plugins.md).
 Suppose your game has a `CombatPlugin` that registers the `PoisonStrength` resource and the `apply_poison` system.
 You can test the plugin as a whole, without manually recreating its internals:
 
@@ -449,7 +449,7 @@ Inside of your own code, be careful to never introduce a gameplay logic dependen
 This is reasonable practice in any case to avoid surprising bugs.
 Splitting your code into multiple crates can be useful to enforce this invariant as Cargo will help you catch cyclic dependencies, but doing so can seriously slow down iteration for small projects.
 
-[Compiling Less Code]: /learn/book/releasing-projects/compiling-less-code
+[Compiling Less Code]: @/learn/book/releasing-projects/compiling-less-code.md
 
 ## Testing Graphical Output
 

--- a/content/learn/book/further-reading/_index.md
+++ b/content/learn/book/further-reading/_index.md
@@ -14,8 +14,8 @@ Bevy has a wide range of different learning materials, targeted at different use
 
 Everyone learns differently, so we offer a variety of complementary paths:
 
-- [Quickstart](/learn/quickstart): Build a simple game through a hands-on tutorial designed for absolute beginners.
-- [The Book](/learn/book): Learn the core concepts that make Bevy work, then explore advanced topics needed to ship a production game.
+- [Quickstart](@/learn/quick-start/introduction.md): Build a simple game through a hands-on tutorial designed for absolute beginners.
+- [The Book](@/learn/book/_index.md): Learn the core concepts that make Bevy work, then explore advanced topics needed to ship a production game.
 - [docs.rs](https://docs.rs/bevy/latest/bevy/): Versioned API documentation that explains every struct, method, and function. Module and crate docs also provide an overview of specific areas of the code.
 - [Feature Examples](https://bevyengine.org/examples): Explore Bevy's features by browsing runnable snippets.
 - [Game Examples](https://bevyengine.org/examples/#games): Explore larger project structure and genre-specific ideas through playable game stubs.

--- a/content/learn/book/intro/_index.md
+++ b/content/learn/book/intro/_index.md
@@ -41,14 +41,14 @@ It exists to both develop Bevy and help people learn how to use it.
 This book is [explanatory documentation](https://diataxis.fr/) covering Bevy's core ideas.
 You can read it cover to cover, or skip ahead to the sections that interest you.
 
-If you are new to Bevy, [read the first chapter](/learn/book/intro/the-three-letters) before proceeding.
+If you are new to Bevy, [read the first chapter](@/learn/book/intro/the-three-letters.md) before proceeding.
 It introduces the ECS vocabulary and core terms you'll need for the rest of this book.
 After that, use the sidebar to jump to any chapter you need.
 We've attempted to arrange them in a useful order, but they do not assume you have read previous chapters.
 
-If you want a broader map of Bevy's documentation ecosystem (quick start guide, examples, API docs, and more), see [Further Reading](/learn/book/further-reading).
+If you want a broader map of Bevy's documentation ecosystem (quick start guide, examples, API docs, and more), see [Further Reading](@/learn/book/further-reading/_index.md).
 
-If you're evaluating whether Bevy is the right fit for your project, read [Is Bevy Right for Your Project?](/learn/book/is-bevy-right-for-your-project).
+If you're evaluating whether Bevy is the right fit for your project, read [Is Bevy Right for Your Project?](@/learn/book/is-bevy-right-for-your-project/_index.md).
 
 {% callout(type="info") %}
 ### Corrections and Extensions

--- a/content/learn/book/intro/apps-worlds.md
+++ b/content/learn/book/intro/apps-worlds.md
@@ -20,7 +20,7 @@ It is possible to have multiple worlds, and it's also possible to run a world co
 
 ## The App
 
-Bevy provides a modular multi-threaded runtime called an [`App`](/learn/book/the-game-loop/app). If you have used web servers before, the basic ideas of an app will probably be familiar: you configure your app with settings and logic, then `run()` it to enter an update loop. It tends to look something like this:
+Bevy provides a modular multi-threaded runtime called an [`App`](@/learn/book/the-game-loop/app.md). If you have used web servers before, the basic ideas of an app will probably be familiar: you configure your app with settings and logic, then `run()` it to enter an update loop. It tends to look something like this:
 
 ```rust
 use bevy::prelude::*;
@@ -35,7 +35,7 @@ fn main() {
 In most cases, your world will be contained within your app.
 The app is responsible for scheduling and executing your systems, and passing the data in and out of them appropriately.
 
-Apps can be used to combine code that's been broken down into modular, reusable pieces, called [plugins](/learn/book/modular-architecture/plugins).
+Apps can be used to combine code that's been broken down into modular, reusable pieces, called [plugins](@/learn/book/modular-architecture/plugins.md).
 
 ## Next Steps
 

--- a/content/learn/book/intro/the-next-three-letters.md
+++ b/content/learn/book/intro/the-next-three-letters.md
@@ -12,7 +12,7 @@ These concepts are core to Bevy's ECS (so much so that they're used in the previ
 ## Resources
 
 **Resources** are global state singletons.
-Unlike [components](/learn/book/intro/the-three-letters#the-c-components), which are reused across multiple entities, resources are unique. For any given resource type (like `Score` in the example below), there can only be one instance in your game world at a time.
+Unlike [components](@/learn/book/intro/the-three-letters.md#the-c-components), which are reused across multiple entities, resources are unique. For any given resource type (like `Score` in the example below), there can only be one instance in your game world at a time.
 
 Like components, resources in Bevy are also "just Rust structs" (or enums).
 
@@ -67,7 +67,7 @@ fn tick_down_poison(mut query: Query<&mut Poison>) {
 }
 ```
 
-Then, when systems are run as part of a Bevy [app](/learn/book/the-game-loop/app), the engine automatically fetches the requested data, parallelizing work between systems wherever possible:
+Then, when systems are run as part of a Bevy [app](@/learn/book/the-game-loop/app.md), the engine automatically fetches the requested data, parallelizing work between systems wherever possible:
 
 ```rs
 fn main() {
@@ -85,7 +85,7 @@ Going back to our database analogy, a query is a lot like a [SQL `SELECT` statem
 
 Queries have a lot more functionality than what's shown here.
 You can request optional components, fetch the `Entity` associated with each item, add query filters, and much more!
-Queries are covered in more detail in the [Queries](/learn/book/storing-data/queries) chapter.
+Queries are covered in more detail in the [Queries](@/learn/book/storing-data/queries.md) chapter.
 
 ## Commands
 
@@ -104,4 +104,4 @@ fn spawn_entities(mut commands: Commands) {
 
 A wide range of built-in commands are provided,
 but you can also write custom commands to queue up any ECS logic you might desire.
-You can read about these in more detail in the [Commands](/learn/book/control-flow/commands) chapter.
+You can read about these in more detail in the [Commands](@/learn/book/control-flow/commands.md) chapter.

--- a/content/learn/book/intro/the-three-letters.md
+++ b/content/learn/book/intro/the-three-letters.md
@@ -86,12 +86,12 @@ fn spawn_entities(mut commands: Commands) {
 }
 ```
 
-Entities are usually spawned using [Commands](/learn/book/control-flow/commands), which queue up complex work to be done later.
+Entities are usually spawned using [Commands](@/learn/book/control-flow/commands.md), which queue up complex work to be done later.
 
 ## The S: Systems
 
 Systems interact with and update the data in the ECS.
-Each system is run every frame by default, and repeats in a loop (specifically, in a [Schedule](/learn/book/the-game-loop/schedules)).
+Each system is run every frame by default, and repeats in a loop (specifically, in a [Schedule](@/learn/book/the-game-loop/schedules.md)).
 In Bevy, systems are "just Rust functions".
 These can fetch data from the ECS, make updates, call external APIs, and anything else that a function can do.
 
@@ -105,12 +105,12 @@ fn my_system(entities: Query<&mut Location>) {
 ```
 
 {% callout(type="info") %}
-Bevy systems use a technique called [dependency injection](https://en.wikipedia.org/wiki/Dependency_injection) to access data about the Bevy world. By declaring your function parameters wrapped in special types like [Query](/learn/book/intro/the-next-three-letters#queries) or [Res](/learn/book/intro/the-next-three-letters#resources), the data for those parameters will be filled in for you automatically — without you having to actually call the system.
+Bevy systems use a technique called [dependency injection](https://en.wikipedia.org/wiki/Dependency_injection) to access data about the Bevy world. By declaring your function parameters wrapped in special types like [Query](@/learn/book/intro/the-next-three-letters.md#queries) or [Res](@/learn/book/intro/the-next-three-letters.md#resources), the data for those parameters will be filled in for you automatically — without you having to actually call the system.
 
 Another cool feature of Bevy systems is automatic parallelism: by inspecting the function parameter types, Bevy can automatically determine if it's safe to run two systems concurrently. For example, if you have a system which regenerates character health by modifying a `Health` component, and a different system that manages the characters' mana pool (say, via a `Mana` component), then Bevy knows that these two data sets are *disjoint* and can be updated at the same time. This is particularly important for optimal utilization of multiple CPU cores.
 {% end %}
 
-Systems usually access entities and their components via [Queries](/learn/book/intro/the-next-three-letters#queries), which will be covered in the next chapter.
+Systems usually access entities and their components via [Queries](@/learn/book/intro/the-next-three-letters.md#queries), which will be covered in the next chapter.
 
 ## Why ECS?
 
@@ -128,13 +128,13 @@ you can:
   - No more speculative rewrites of whole subsystems: gradually optimize the hot loops.
 - Have engine code that looks like library code that looks like game code.
   - Weird behavior? Check the source!
-  - This makes [contributing](/learn/contribute) fixes and features to Bevy much easier.
+  - This makes [contributing](@/learn/contribute/_index.md) fixes and features to Bevy much easier.
   - Plus it helps support a thriving, heavily interoperable [ecosystem of third-party libraries](https://bevy.org/assets/).
 - Build consistent, universal abstractions on a common base of data structures.
   - Shared data structures mean that improvements and bug fixes trickle down automatically.
-  - Use the same powerful patterns for [control flow](/learn/book/control-flow/) everywhere.
-  - Structure your application using a uniform, flexible [modular architecture](/learn/book/modular-architecture).
-  - Debug and inspect every part of your game using the same [dev tools](/learn/book/development-practices).
+  - Use the same powerful patterns for [control flow](@/learn/book/control-flow/_index.md) everywhere.
+  - Structure your application using a uniform, flexible [modular architecture](@/learn/book/modular-architecture/_index.md).
+  - Debug and inspect every part of your game using the same [dev tools](@/learn/book/development-practices/_index.md).
 
 Learning to take advantage of everything a modern ECS has to offer will take time:
 if you want to be able to tackle any data modelling problem that games have to throw at you,

--- a/content/learn/book/is-bevy-right-for-your-project/_index.md
+++ b/content/learn/book/is-bevy-right-for-your-project/_index.md
@@ -24,7 +24,7 @@ Bevy is delightful! You should use Bevy if:
   - Whether you're making CAD software, art installations, or scientific simulations, Bevy can be extremely flexible.
 - *You care about open source software:*
   - Read, understand, and hack your tools from top-to-bottom.
-- *You want an engine with a lively [community](/community):*
+- *You want an engine with a lively [community](@/community/_index.md):*
   - Users, engine devs, and ecosystem creators join forces from across the world.
 - *You never want to have to pay licensing fees or worry about vendor lock-in.*
   - Bevy is free and open source from now until the end of time.

--- a/content/learn/book/modular-architecture/plugins.md
+++ b/content/learn/book/modular-architecture/plugins.md
@@ -149,7 +149,7 @@ Then, when the app is run, a few other plugin life-cycle functions are called, a
 
 In most cases, this complexity can be completely ignored, but when working with subsystems that require deferred initialization it can be helpful.
 
-[apps]: /learn/book/the-game-loop/app
+[apps]: @/learn/book/the-game-loop/app.md
 [`App`]: https://docs.rs/bevy/latest/bevy/app/struct.App.html
 [`App::add_systems`]: https://docs.rs/bevy/latest/bevy/app/struct.App.html?search=add#method.add_systems
 [`App::add_plugins`]: https://docs.rs/bevy/latest/bevy/app/struct.App.html?search=add#method.add_plugins

--- a/content/learn/book/modular-architecture/project-organization.md
+++ b/content/learn/book/modular-architecture/project-organization.md
@@ -24,7 +24,7 @@ Thankfully, the Bevy community has answers to these questions:
   - placing these at the top of your files can act as a simple, consistent "table of contents"
 
 [orphan rules]: https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules
-[plugin]: /learn/book/modular-architecture/plugins
+[plugin]: @/learn/book/modular-architecture/plugins.md
 
 ## Modules
 
@@ -66,9 +66,9 @@ and use the cached compilation results for everything else.
 
 [crates]: https://doc.rust-lang.org/book/ch07-01-packages-and-crates.html
 [workspaces]: https://doc.rust-lang.org/cargo/reference/workspaces.html
-[creating libraries]: /learn/book/releasing-projects/libraries-for-bevy
+[creating libraries]: @/learn/book/releasing-projects/libraries-for-bevy.md
 [Rust parallelizes compilation at the crate level]: https://www.feldera.com/blog/cutting-down-rust-compile-times-from-30-to-2-minutes-with-one-thousand-crates
-[setup tips for faster compilations]: /learn/book/development-practices/fast-compiles
+[setup tips for faster compilations]: @/learn/book/development-practices/fast-compiles.md
 [`cargo build --timings`]: https://doc.rust-lang.org/cargo/reference/timings.html
 
 ## Item Visibility

--- a/content/learn/book/releasing-projects/libraries-for-bevy.md
+++ b/content/learn/book/releasing-projects/libraries-for-bevy.md
@@ -79,7 +79,7 @@ A few conventions go a long way:
 
 - **Expose a plugin.** The standard entry point for a Bevy library is a [`Plugin`](https://docs.rs/bevy/latest/bevy/app/trait.Plugin.html). Even if your crate is simple, wrapping your setup logic in a plugin gives users a consistent, predictable way to integrate it: `app.add_plugins(YourPlugin)`.
 - **Use the ECS where it makes sense.** Bevy users expect their crates to use components, resources, events and messages. Structuring your crate to use them makes it easier to extend, modify and inspect.
-- **Don't panic.** Library code should almost never crash. Program defensively, and return `Result` when something goes wrong. Log an error or warning if there's nowhere to return. Reserve panics exclusively for upholding soundness invariants. Read more about [handling errors here](../control-flow/handling-errors.md).
+- **Don't panic.** Library code should almost never crash. Program defensively, and return `Result` when something goes wrong. Log an error or warning if there's nowhere to return. Reserve panics exclusively for upholding soundness invariants. Read more about [handling errors here](@/learn/book/control-flow/handling-errors.md).
 - **Follow Rust API guidelines.** The [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/) are a great reference for naming, documentation, and API design.
 - **Use feature flags to make expensive or niche functionality opt-in.** If your crate has optional integrations (e.g. serialization, debug tooling, support for specific Bevy subsystems), gate them behind [Cargo features](https://doc.rust-lang.org/cargo/reference/features.html) rather than pulling everything in by default. This keeps compile times down and avoids forcing unwanted dependencies on your users. A few guidelines:
   - Name features after what they enable (e.g. `serialize`, `bevy_ui`), not what they depend on.
@@ -192,7 +192,7 @@ We have a few additional setup suggestions:
   type_complexity = "allow"
   ```
 
-Take a look at our chapter on [Testing](/learn/book/development-practices/testing):
+Take a look at our chapter on [Testing](@/learn/book/development-practices/testing.md):
 this advice is particularly useful for library authors.
 
 ### Configuring Github repo settings

--- a/content/learn/book/storing-data/_index.md
+++ b/content/learn/book/storing-data/_index.md
@@ -8,4 +8,4 @@ status = 'hidden'
 +++
 
 Bevy's ECS (Entity-Component-System) is the central, unified way we store data.
-While the most fundamental concepts were introduced in the [Introduction](/learn/book/intro), this chapter dives deeper into the various ways we can store and access data within the ECS.
+While the most fundamental concepts were introduced in the [Introduction](@/learn/book/intro/_index.md), this chapter dives deeper into the various ways we can store and access data within the ECS.

--- a/content/learn/book/storing-data/designing-components.md
+++ b/content/learn/book/storing-data/designing-components.md
@@ -170,7 +170,7 @@ fn handle_clickable_props(trigger: On<Pointer<Click>>, query: Query<&ClickablePr
 
 This can be repeated with other traits: [`Event`] and [`Message`] are quite powerful if you want to hook into existing logic.
 
-Storing [one-shot systems](/learn/book/control-flow/systems) can be even more expressive.
+Storing [one-shot systems](@/learn/book/control-flow/systems.md) can be even more expressive.
 See the [callbacks example](https://github.com/bevyengine/bevy/blob/latest/examples/ecs/callbacks.rs) for a demonstration of this pattern.
 
 If your benchmarks show that you need to make this pattern more performant, you can consider swapping to [function pointers](https://doc.rust-lang.org/std/primitive.fn.html).

--- a/content/learn/book/storing-data/entities-components.md
+++ b/content/learn/book/storing-data/entities-components.md
@@ -18,7 +18,7 @@ Internally, [`Entity`] is roughly shaped like a `u64`, with arbitrary (unique) b
 While it is possible to work with the [`Entity`] type directly, it should be treated as an opaque, black box key.
 Bevy makes no guarantees that exact entity assignment or storage behavior will be stable across any version boundary.
 
-[world]: /learn/book/storing-data/world
+[world]: @/learn/book/storing-data/world.md
 [`Entity`]: https://docs.rs/bevy/latest/bevy/ecs/entity/struct.Entity.html
 [`HashMap`]: https://doc.rust-lang.org/std/collections/struct.HashMap.html
 
@@ -53,7 +53,7 @@ fn spawning_system(mut commands: Commands){
 }
 ```
 
-[exclusive system]: /learn/book/control-flow/systems/#exclusive-systems
+[exclusive system]: @/learn/book/control-flow/systems.md#exclusive-systems
 [`World`]: https://docs.rs/bevy/latest/bevy/ecs/world/struct.World.html
 [`Commands`]: https://docs.rs/bevy/latest/bevy/ecs/system/struct.Commands.html
 
@@ -71,7 +71,7 @@ To make a basic cube, you'd probably need to add:
 - A [`StandardMaterial`] to define how that mesh should be rendered (in practice, actually a [`Handle`] to a [`StandardMaterial`])
 - Etc.
 
-[introduction section on components]: /learn/book/intro/the-three-letters#the-c-components
+[introduction section on components]: @/learn/book/intro/the-three-letters.md#the-c-components
 [`Transform`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Transform.html
 [`Mesh`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Mesh.html
 [`Handle`]: https://docs.rs/bevy/latest/bevy/asset/enum.Handle.html

--- a/content/learn/book/storing-data/local-system-param.md
+++ b/content/learn/book/storing-data/local-system-param.md
@@ -44,7 +44,7 @@ fn increment_local_system_data(mut local: Local<Option<NoGoodDefaultValue>>){
 ```
 
 [`Local<T>`]: https://docs.rs/bevy/latest/bevy/ecs/system/struct.Local.html
-[resource]: /learn/book/storing-data/resources
+[resource]: @/learn/book/storing-data/resources.md
 [`MessageReader`]: https://docs.rs/bevy/latest/bevy/ecs/message/struct.MessageReader.html
 [`on_timer`]: https://docs.rs/bevy/latest/bevy/time/common_conditions/fn.on_timer.html
 [`Default`]: https://doc.rust-lang.org/std/default/trait.Default.html

--- a/content/learn/book/storing-data/queries.md
+++ b/content/learn/book/storing-data/queries.md
@@ -10,7 +10,7 @@ Queries are your primary tool for interacting with the Bevy world, allowing you 
 Queries create a filtered "view" into the metaphorical database that makes up our ECS.
 With that view you can iterate over the requested components, ask what the "row number" (`Entity`) is for each element, or fetch the matching components for a particular `Entity` value.
 
-We briefly covered queries in our [introduction](/learn/book/intro/) to Bevy, so make sure to review that section if you haven't read it yet.
+We briefly covered queries in our [introduction](@/learn/book/intro/_index.md) to Bevy, so make sure to review that section if you haven't read it yet.
 If you're entirely brand new to Bevy or ECS, we would recommend you to start there before continuing on this page.
 
 ## Anatomy of a Query
@@ -173,7 +173,7 @@ While this is talked about in more depth in the chapter on [change detection], i
 [query item]: https://docs.rs/bevy/latest/bevy/ecs/query/trait.QueryData.html#associatedtype.Item
 [`Mut<Life>`]: https://docs.rs/bevy/latest/bevy/ecs/change_detection/struct.Mut.html
 [smart pointer]: https://doc.rust-lang.org/book/ch15-00-smart-pointers.html
-[change detection]: /learn/book/control-flow/change-detection
+[change detection]: @/learn/book/control-flow/change-detection.md
 [`Changed`]: https://docs.rs/bevy/latest/bevy/ecs/query/struct.Changed.html
 [`Added`]: https://docs.rs/bevy/latest/bevy/ecs/query/struct.Added.html
 
@@ -230,8 +230,8 @@ fn despawn_all_enemies(enemies: Query<Entity, With<Enemy>>, mut commands: Comman
 }
 ```
 
-[hooks]: /learn/book/control-flow/lifecycle-events
-[relations]: /learn/book/storing-data/relations
+[hooks]: @/learn/book/control-flow/lifecycle-events.md
+[relations]: @/learn/book/storing-data/relations.md
 [`Query::get`]: https://docs.rs/bevy/latest/bevy/ecs/system/struct.Query.html#method.get
 [`Query::get_mut`]: https://docs.rs/bevy/latest/bevy/ecs/system/struct.Query.html#method.get_mut
 [`Entity`]: https://docs.rs/bevy/latest/bevy/ecs/entity/struct.Entity.html
@@ -291,8 +291,8 @@ fn kill_player_when_dead_query_single(player: Single<(Entity, &Life), With<Playe
 For more discussion on [`Single`] and how it works, please see the [error handling] chapter.
 Similarly, see the [resources] chapter of this book for a discussion on the choice between using a singleton entity or a resource.
 
-[error handling]: /learn/book/control-flow/handling-errors
-[resources]: /learn/book/storing-data/resources
+[error handling]: @/learn/book/control-flow/handling-errors.md
+[resources]: @/learn/book/storing-data/resources.md
 [`Query::single`]: https://docs.rs/bevy/latest/bevy/ecs/system/struct.Query.html#method.single
 [`QuerySingleError`]: https://docs.rs/bevy/latest/bevy/ecs/query/enum.QuerySingleError.html
 [`Single`]: https://docs.rs/bevy/latest/bevy/ecs/system/struct.Single.html

--- a/content/learn/book/storing-data/resources.md
+++ b/content/learn/book/storing-data/resources.md
@@ -26,7 +26,7 @@ If you might need multiple instances, then consider using [entities and componen
 Bevy uses resources for many of the built-in features of the engine.
 For example, Bevy's [`AssetServer`] is a resource.
 
-[entities and components]: /learn/book/storing-data/entities-components
+[entities and components]: @/learn/book/storing-data/entities-components.md
 [`World`]: https://docs.rs/bevy/latest/bevy/ecs/world/struct.World.html
 [`AssetServer`]: https://docs.rs/bevy/latest/bevy/asset/struct.AssetServer.html
 

--- a/content/learn/book/storing-data/world.md
+++ b/content/learn/book/storing-data/world.md
@@ -23,5 +23,5 @@ However, it also means that entities must be moved between tables when component
 With a `&World` reference, you can read anything out of the ECS.
 With a `&mut World`, you can write to it as well.
 
-[entity]: /learn/book/storing-data/entities-components
+[entity]: @/learn/book/storing-data/entities-components.md
 [`World`]: https://docs.rs/bevy/latest/bevy/prelude/struct.World.html

--- a/content/learn/book/the-game-loop/app.md
+++ b/content/learn/book/the-game-loop/app.md
@@ -31,11 +31,11 @@ We will take a closer look at the runner function in the [custom loops] chapter.
 [`App::world_mut`]:  https://docs.rs/bevy/latest/bevy/app/struct.App.html#method.world_mut
 [`App::set_runner`]:  https://docs.rs/bevy/latest/bevy/app/struct.App.html#method.set_runner
 [`World`]: https://docs.rs/bevy/latest/bevy/ecs/world/index.html
-[systems]: /learn/book/control-flow/systems
-[resources]: /learn/book/storing-data/resources
-[events]: /learn/book/control-flow/events
-[schedules]: /learn/book/the-game-loop/schedules
-[custom loops]: /learn/book/the-game-loop/schedules
-[plugins]: /learn/book/modular-architecture/plugins
+[systems]: @/learn/book/control-flow/systems.md
+[resources]: @/learn/book/storing-data/resources.md
+[events]: @/learn/book/control-flow/events.md
+[schedules]: @/learn/book/the-game-loop/schedules.md
+[custom loops]: @/learn/book/the-game-loop/schedules.md
+[plugins]: @/learn/book/modular-architecture/plugins.md
 [`DefaultPlugins`]: https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html
 [`MinimalPlugins`]: https://docs.rs/bevy/latest/bevy/struct.MinimalPlugins.html

--- a/content/learn/book/the-game-loop/game-time.md
+++ b/content/learn/book/the-game-loop/game-time.md
@@ -27,7 +27,7 @@ These include timers, stopwatches, system conditions, and even some command opti
 
 If you'd like to read about these tools, please see the [Time Controls page] located in the Control Flow chapter.
 
-[Time Controls page]: /learn/book/control-flow/time-controls
+[Time Controls page]: @/learn/book/control-flow/time-controls.md
 
 {% end %}
 
@@ -111,8 +111,8 @@ If your systems uniformly rely on [`Time`], this will affect your entire game:
 halting, slowing or speeding up animations, movement, projectiles, physics and so on.
 Alternatively, [states] and [run conditions] can be used to skip systems while the game is paused.
 
-[states]: /learn/book/control-flow/states
-[run conditions]: /learn/book/control-flow/run-conditions
+[states]: @/learn/book/control-flow/states.md
+[run conditions]: @/learn/book/control-flow/run-conditions.md
 
 ## Fixing your timestep
 

--- a/content/learn/book/the-game-loop/schedules.md
+++ b/content/learn/book/the-game-loop/schedules.md
@@ -93,14 +93,14 @@ Bevy itself uses this pattern for both the [`Main`] schedule and our built-in [f
 [`PostUpdate`]: https://docs.rs/bevy/latest/bevy/app/struct.PostUpdate.html
 [`Last`]: https://docs.rs/bevy/latest/bevy/app/struct.Last.html
 [`Main`]: https://docs.rs/bevy/latest/bevy/app/struct.Main.html
-[systems]: /learn/book/control-flow/systems
-[app]: /learn/book/the-game-loop/app
-[plugins]: /learn/book/modular-architecture/plugins
-[state machine abstraction]: /learn/book/control-flow/states
-[fixed update loop]: /learn/book/the-game-loop/time-and-timers#fixing-your-timestep
+[systems]: @/learn/book/control-flow/systems.md
+[app]: @/learn/book/the-game-loop/app.md
+[plugins]: @/learn/book/modular-architecture/plugins.md
+[state machine abstraction]: @/learn/book/control-flow/states.md
+[fixed update loop]: @/learn/book/the-game-loop/game-time.md#fixing-your-timestep
 [`ScheduleRunnerPlugin`]: https://docs.rs/bevy/latest/bevy/app/struct.ScheduleRunnerPlugin.html
 [`MinimalPlugins`]: https://docs.rs/bevy/latest/bevy/struct.MinimalPlugins.html
 [`DefaultPlugins`]: https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html
 [`MainScheduleOrder`]: https://docs.rs/bevy/latest/bevy/app/struct.MainScheduleOrder.html
 [`World::run_schedule`]: https://docs.rs/bevy/latest/bevy/prelude/struct.World.html#method.run_schedule
-[fixed time]: /learn/book/the-game-loop/game-time#frame-rate-independence-and-delta-time
+[fixed time]: @/learn/book/the-game-loop/game-time.md#frame-rate-independence-and-delta-time

--- a/content/learn/book/the-renderer/render-pipelines.md
+++ b/content/learn/book/the-renderer/render-pipelines.md
@@ -80,7 +80,7 @@ Once copied over, a connection between the Render `SubApp` entity and their Main
 Alternatively, if you only need a specific type of asset (like a texture or a mesh), you can load an [`Asset`].
 `Asset`s that are loaded in your Main `SubApp` are automatically copied over in the `ExtractSchedule`.
 Bevy is able to do this by reading the associated [`AssetEvent`] messages that the `Asset` type emits when registered and loaded.
-You can read more about how `Asset`s are loaded and handled by Bevy in the [dedicated Assets chapter](/learn/book/assets).
+You can read more about how `Asset`s are loaded and handled by Bevy in the [dedicated Assets chapter](@/learn/book/assets/_index.md).
 
 ### Prepare & Queue
 


### PR DESCRIPTION
Previously, the bevy book used primarily absolute (`"/learn/book"`) paths for links between documents, in a few cases using relative paths. Absolute paths were a problem in particular because zola cannot validate them, so there were 4 broken links that went undetected. This PR converts all the intra-document links to use the `@/` (content-relative) syntax, as well as fixing the broken links.

Note that the `@/` path points to the actual file location, not the slugified / trimmed URL that it is transforms into.

Note that the actual conversion was done by a Python script, not by hand.