### PR TITLE
Fix markdown errors

### DIFF
--- a/content/learn/book/assets/processing.md
+++ b/content/learn/book/assets/processing.md
@@ -21,7 +21,7 @@ folder are automatically processed by the registered processors to produce the g
 of assets. Your game will automatically use the processed assets (without needing to change anything
 else).
 
-{% callout(type="important") %}
+{% callout(type="info") %}
 
 While it is possible to enable asset processing just before publishing to do steps like compression,
 we **strongly** recommend users choose at the beginning of their project whether to use processing

--- a/content/learn/book/control-flow/events.md
+++ b/content/learn/book/control-flow/events.md
@@ -6,7 +6,7 @@ weight = 9
 status = 'hidden'
 +++
 
-While Systems are great for running logic at scheduled updates, many features need to be reactive, not scheduled. Picking up an item, performing an attack, or even hovering the cursor over an object are all actions that wouldn't work very well if they *had* to run on every schedule update. Instead of a System, we can use **Events** to activate some logic or functionality at a specific time or in response to something occurring.
+While Systems are great for running logic at scheduled updates, many features need to be reactive, not scheduled. Picking up an item, performing an attack, or even hovering the cursor over an object are all actions that wouldn't work very well if they _had_ to run on every schedule update. Instead of a System, we can use **Events** to activate some logic or functionality at a specific time or in response to something occurring.
 
 There are three required parts when using an Event: a **Trigger**, an **Observer**, and the `Event` itself.
 
@@ -25,7 +25,7 @@ struct Speak {
 }
 ```
 
-1. Add an [`Observer`] to the `World` that will watch for our event:
+2. Add an [`Observer`] to the `World` that will watch for our event:
 
 ```rust
 // To add the observer immediately:
@@ -39,7 +39,7 @@ commands.add_observer(|speak: On<Speak>| {
 });
 ```
 
-1. Trigger the `Speak` event:
+3. Trigger the `Speak` event:
 
 ```rust
 // To trigger the event immediately:
@@ -66,7 +66,7 @@ commands.trigger(Speak {
     message: "This event runs in the queue!".to_string(),
 });
 
