### PR TITLE
Book: fix dangling markdown references

### DIFF
--- a/content/learn/book/control-flow/events.md
+++ b/content/learn/book/control-flow/events.md
@@ -156,6 +156,7 @@ world.add_observer(
 ```
 
 [`.run_if`]: https://docs.rs/bevy/latest/bevy/ecs/observer/struct.Observer.html#method.run_if
+[Skipping Systems page]: @/learn/book/control-flow/run-conditions.md
 
 ## Event Triggers
 

--- a/content/learn/book/control-flow/systems.md
+++ b/content/learn/book/control-flow/systems.md
@@ -180,6 +180,7 @@ See the section on [local system state] for more details.
 ["splits the borrow"]: https://doc.rust-lang.org/nomicon/borrow-splitting.html
 
 [local system state]: @/learn/book/storing-data/local-system-param.md
+[Queries book section]: @/learn/book/storing-data/queries.md
 
 ## Running Systems In Schedules
 

--- a/content/learn/book/the-game-loop/game-time.md
+++ b/content/learn/book/the-game-loop/game-time.md
@@ -168,8 +168,11 @@ Note that Bevy's "fixed timesteps" are not the right mechanism to use for gamepl
 In most cases, [`Timer`] components and the [`on_timer`] run condition are more appropriate.
 
 Bevy only supports a single fixed timestep across your entire project, and its use is completely optional.
-Please see our [timers and cooldowns] section below for the tools available to model this type of behavior.
+Please see the [Time Controls page] for the tools available to model this type of behavior.
 
+[`Timer`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Timer.html
+[`on_timer`]: https://docs.rs/bevy/latest/bevy/time/common_conditions/fn.on_timer.html
+[Time Controls page]: @/learn/book/control-flow/time-controls.md
 [`Time<Fixed>::timestep`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Time.html#method.timestep
 [`Main`]: https://docs.rs/bevy/latest/bevy/app/struct.Main.html
 [`FixedMain`]: https://docs.rs/bevy/latest/bevy/app/struct.FixedMain.html

--- a/content/learn/book/the-game-loop/schedules.md
+++ b/content/learn/book/the-game-loop/schedules.md
@@ -102,5 +102,6 @@ Bevy itself uses this pattern for both the [`Main`] schedule and our built-in [f
 [`MinimalPlugins`]: https://docs.rs/bevy/latest/bevy/struct.MinimalPlugins.html
 [`DefaultPlugins`]: https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html
 [`MainScheduleOrder`]: https://docs.rs/bevy/latest/bevy/app/struct.MainScheduleOrder.html
+[`ScheduleLabel`]: https://docs.rs/bevy/latest/bevy/ecs/schedule/trait.ScheduleLabel.html
 [`World::run_schedule`]: https://docs.rs/bevy/latest/bevy/prelude/struct.World.html#method.run_schedule
 [fixed time]: @/learn/book/the-game-loop/game-time.md#frame-rate-independence-and-delta-time


### PR DESCRIPTION
This fixes a number of markdown reference links which have no url definition.

Note: the adversarial review identified two links which currently resolve but go to places that are unhelpful. I did not touch these, as I am unsure what's the correct destination:

* `control-flow/change-detection.md:201` — `[explicit system ordering]` points at `run-conditions`
* `the-game-loop/app.md:38` — `[custom loops]` points at `schedules`, which never discusses the runner function.
