### PR TITLE
Change book links from `bevyengine.org` to `bevy.org`.

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -25,7 +25,7 @@ theme = "bevy-syntax-theme"
 extra_themes = ["themes/bevy-syntax-theme.json"]
 extra_grammars = ["grammars/ron.json"]
 
-error_on_missing_language = true
+# error_on_missing_language = true
 
 [extra]
 # Put all your custom variables here

--- a/config.toml
+++ b/config.toml
@@ -25,5 +25,7 @@ theme = "bevy-syntax-theme"
 extra_themes = ["themes/bevy-syntax-theme.json"]
 extra_grammars = ["grammars/ron.json"]
 
+error_on_missing_language = true
+
 [extra]
 # Put all your custom variables here

--- a/content/learn/book/further-reading/_index.md
+++ b/content/learn/book/further-reading/_index.md
@@ -17,8 +17,8 @@ Everyone learns differently, so we offer a variety of complementary paths:
 - [Quickstart](@/learn/quick-start/introduction.md): Build a simple game through a hands-on tutorial designed for absolute beginners.
 - [The Book](@/learn/book/_index.md): Learn the core concepts that make Bevy work, then explore advanced topics needed to ship a production game.
 - [docs.rs](https://docs.rs/bevy/latest/bevy/): Versioned API documentation that explains every struct, method, and function. Module and crate docs also provide an overview of specific areas of the code.
-- [Feature Examples](https://bevyengine.org/examples): Explore Bevy's features by browsing runnable snippets.
-- [Game Examples](https://bevyengine.org/examples/#games): Explore larger project structure and genre-specific ideas through playable game stubs.
+- [Feature Examples](https://bevy.org/examples): Explore Bevy's features by browsing runnable snippets.
+- [Game Examples](https://bevy.org/examples/#games): Explore larger project structure and genre-specific ideas through playable game stubs.
 
 ## How to Use These Together
 

--- a/content/learn/book/intro/_index.md
+++ b/content/learn/book/intro/_index.md
@@ -29,14 +29,14 @@ but don't be afraid: it'll click soon enough.
 
 ## Who Builds Bevy?
 
-Bevy is built in the open by hundreds of [community contributors](https://bevyengine.org/learn/contribute/introduction).
+Bevy is built in the open by hundreds of [community contributors](https://bevy.org/learn/contribute/introduction).
 No one person or corporation owns it, and thus no single entity controls how Bevy can be used.
 It's dual-licensed under both the [MIT](https://github.com/bevyengine/bevy/blob/main/LICENSE-MIT) and [Apache v2](https://github.com/bevyengine/bevy/blob/main/LICENSE-APACHE) licenses, giving users the choice of determining which license best fits their use case.
 
-The [Bevy Foundation](https://bevyengine.org/foundation/) is a 501(c)(3) nonprofit that is responsible for promoting, protecting, and advancing the Bevy engine.
+The [Bevy Foundation](https://bevy.org/foundation/) is a 501(c)(3) nonprofit that is responsible for promoting, protecting, and advancing the Bevy engine.
 It exists to both develop Bevy and help people learn how to use it.
 
-## What Is the Bevy Book? 
+## What Is the Bevy Book?
 
 This book is [explanatory documentation](https://diataxis.fr/) covering Bevy's core ideas.
 You can read it cover to cover, or skip ahead to the sections that interest you.
@@ -51,11 +51,12 @@ If you want a broader map of Bevy's documentation ecosystem (quick start guide, 
 If you're evaluating whether Bevy is the right fit for your project, read [Is Bevy Right for Your Project?](@/learn/book/is-bevy-right-for-your-project/_index.md).
 
 {% callout(type="info") %}
+
 ### Corrections and Extensions
 
 Like any good piece of documentation, the Bevy Book is continuously updated.
 
 If you spot a typo, [submit a quick PR](https://github.com/bevyengine/bevy-website/pulls).
 The files used to create the book are just Markdown; you can find them in `content/learn/book`.
-If you'd like to refactor something or add a new section, read our [Contributing Guide](https://bevyengine.org/learn/contribute/introduction/) and we'd be happy to welcome you to the flock!
+If you'd like to refactor something or add a new section, read our [Contributing Guide](https://bevy.org/learn/contribute/introduction/) and we'd be happy to welcome you to the flock!
 {% end %}

--- a/content/learn/book/is-bevy-right-for-your-project/_index.md
+++ b/content/learn/book/is-bevy-right-for-your-project/_index.md
@@ -14,39 +14,39 @@ Use this page to make an informed decision.
 
 Bevy is delightful! You should use Bevy if:
 
-- *You like Rust:*
+- _You like Rust:_
   - It's a modern, safe, high-performance language with incredible tooling and a welcoming community.
-- *You like ECS:*
+- _You like ECS:_
   - Fast, elegant, and extremely parallelizable, ECS handles extreme levels of complexity well.
-- *You prefer a code-first approach to game logic:*
+- _You prefer a code-first approach to game logic:_
   - Bevy is all just plain Rust.
-- *You're making something unusual:*
+- _You're making something unusual:_
   - Whether you're making CAD software, art installations, or scientific simulations, Bevy can be extremely flexible.
-- *You care about open source software:*
+- _You care about open source software:_
   - Read, understand, and hack your tools from top-to-bottom.
-- *You want an engine with a lively [community](@/community/_index.md):*
+- _You want an engine with a lively [community](@/community/_index.md):_
   - Users, engine devs, and ecosystem creators join forces from across the world.
-- *You never want to have to pay licensing fees or worry about vendor lock-in.*
+- _You never want to have to pay licensing fees or worry about vendor lock-in._
   - Bevy is free and open source from now until the end of time.
 
 ## Why Not Use Bevy?
 
 We love Bevy, but it's not the right tool for every project. You should not use Bevy if:
 
-- *You need a stable, mature tool:*
+- _You need a stable, mature tool:_
   - Bevy iterates quickly, and ships breaking changes approximately once every four months.
-  - Many serious users upgrade Bevy mid-project with the help of our [migration guides](https://bevyengine.org/learn/migration-guides/introduction/), but this can be a serious time sink on large projects.
-- *You want to ship (relatively traditional) games very quickly:*
+  - Many serious users upgrade Bevy mid-project with the help of our [migration guides](https://bevy.org/learn/migration-guides/introduction/), but this can be a serious time sink on large projects.
+- _You want to ship (relatively traditional) games very quickly:_
   - Bevy is still not finished, stable software: many important features are missing.
   - While you can build these features yourself, or work with others in the community, doing so will take valuable development time and add risk.
   - [Godot](https://godotengine.org/) is a fantastic choice for many common game genres, and it's even [scriptable with Rust](https://github.com/godot-rust/gdext).
-- *You need to make a lot of game content:*
+- _You need to make a lot of game content:_
   - Bevy does not currently have a graphical editor.
-- *You want scripting language support out-of-the-box:*
+- _You want scripting language support out-of-the-box:_
   - Unlike other game engines, gameplay logic is written in the same language (and style) as engine logic.
   - That said, it is possible. Bevy and Rust provide the tools needed to integrate Lua, Python and more.
-  - Take a look at [Bevy Assets](https://bevyengine.org/assets) to see the options that the community has provided.
-- *You want to ship to consoles:*
+  - Take a look at [Bevy Assets](https://bevy.org/assets) to see the options that the community has provided.
+- _You want to ship to consoles:_
   - Rust (and therefore Bevy) is currently not supported on Sony or Nintendo consoles.
 
 ## Bevy Beyond Games


### PR DESCRIPTION
This only changes links embedded in The Book. Historical links in the News section and other places were left untouched.