-// We can define a variable with its type as 
+// We can define a variable with its type as
 // `Speak` to make the code look cleaner:
 let custom_message: Speak = Speak {
     message: "And this is defined before-hand to make everything look nicer!".to_string(),
@@ -81,13 +81,13 @@ commands.trigger(custom_message);
 
 Once we have defined our `Event`, we need to create an [`Observer`] that will do something when our `Event` gets triggered. This can be as straightforward as calling the `add_observer` method on [`World`] or [`Commands`], but this is not the only way to make an `Observer`.
 
-At its core, `Observer` is a [`Component`] that is added to an `Entity`. When we run `World::add_observer`, all that's actually happening is telling `World` to spawn a new `Entity` with an `Observer` component. Within that `Observer` component, we specify what `Event` we want the `Entity` to react to and what should happen when the `Event` happens. As we'll see later on with `EntityEvent`, this can be very handy for when we have an `Observer` that should only run when targeting a *specific* `Entity`.
+At its core, `Observer` is a [`Component`] that is added to an `Entity`. When we run `World::add_observer`, all that's actually happening is telling `World` to spawn a new `Entity` with an `Observer` component. Within that `Observer` component, we specify what `Event` we want the `Entity` to react to and what should happen when the `Event` happens. As we'll see later on with `EntityEvent`, this can be very handy for when we have an `Observer` that should only run when targeting a _specific_ `Entity`.
 
 ```rust
 // `world` creates a new `Entity` with an `Observer` component, watching for a `Speak` event.
 world.add_observer(|speak: On<Speak>| {
     // When `Speak` is triggered, print out the message to the console.
-    println!("{}", speak.message); 
+    println!("{}", speak.message);
 });
 ```
 
@@ -105,7 +105,7 @@ world.add_observer(|event: On<DespawnEnemyUnits>, commands: Commands, enemy_unit
 
 In the above example, we've created an `Observer` that will run its `ObserverSystem` when a `DespawnEnemyUnits` event is triggered. Additionally, we've accessed `Commands` and `Query` as parameters to gain access to the data we need. Within the `ObserverSystem`, we use a `for` loop to despawn every `Enemy` entity that is given in the `enemy_units` query.
 
-It is also worth noting that we can trigger an `Event` within an `ObserverSystem`. Instead of triggering immediately (as is the case when using `World::trigger`), triggering an `Event` inside an `Observer` with `Commands::trigger` will run the newly triggered `ObserverSystem` at the end of the `Command` queue. Once all of the other `Observer` commands that are currently in the queue are run, then the new `ObserverSystem` will be run. Be aware that these events are evaluated *recursively*, and will exit once there are no more events left.
+It is also worth noting that we can trigger an `Event` within an `ObserverSystem`. Instead of triggering immediately (as is the case when using `World::trigger`), triggering an `Event` inside an `Observer` with `Commands::trigger` will run the newly triggered `ObserverSystem` at the end of the `Command` queue. Once all of the other `Observer` commands that are currently in the queue are run, then the new `ObserverSystem` will be run. Be aware that these events are evaluated _recursively_, and will exit once there are no more events left.
 
 ```rust
 // When Event `A` is triggered, it in turn will trigger Event `B`.
@@ -188,14 +188,13 @@ fn player_damage(mut commands: Commands, player: Single<(Entity, Name), With<Pla
     // Damage value.
     let damage_value: i32 = 4;
     // Get the player's name.
-    let (player_entity, player_name): (Entity, Name) = *player;    
+    let (player_entity, player_name): (Entity, Name) = *player;
     // Trigger a PlayerDamage event and pass the event the required values.
     commands.trigger(PlayerDamage {
         amount: damage_value,
         taken_by: player_name.to_string(),
     });
 }
-
 ```
 
 A `Trigger` determines which observers will be activated. When we call `commands.add_observer()` in the above example, `damage_event: On<PlayerDamage>` is the `Trigger` which will cause the `Observer` to run its code. If there were other observers added that also had `On<PlayerDamage>` triggers, those observers would also run their code when we trigger a `PlayerDamage` event.
@@ -210,7 +209,7 @@ As we mentioned above, a `Trigger` can also be used to pass values from the `Eve
 
 ## Entity Events
 
-Up until now, events have been utilized in a *global* context, meaning that observers will run their code without taking any specific entities into account.
+Up until now, events have been utilized in a _global_ context, meaning that observers will run their code without taking any specific entities into account.
 
 What if we do have some unique functionality that we want to run on certain entities? We can achieve this by modifying our `Event` types to implement [`EntityEvent`] rather than [`Event`]:
 
@@ -259,7 +258,7 @@ struct Explode(#[event_target] Entity, i32, f32); // Using #[event_target] insid
 Just as with a global [`Event`], [`EntityEvent`] also needs a [`Trigger`]. We trigger an `EntityEvent` the same way we trigger a regular `Event`, however this time we make sure to specify our `event_target` entity (along with any other fields on the `EntityEvent`):
 
 ```rust
-// Trigger an Explode `EntityEvent`, passing in a tuple consisting of 
+// Trigger an Explode `EntityEvent`, passing in a tuple consisting of
 // an Entity (`some_entity`), an i32 (`4`), and a f32 (`2.5`).
 world.trigger(Explode(some_entity, 4, 2.5));
 ```
@@ -329,7 +328,7 @@ struct Click {
 By default, `EntityEvent` propagation will follow the [`ChildOf`] relation, starting at the original entity ("child") that the [`EntityEvent`] was triggered on and then repeatedly triggering on the `Entity` that is contained within the `ChildOf` component ("parent"). However, we can also specify a custom traversal implementation that will propagate along a custom relation.
 
 ```rust
-// "ChildOf" equivalent. 
+// "ChildOf" equivalent.
 #[derive(Component)]
 #[relationship(relationship_target = ClickableBy)]
 struct Clickable(Entity);
@@ -352,5 +351,4 @@ To see [`EntityEvent`] propagation in action, the [Bevy Examples Page] has an [O
 [Relations]: @/learn/book/storing-data/relations.md
 [Bevy Examples Page]: https://bevy.org/examples
 [Observer Propagation]: https://bevy.org/examples/ecs-entity-component-system/observer-propagation/
-
 [`ChildOf`]: https://docs.rs/bevy/latest/bevy/prelude/struct.ChildOf.html

--- a/content/learn/book/control-flow/messages.md
+++ b/content/learn/book/control-flow/messages.md
@@ -6,9 +6,9 @@ weight = 12
 status = 'hidden'
 +++
 
-When designing your Bevy applications, you might encounter situations where `Events` are evaluated *too* quickly.
-Or, maybe you don't need to *immediately* perform some logic that an `Observer` will watch for.
-There might even be some repeated functionality that you'll want to *defer* and accumulate before eventually processing.
+When designing your Bevy applications, you might encounter situations where `Events` are evaluated _too_ quickly.
+Or, maybe you don't need to _immediately_ perform some logic that an `Observer` will watch for.
+There might even be some repeated functionality that you'll want to _defer_ and accumulate before eventually processing.
 These are the situations where **Messages** are the preferred tool.
 [`Messages`] offer a communication channel for accumulating and efficiently processing many similar actions.
 They can be created and read from using system parameters and are stored in a [`Messages<M>`] resource.
@@ -16,7 +16,7 @@ They can be created and read from using system parameters and are stored in a [`
 You can use `Messages` for a variety of different functionalities.
 Some messages might re-occur over a longer period of time, like continuously applying damage effects or regularly updating a leaderboard.
 Others can be short-lived, such as checking for whether a player can interact with an object or if a UI element should appear.
-The key concept to remember is that a `Message` is best used for logic that can be *deferred* rather than requiring immediate action.
+The key concept to remember is that a `Message` is best used for logic that can be _deferred_ rather than requiring immediate action.
 
 To start using messages, our first steps are to derive the `Message` trait on a struct and then add the [`MessageWriter`] and [`MessageReader`] system parameters to some systems.
 
@@ -102,7 +102,7 @@ fn main() {
 
 ## Reading & Writing Messages
 
-Messages function based on *writing* them in response to something happening and *reading* them at a later point to perform some functionality.
+Messages function based on _writing_ them in response to something happening and _reading_ them at a later point to perform some functionality.
 Let's work through an example to showcase how and why messages should be used in your application.
 To do this we'll be creating a very basic scoreboard update mechanic for a king-of-the-hill style gamemode.
 Before we jump into the code, lets assess our objectives for the scoreboard update:
@@ -127,10 +127,9 @@ fn main() {
         // Initialize our ScoreboardUpdate message and update it in the First schedule.
         .add_message::<ScoreboardUpdate>();
 }
-
 ```
 
-Now lets *write* our message which will update the scoreboard.
+Now lets _write_ our message which will update the scoreboard.
 We'll do this by creating a `Single` query for the hill objective that our players are fighting for control of.
 Specifically we'll be looking for the player `Entity` value stored in a `CurrentHillKing` component, which is a part of an `Entity` with a `HillObjective` marker component.
 Once we have our player `Entity`, we'll write a new `ScoreboardUpdate` message containing the player and the value to update their score by (5 in our case).
@@ -143,16 +142,16 @@ fn write_scoreboard_update(
     // Our hill which contains the player in control of the hill.
     hill_query: Single<&CurrentHillKing, With<HillObjective>>,
 ) {
-    // Read the Entity stored in the CurrentHillKing component on 
+    // Read the Entity stored in the CurrentHillKing component on
     // the HillObjective entity.
     let current_king = hill_query.0;
-    // Create a new ScoreboardUpdate message with the Entity in 
+    // Create a new ScoreboardUpdate message with the Entity in
     // control and a point value of 5.
     update_writer.write(ScoreboardUpdate(current_king, 5));
 }
 ```
 
-Next, we need a system to *read* our message and do something with the values we pass in.
+Next, we need a system to _read_ our message and do something with the values we pass in.
 With our example, since `ScoreboardUpdate` contains a player `Entity` and a score `i32` value we'll access a `Scoreboard` resource and call a method to update the scores contained within.
 Additionally, we can check to see if any player's score is above 500, which is our condition for the match ending.
 
@@ -163,11 +162,11 @@ fn read_scoreboard_update(
     mut update_reader: MessageReader<ScoreboardUpdate>,
     mut scoreboard_res: ResMut<Scoreboard>,
 ) {
-    // Read all of the ScoreboardUpdate messages in `update_reader`. 
+    // Read all of the ScoreboardUpdate messages in `update_reader`.
     for score_update in update_reader.read() {
         scoreboard_res.update_score(score_update.player, score_update.value);
     }
-    
+
     if scoreboard_res.highest_player_score() >= 500 {
         // If a player's score is above 500, end the game.
         println!("Game Over!");
@@ -180,7 +179,7 @@ fn read_scoreboard_update(
 
 Finally, we can add our systems into their respective schedules.
 Keep in mind that the system which updates our `ScoreboardUpdate` message resource is going to be run in the `First` schedule, which is the first thing run on every new frame.
-As a result we'll want to schedule `read_scoreboard_update` *before* `write_scoreboard_update`, but after the `First` schedule completes.
+As a result we'll want to schedule `read_scoreboard_update` _before_ `write_scoreboard_update`, but after the `First` schedule completes.
 The `PreUpdate` schedule fits nicely for `read_scoreboard_update`, running before `Update` and well before `PostUpdate` which is where we'll place `write_scoreboard_update`.
 This prevents multiple `ScoreboardUpdate` messages being read at once and allows our gameplay systems to run with a freshly updated `Scoreboard` resource.
 
@@ -189,7 +188,7 @@ fn main() {
     App::new()
         .add_plugins(king_of_the_hill_plugin)
         .add_message::<ScoreboardUpdate>()
-        // The `First` schedule runs before PreUpdate, which allows our messages to be 
+        // The `First` schedule runs before PreUpdate, which allows our messages to be
         // updated.
         .add_systems(PreUpdate, read_scoreboard_update)
         // Once all of our gameplay systems run in Update, then we can accurately write
@@ -200,17 +199,17 @@ fn main() {
 ```
 
 In reality, this setup is too simple to be used without further modifications.
-For example, because all of our schedules are run *every frame*, it wouldn't be practical to update an actual scoreboard like this.
+For example, because all of our schedules are run _every frame_, it wouldn't be practical to update an actual scoreboard like this.
 However, you should now be able to see one way that `Messages` can be used and how they need to be arranged so that they will work as you intend them to.
 
 ## Altering Messages
 
-We can do more than just write and read messages though. One of the best aspects of messages is that they're able to be *mutated* after we've already written them. [`MessageMutator`] gives you access to read and alter messages of a specific type. We can use it by declaring it as a system parameter in the same way that we use `MessageWriter` and `MessageReader`.
+We can do more than just write and read messages though. One of the best aspects of messages is that they're able to be _mutated_ after we've already written them. [`MessageMutator`] gives you access to read and alter messages of a specific type. We can use it by declaring it as a system parameter in the same way that we use `MessageWriter` and `MessageReader`.
 
 ```rust
 // Custom message type.
 #[derive(Message, Debug)]
-pub struct MyMessage(pub u32); 
+pub struct MyMessage(pub u32);
 
 // A system which reads and mutates all MyMessage messages.
 fn my_system(mut mutator: MessageMutator<MyMessage>) {
@@ -225,7 +224,7 @@ One thing to note is that `MessageMutator` does not run in parallel.
 This is because `MessageMutator` mutably accesses the `Messages<M>` resource that contains all of the messages of a given type.
 The same applies for `MessageWriter` as well.
 Systems accessing either will only run sequentially with each other.
-On the other hand, `MessageReader` *can* be accessed by multiple systems concurrently if they only access `MessageReader`.
+On the other hand, `MessageReader` _can_ be accessed by multiple systems concurrently if they only access `MessageReader`.
 Although these systems still cannot run concurrently with systems accessing `MessageMutator` or `MessageWriter`.
 
 Ultimately `MessageWriter`, `MessageReader`, and `MessageMutator` are all accessing the `Messages<M>` resource for a given `Message` type.
@@ -234,13 +233,13 @@ If you find that there is some functionality that these three system parameters 
 ```rust
 // Custom message type.
 #[derive(Message, Debug)]
-pub struct MyMessage(pub u32); 
+pub struct MyMessage(pub u32);
 
 fn message_resource(mut messages: ResMut<Messages<MyMessage>>) {
-    // Drain all of the messages out of the resource, 
+    // Drain all of the messages out of the resource,
     // and remove any message with a value of 2.
     let filtered_messages = messages.drain().filter(|message| message.0 != 2);
-    
+
     // Add the filtered messages back into the resource.
     messages.write_batch(filtered_messages);
 }
@@ -292,7 +291,7 @@ By using messages, we avoid the headache of making sure entities are tracked sep
 
 ## Message Lifespan
 
-We've mentioned that one of the benefits of using messages is that we can *defer* processing them until a later point.
+We've mentioned that one of the benefits of using messages is that we can _defer_ processing them until a later point.
 This might raise several questions. How long do messages exist for? Can we defer processing them indefinitely? When are messages dropped or deleted?
 
 The short answer is that every `Message` stored in a `Messages<M>` resource is accessible for up to two `Messages::update` method calls.
@@ -309,7 +308,7 @@ If `Messages::update` is never called, these buffers will continue to grow in si
 
 ### Messages in FixedUpdate
 
-Using `App:add_message<M>()` to register your `Message` will run `Messages::update` *every frame*.
+Using `App:add_message<M>()` to register your `Message` will run `Messages::update` _every frame_.
 Like we mentioned at the top, this is because the `message_update_system` is placed in the `First` schedule, meaning it will be the first thing updated every frame.
 However we aren't locked into this behaviour.
 If we instead want our `Messages` to be updated within the [`FixedUpdate`] schedule rather than being frame-dependent, we can do so by several means.
@@ -319,13 +318,13 @@ The first would be to manually place `message_update_system` in the `FixedUpdate
 ```rust
 fn main() {
     App::new()
-        // The message_update_system will update all Messages 
+        // The message_update_system will update all Messages
         // registered in your application.
         .add_systems(FixedUpdate, message_update_system);
 }
 ```
 
-However, this is indiscriminant and will update *every* `Message` type in your application.
+However, this is indiscriminant and will update _every_ `Message` type in your application.
 Instead, it's likely that you'll want more fine-grained control over which `Messages` update in `FixedUpdate` versus those that update every frame.
 We'll have to access each individual `Messages<M>` resource to accomplish this.
 
@@ -348,7 +347,7 @@ fn deal_tick_damage_update(mut tick_damage_messages: ResMut<Messages<TickDamage>
     tick_damage_messages.update();
 }
 
-// This system will read from the Message<TickDamage> resource 
+// This system will read from the Message<TickDamage> resource
 // and apply damage to entities.
 fn deal_tick_damage(mut tick_damage_reader: MessageReader<TickDamage>, mut health_query: Query<&mut Health>) {
     for tick_damage in tick_damage_reader.par_read() {
@@ -364,7 +363,7 @@ fn warn_tick_damage_update(mut warn_messages: ResMut<Messages<WarnTickDamage>>) 
     warn_message.update();
 }
 
-// This system will read from the Message<WarnTickDamage> resource 
+// This system will read from the Message<WarnTickDamage> resource
 // and print a warning message.
 fn warn_tick_damage(warn_tick_damage_reader: MessageReader<WarnTickDamage>) {
     for message in warn_tick_damage_reader.par_read() {
@@ -372,12 +371,12 @@ fn warn_tick_damage(warn_tick_damage_reader: MessageReader<WarnTickDamage>) {
     }
 }
 
-// This system will add the Message<TickDamage> and Message<WarnTickDamage> 
+// This system will add the Message<TickDamage> and Message<WarnTickDamage>
 // resources to the world.
 fn add_messages(mut commands: Commands) {
     let warn_message = Messages::<WarnTickDamage>::default();
     let tick_damage_message = Messages::<TickDamage>::default();
-    
+
     commands.insert_resource(warn_message);
     commands.insert_resource(tick_damage_message);
 }

--- a/content/learn/book/control-flow/time-controls.md
+++ b/content/learn/book/control-flow/time-controls.md
@@ -23,7 +23,9 @@ These are two simple tools that can be incredibly helpful, however Bevy provides
 We'll detail those further down this page, but for now let's get a little more familiar with `Timer`s and `Stopwatch`s.
 
 {% callout(type="info") %}
+
 ## Time Versus Time Controls
+
 This page details the various tools that Bevy provides to interact with time.
 However, this page does not specify how time is set up in Bevy or how you should be using time.
 We also won't go into too much detail when using these tools inside of different schedules or how the outcome of these tools will vary based on what version of time they follow.
@@ -52,7 +54,7 @@ They allow you to track a duration of time and determine when it has finished.
 Instead, `Timer`s are intended to be wrapped inside of simple components.
 
 ```rust
-// A simple component that holds a `Timer` for the 
+// A simple component that holds a `Timer` for the
 // cool-down of an ability.
 #[derive(Component)]
 struct AbilityTimer {
@@ -73,7 +75,9 @@ fn update_ability_timer(mut query: Query<&mut AbilityTimer>) {
 ```
 
 {% callout(type="warning") %}
+
 ### Consistent Ticking
+
 Depending on where you `tick` a `Timer`, you might find that the timer is inconsistent or not behaving as intended.
 This might depend on what [`Schedule`] the `tick`ing system is placed in.
 Systems placed in the [`Update`] schedule will run every frame, meaning that a `Timer` being ticked with a `Duration` value of 1 second could wind up advancing 60 seconds if your game runs at 60 frames per second.
@@ -87,7 +91,6 @@ To read more about "time-step" and how Bevy handles time, we recommend reading t
 
 [delta time]: https://en.wikipedia.org/wiki/Delta_timing
 [Time page]: @/learn/book/the-game-loop/game-time.md
-
 [`Schedule`]: https://docs.rs/bevy/latest/bevy/ecs/prelude/struct.Schedule.html
 [`Update`]: https://docs.rs/bevy/latest/bevy/app/struct.Update.html
 [`Time`]: https://docs.rs/bevy/latest/bevy/time/struct.Time.html
@@ -113,7 +116,7 @@ Timer::from_seconds(3.0, TimerMode::Once);
 
 Two `Duration`s are stored when a `Timer` is first created.
 The first stores the length of the timer (i.e. the value we passed when creating the `Timer`), while the second stores how much time has elapsed since the timer started.
-We can access both of these `Duration` values using the [`Timer::remaining`] and [`Timer::elapsed`] methods. 
+We can access both of these `Duration` values using the [`Timer::remaining`] and [`Timer::elapsed`] methods.
 If we only need the actual time values from these, we can use [`Timer::remaining_secs`] and [`Timer::elapsed_secs`] to get `f32` values instead of a `Duration` value.
 
 ```rust
@@ -224,7 +227,7 @@ struct AutomaticCookieClick {
 // A system that automatically clicks cookies based
 // on the `AutomaticCookieClick` timer
 fn automatically_click_cookies(
-    mut cookies: ResMut<Cookies>, 
+    mut cookies: ResMut<Cookies>,
     mut query: Query<&mut AutomaticCookieClick>,
     time: Res<Time>,
 ) {
@@ -292,7 +295,7 @@ To wrap up our Cookie Clicker example, let's create a boost in the number of coo
 struct CookieBoost(pub bool);
 
 fn automatically_click_cookies(
-    mut cookies: ResMut<Cookies>, 
+    mut cookies: ResMut<Cookies>,
     mut query: Query<&mut AutomaticCookieClick>,
     time: Res<Time>,
     boost: Res<CookieBoost>,
@@ -388,7 +391,6 @@ fn end_match(
         commands.remove_resource::<MatchTimeCounter>();
     }
 }
-
 ```
 
 ## System Timer Conditions

--- a/content/learn/book/development-practices/fast-compiles.md
+++ b/content/learn/book/development-practices/fast-compiles.md
@@ -36,7 +36,7 @@ On Windows you must also enable the [performance optimizations] or you will get 
 In order to run `cargo test --doc`, you must also add the path returned by `rustc --print target-libdir` to your `PATH` environment variable.
 {% end %}
 
-{% callout(type="note") %}
+{% callout(type="info") %}
 Shipping your game with dynamic linking enabled is not recommended because it requires you to include `libbevy_dylib` alongside your game, it prevents certain optimizations, and can increase the size of your game.
 If you remove the `dynamic_linking` feature, your game executable can run standalone.
 {% end %}
@@ -47,28 +47,29 @@ If dynamic linking isn't preferred or possible, we can use alternative linkers d
 
 <details>
   <summary>Mold</summary>
-  
-  [Mold](https://github.com/rui314/mold) is an alternative linker for Linux systems claiming to be faster than LLVM's `lld` linker. However, it also comes with drawbacks, such as limited platform support and occasional stability issues. To install Mold, use your preferred package manager.
-  
+
+[Mold](https://github.com/rui314/mold) is an alternative linker for Linux systems claiming to be faster than LLVM's `lld` linker. However, it also comes with drawbacks, such as limited platform support and occasional stability issues. To install Mold, use your preferred package manager.
+
 Examples:
-  
-* **Ubuntu**: `sudo apt-get install mold clang`
-* **Fedora**: `sudo dnf install mold clang`
-* **Arch**: `sudo pacman -S mold clang`
-  
+
+- **Ubuntu**: `sudo apt-get install mold clang`
+- **Fedora**: `sudo dnf install mold clang`
+- **Arch**: `sudo pacman -S mold clang`
+
 You will also need to add the following to your Cargo config at `/path/to/project/.cargo/config.toml`:
 
-  ```toml
-  [target.x86_64-unknown-linux-gnu]
-  linker = "clang"
-  rustflags = ["-C", "link-arg=-fuse-ld=/path/to/mold"]
-  # Where "/path/to/mold" is the location of your mold installation.
-  ```
-  
-  {% callout(type="note") %}
-    Disabling `bevy/dynamic_linking` may improve Mold's performance.
-    <sup>[citation needed]</sup>
-  {% end %}
+```toml
+[target.x86_64-unknown-linux-gnu]
+linker = "clang"
+rustflags = ["-C", "link-arg=-fuse-ld=/path/to/mold"]
+# Where "/path/to/mold" is the location of your mold installation.
+```
+
+{% callout(type="info") %}
+Disabling `bevy/dynamic_linking` may improve Mold's performance.
+<sup>[citation needed]</sup>
+{% end %}
+
 </details>
 
 ## Nightly Rust Compiler
@@ -121,9 +122,8 @@ When shipping your game, you should still compile it with LLVM.
 Enabling cranelift is known to break local variable inspection while debugging.
 You can only inspect statics.
 This is caused by the fact that `rustc_codegen_cranelift` is missing DWARF support.
-See [`cranelift #166](https://github.com/rust-lang/rustc_codegen_cranelift/issues/166) for more information.
+See [`cranelift #166`](https://github.com/rust-lang/rustc_codegen_cranelift/issues/166) for more information.
 {% end %}
-
 
 ## Generic Sharing
 
@@ -148,13 +148,14 @@ rustflags = [
 
 [sccache](https://github.com/mozilla/sccache) is a compiler cache that wraps `rustc` to cache compiled artifacts.
 
-In a standard local workflow, `sccache` provides little benefit. Its value becomes apparent when your workflow involves building your project across multiple target directories or frequently toggling feature flags. 
+In a standard local workflow, `sccache` provides little benefit. Its value becomes apparent when your workflow involves building your project across multiple target directories or frequently toggling feature flags.
 
 This is particularly true when building inside container environments like Docker or Podman. By configuring `sccache` and mounting a shared cache directory into your containers, you can reuse compiled artifacts and significantly cut down on build times.
 
 To enable `sccache`, install it and update your Cargo configuration.
 
 1. Install `sccache`:
+
    ```sh
    cargo install sccache
    ```

--- a/content/learn/book/development-practices/hot-reloading.md
+++ b/content/learn/book/development-practices/hot-reloading.md
@@ -27,7 +27,7 @@ When enabled, assets loaded in your game will automatically reload when their as
 
 To detect changes that occur due to hot-reloading, listen for [`AssetEvent::Modified`], or use the [`AssetChanged`] query filter.
 
-{% callout(type="note") %}
+{% callout(type="info") %}
 If you are also using embedded assets (through the [`load_embedded_asset!`] macro), it can be useful to also enable the `embedded_watcher` feature.
 {% end %}
 
@@ -122,9 +122,9 @@ There's non-trivial setup work, significant indirection, and you cannot capture 
 This pattern is best suited to games that have a large amount of structured gameplay data that needs tuning:
 it would work well for something like an ARPG, but poorly for a walking simulator.
 
-{% callout(type="note") %}
+{% callout(type="info") %}
 
-Within the games industry, games that use this pattern are sometimes called "data-driven". 
+Within the games industry, games that use this pattern are sometimes called "data-driven".
 This is not to be confused with data-driven in the sense of using data to make decisions, or data-oriented, where your game maps well to the underlying hardware of the machine to run faster.
 As a result, Bevy uses the less confusing term "asset-driven" when discussing this pattern.
 

--- a/content/learn/book/intro/the-three-letters.md
+++ b/content/learn/book/intro/the-three-letters.md
@@ -8,7 +8,7 @@ status = 'hidden'
 
 Bevy's architecture centers around its [ECS](https://en.wikipedia.org/wiki/Entity_component_system): E for **Entity**, C for **Component** and S for **System**. ECS is a high-performance way of organizing the data of a program, and controlling how that data is accessed and updated.
 ECS has been utilized in a number of commercial game engines, and has been increasing in popularity over the last couple of decades.
-Bevy however is relatively unique in how widely it uses these patterns: ECS in Bevy is used *everywhere*, not just for performance-critical code.
+Bevy however is relatively unique in how widely it uses these patterns: ECS in Bevy is used _everywhere_, not just for performance-critical code.
 
 There are two main mental models for how to think about ECS:
 
@@ -40,7 +40,7 @@ In the "in-memory database" model, entities are the row keys in our database, wi
 While entities are conceptually similar to Objects in object-oriented engines, they are distinctly different because they **do not store any behavior**.
 Instead, behavior is controlled by [systems](#the-s-systems).
 
-{% callout(type="note") %}
+{% callout(type="info") %}
 **Note on terminology**: Sometimes, using the word "entity" on its own can be ambiguous. Does it mean the row/id/primary key or does it mean the game object/thing it represents with all its data? In Bevy, entity ids are modeled in the `Entity` type. As a result, `Entity` typically refers to the id, and a lowercase "entity" typically refers to the game object.
 {% end %}
 
@@ -107,7 +107,7 @@ fn my_system(entities: Query<&mut Location>) {
 {% callout(type="info") %}
 Bevy systems use a technique called [dependency injection](https://en.wikipedia.org/wiki/Dependency_injection) to access data about the Bevy world. By declaring your function parameters wrapped in special types like [Query](@/learn/book/intro/the-next-three-letters.md#queries) or [Res](@/learn/book/intro/the-next-three-letters.md#resources), the data for those parameters will be filled in for you automatically — without you having to actually call the system.
 
-Another cool feature of Bevy systems is automatic parallelism: by inspecting the function parameter types, Bevy can automatically determine if it's safe to run two systems concurrently. For example, if you have a system which regenerates character health by modifying a `Health` component, and a different system that manages the characters' mana pool (say, via a `Mana` component), then Bevy knows that these two data sets are *disjoint* and can be updated at the same time. This is particularly important for optimal utilization of multiple CPU cores.
+Another cool feature of Bevy systems is automatic parallelism: by inspecting the function parameter types, Bevy can automatically determine if it's safe to run two systems concurrently. For example, if you have a system which regenerates character health by modifying a `Health` component, and a different system that manages the characters' mana pool (say, via a `Mana` component), then Bevy knows that these two data sets are _disjoint_ and can be updated at the same time. This is particularly important for optimal utilization of multiple CPU cores.
 {% end %}
 
 Systems usually access entities and their components via [Queries](@/learn/book/intro/the-next-three-letters.md#queries), which will be covered in the next chapter.

--- a/content/learn/book/releasing-projects/compiling-less-code.md
+++ b/content/learn/book/releasing-projects/compiling-less-code.md
@@ -27,7 +27,6 @@ This is equivalent to:
 
 ```toml
 bevy = { version = "0.19", default-features = true }
-
 ```
 
 Bevy's default features are designed to provide a beginner-friendly experience that works out of the box.
@@ -49,7 +48,7 @@ For most users, feature collections are the right level of granularity.
 ## Feature Collections
 
 Bevy is a large project, with lots of different functionality and users who each have their own unique needs.
-As a result, it has *many* feature flags, and these feature flags often change quickly across versions.
+As a result, it has _many_ feature flags, and these feature flags often change quickly across versions.
 
 To make this easier to manage, Bevy offers "feature collections", which are feature flags that simply enable other features.
 You can see the full list of features by reading `bevy`'s [Cargo.toml](https://github.com/bevyengine/bevy/blob/latest/Cargo.toml).
@@ -80,7 +79,7 @@ As a result, disabling plugins or removing systems from schedules will not resul
 
 Users who are particularly interested in optimizing binary size, compile times, or even runtime performance may find it useful to try to shrink the set of feature flags they're using even further.
 This process can be quite time-consuming and frustrating (especially when updating Bevy versions), and we recommend only doing so if it's absolutely needed.
-You *will* have to dig into the internals regularly, and track the flow of features across multiple crates.
+You _will_ have to dig into the internals regularly, and track the flow of features across multiple crates.
 
 Bevy's feature flags follow a fairly complex flow:
 
@@ -95,11 +94,11 @@ There are two viable approaches to constructing a minimal feature set:
 2. Start with a fairly permissive set of features, construct a working project, and then pare them down. Replace feature collections with their corresponding set of features and then attempt to delete features one-at-a-time to see what breaks.
 
 Both of these can work well; approach 1 prioritizes faster compilation times throughout development, while approach 2 will let you get off the ground more easily.
-Again, this process is *fully* optional: you should not feel like you *have* to do this unless you have real data that it's important for your particular project.
+Again, this process is _fully_ optional: you should not feel like you _have_ to do this unless you have real data that it's important for your particular project.
 
 {% callout(type="info") %}
 
-Features in Rust are *additive*.
+Features in Rust are _additive_.
 This means that if any crate in your tree enables a feature,
 it will be enabled for all users of the crate.
 

--- a/content/learn/book/releasing-projects/profiling.md
+++ b/content/learn/book/releasing-projects/profiling.md
@@ -7,7 +7,7 @@ weight = 0
 
 You cannot optimize what you cannot measure.
 
-If you want to improve the performance of your game, library, or application, you first *must* measure it.
+If you want to improve the performance of your game, library, or application, you first _must_ measure it.
 This involves finding both a baseline to check if your changes worked, and a breakdown of the costs incurred from making those changes.
 
 This process, known as **profiling**, is essential to any serious optimization work.
@@ -32,7 +32,7 @@ This can be done by setting the `RUST_LOG=info` environment variable when runnin
 
 You also need to select a `tracing` backend using one of the cargo features described in the below sections.
 
-{% callout(type="note") %}
+{% callout(type="info") %}
 When your app is bottlenecked by the GPU, you may encounter frames that have multiple prepare-set systems all taking an unusually long time to complete, and all finishing at about the same time.
 
 See the section on GPU profiling for determining what GPU work is the bottleneck.
@@ -186,20 +186,20 @@ There is no need to create an Xcode project.
 
 1. In the menu bar click on Debug > Debug Executable…
 
-    ![Xcode's menu bar open to Debug > Debug Executable...](https://github.com/user-attachments/assets/efdc5037-0957-4227-b29d-9a789ba17a0a)
+   ![Xcode's menu bar open to Debug > Debug Executable...](https://github.com/user-attachments/assets/efdc5037-0957-4227-b29d-9a789ba17a0a)
 
 2. Select your executable from your project’s target folder.
 3. The Scheme Editor will open. If your assets are not located next to your executable, you can go to the Arguments tab and set `BEVY_ASSET_ROOT` to the absolute path for your project (the parent of your assets folder). The rest of the defaults should be fine.
 
-    ![Xcode's Schema Editor opened to an environment variable configuration](https://github.com/user-attachments/assets/29cafb05-0c49-4777-8d41-8643812e8f6a)
+   ![Xcode's Schema Editor opened to an environment variable configuration](https://github.com/user-attachments/assets/29cafb05-0c49-4777-8d41-8643812e8f6a)
 
 4. Click the play button in the top left and this should start your bevy app.
 
-    ![A cursor hovering over the play button in XCode](https://github.com/user-attachments/assets/859580e2-779b-4db8-8ea6-73cf4ef696c9)
+   ![A cursor hovering over the play button in XCode](https://github.com/user-attachments/assets/859580e2-779b-4db8-8ea6-73cf4ef696c9)
 
 5. Go back to Xcode and click on the Metal icon in the bottom drawer and then Capture in the following the popup menu.
 
-    ![A cursor hovering over the Capture button in the Metal debugging popup menu](https://github.com/user-attachments/assets/c0ce1591-0a53-499b-bd1b-4d89538ea248)
+   ![A cursor hovering over the Capture button in the Metal debugging popup menu](https://github.com/user-attachments/assets/c0ce1591-0a53-499b-bd1b-4d89538ea248)
 
 6. Start debugging and profiling!
 
@@ -213,11 +213,11 @@ While it doesn't provide as much detail as vendor-specific tooling, Tracy can al
 
 When you compile with Bevy's `trace_tracy` feature, GPU spans will show up in a separate row at the top of Tracy, labeled as `RenderQueue`.
 
-{% callout(type="note") %}
+{% callout(type="info") %}
 Due to dynamic clock speeds, GPU timings will have large frame-to-frame variance, unless you use an external tool to lock your GPU clocks to base speeds. When measuring GPU performance via Tracy, only look at the MTPC column of Tracy's statistics panel, or the span distribution/median, and not at any individual frame data.
 {% end %}
 
-{% callout(type="note") %}
+{% callout(type="info") %}
 Unlike ECS systems, Bevy will not automatically add GPU profiling spans. You will need to add GPU timing spans yourself for any custom rendering work. See the [`RenderDiagnosticsPlugin`](https://docs.rs/bevy/latest/bevy/render/diagnostic/struct.RenderDiagnosticsPlugin.html) docs for more details.
 {% end %}
 
@@ -227,7 +227,7 @@ The binary that you would actually ship to your users will be found in your `tar
 For example, this might be `target/release/super_boids.exe`.
 You can see how big this is by simply examining it in your file browser.
 
-The size of the `target` directory is *not* the size of the final binary.
+The size of the `target` directory is _not_ the size of the final binary.
 This directory stores a huge amount of cached compilation results,
 speeding up recompilation at the cost of hard drive space.
 

--- a/content/learn/book/releasing-projects/release-builds.md
+++ b/content/learn/book/releasing-projects/release-builds.md
@@ -21,7 +21,9 @@ opt-level = 'z'
 lto = "fat"
 codegen-units = 1
 strip = true
+```
 
+```toml
 # Optimized for speed
 # Good for desktop
 [profile.release]

--- a/content/learn/book/storing-data/relations.md
+++ b/content/learn/book/storing-data/relations.md
@@ -124,7 +124,7 @@ fn spawn_entity_with_children(mut commands: Commands) {
 }
 ```
 
-{% callout(type="warn") %}
+{% callout(type="warning") %}
 **Caution**
 
 In this shorter syntax, the parentheses around each child entity can trip you up if you are not careful.

--- a/content/learn/book/storing-data/resources.md
+++ b/content/learn/book/storing-data/resources.md
@@ -46,6 +46,7 @@ fn update_music_volume(mut settings: ResMut<AudioSettings>) {
     settings.music_volume = 0.8;
 }
 ```
+
 [`Res`]: https://docs.rs/bevy/latest/bevy/ecs/system/struct.Res.html
 [`ResMut`]: https://docs.rs/bevy/latest/bevy/ecs/system/struct.ResMut.html
 
@@ -116,7 +117,7 @@ fn setup_audio_settings(world: &mut World) {
 }
 ```
 
-{% callout(type="warn") %}
+{% callout(type="warning") %}
 **Caution**
 
 Use care when accessing resources which may not exist.
@@ -133,6 +134,7 @@ fn audio_settings_system(settings_res: Option<Res<AudioSettings>>) {
 
 [`Res`]: https://docs.rs/bevy/latest/bevy/ecs/system/struct.Res.html
 [`ResMut`]: https://docs.rs/bevy/latest/bevy/ecs/system/struct.ResMut.html
+
 {% end %}
 
 ## Resources vs Singleton Entities

--- a/content/learn/book/the-game-loop/game-time.md
+++ b/content/learn/book/the-game-loop/game-time.md
@@ -20,7 +20,9 @@ This is helpful for performance reasons, but more critically,
 it ensures consistency of behavior across all of the various bits of game logic.
 
 {% callout(type="info") %}
+
 ## Time Versus Time Controls
+
 This page explains how Bevy sets up and interacts with time across the engine.
 However, it doesn't cover the tools that are provided to help you use time in your games.
 These include timers, stopwatches, system conditions, and even some command options that all rely on time.
@@ -47,11 +49,11 @@ use bevy::prelude::*;
 struct Player;
 
 fn move_player(mut player_transform: Single<&mut Transform, With<Player>>){
-    // With Bevy's default camera setup and a 60 fps framerate, 
+    // With Bevy's default camera setup and a 60 fps framerate,
     // this will move the player 60 pixels per second in 2D (reasonable),
     // or 60 meters per second in 3D (wheee!)
     const PLAYER_MOVEMENT: f32 = 1.;
-    
+
     player_transform.translation.x += PLAYER_MOVEMENT;
 }
 ```
@@ -61,19 +63,19 @@ But what happens when our game stutters, and the frame rate drops?
 Suddenly, rather than moving 60 units per second at our target 60 frames per second,
 our player is moving at an unsteady 20-30 units per second. Oh no!
 
-Instead, we can compensate for this effect by fixing our *speed* (or other rates of change per second),
+Instead, we can compensate for this effect by fixing our _speed_ (or other rates of change per second),
 and then multiplying by the elapsed time.
 
-```rust, hide_lines=1-4,hide_lines=1-5
+```rust,hide_lines=1-5
 # use bevy::prelude::*;
-# 
+#
 # #[derive(Component)]
 # struct Player;
 #
 fn move_player(mut player_transform: Single<&mut Transform, With<Player>>, time: Res<Time>){
     // At 60 FPS, this will be the same as before
     const PLAYER_SPEED: f32 = 60.;
-    
+
     player_transform.translation.x += PLAYER_SPEED * time.delta_secs();
 }
 ```
@@ -122,7 +124,7 @@ it's better to simply always advance time by a fixed amount.
 This is particularly important for physics and networking.
 
 To understand how to work with fixed time in Bevy, we need to first learn a little bit about how [`Time`] actually works under the hood.
-As the docs on [`Time`] explain, there's actually *three* distinct types of time being measured:
+As the docs on [`Time`] explain, there's actually _three_ distinct types of time being measured:
 
 - real time: the actual wall clock time
   - use this for things like UI animations that you don't want to be affected by pausing
@@ -150,6 +152,7 @@ to [`Real`], [`Virtual`] or [`Fixed`].
 [`Real`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Real.html
 [`Virtual`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Virtual.html
 [`Fixed`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Fixed.html
+
 {% end %}
 
 Now that we have the required vocabulary, let's go over exactly how the fixed timestep logic works in Bevy:


### PR DESCRIPTION
Apologies for such a large diff, the actual number of fixes is on the order of a dozen, but it's buried in all the link canonicalization that VSCode insists on doing.

Summary of actual changes:
* Fix references to non-existent callout types ("warn" -> "warning", "note" -> "info")
* Fix missing closing backtick
* Removed extra trailing lines in fenced code blocks
* Changed numbered list to 1. 2. 3. instead of 1. 1. 1. (which didn't auto-renumber)
* Fixed extra space after rust language tag, conflicting hide_lines decls.
* Separated two Cargo.toml examples into separate code blocks

Note: The callout inside the `<details>` block in `fast-compiles` looks odd, but does work.