### PR TITLE
Book Fixes

### DIFF
--- a/content/learn/book/assets/bevy's-asset-framework.md
+++ b/content/learn/book/assets/bevy's-asset-framework.md
@@ -8,7 +8,7 @@ status = 'hidden'
 
 **Assets** have two defining qualities that shape how Bevy works with them:
 
-1. They can be loaded and unloaded at runtime (as opposed to being part of your game's code). Typically, assets are stored in the file system on the user's hard drive.
+1. They can be loaded and unloaded at runtime (as opposed to being part of your game's code). Typically, assets are stored in the filesystem on the user's hard drive.
 2. They are often very large: asset files can be multiple megabytes, when typical data-storing components are measured in bytes.
 
 The first point means that we need tools to dynamically load (and unload) assets at runtime.

--- a/content/learn/book/assets/custom_assets.md
+++ b/content/learn/book/assets/custom_assets.md
@@ -70,7 +70,8 @@ Finally, in your `main` function, call `init_asset` with your asset type to regi
 
 ```rust
 fn main() {
-    App::new(DefaultPlugins)
+    App::new()
+        .add_plugins(DefaultPlugins)
         .init_asset::<Card>()
         .run()
 }
@@ -95,7 +96,8 @@ For this, we need to define an asset loader: Bevy needs to know how it should re
 
 ```rust
 fn main() {
-    App::new(DefaultPlugins)
+    App::new()
+        .add_plugins(DefaultPlugins)
         .init_asset::<Card>()
         .register_asset_loader(CardLoader)
         .run()

--- a/content/learn/book/assets/lifetimes.md
+++ b/content/learn/book/assets/lifetimes.md
@@ -70,7 +70,7 @@ struct EnemyAssets {
 
 fn load_enemy_assets_in_startup(
     asset_server: Res<AssetServer>,
-    mut commands: AssetCommands
+    mut commands: Commands
 ) {
     commands.insert_resource(EnemyAssets {
         sprite: asset_server.load("enemy.png"),
@@ -168,6 +168,7 @@ fn main() {
 
 #[derive(States, Clone, Copy, PartialEq, Eq, Hash, Debug, Default)]
 enum AssetsState {
+    #[default]
     Loading,
     Loaded,
 }

--- a/content/learn/book/assets/processing.md
+++ b/content/learn/book/assets/processing.md
@@ -174,7 +174,7 @@ impl AssetSaver for MySaver {
         &self,
         writer: &mut Writer,
         asset: SavedAsset<'_, '_, Self::Asset>,
-        _settings; &Self::Settings,
+        _settings: &Self::Settings,
         _asset_path: AssetPath<'_>,
     ) -> Result<NewAssetLoader::Settings, BevyError> {
         // Note: this is a simplified example where we assume we have no "subassets". If we did,

--- a/content/learn/book/control-flow/change-detection.md
+++ b/content/learn/book/control-flow/change-detection.md
@@ -47,7 +47,7 @@ fn detect_changed_position(query: Query<(Entity, &Position), Changed<Position>>)
 
 Removing components works differently, see the section below.
 
-## Checking For Changes
+## Checking for Changes
 
 In some cases, you may want to know whether or not an entity's components have changed, but at the same time want to access all the entities, even the ones that have _not_ changed.
 
@@ -109,11 +109,11 @@ fn detect_changed_score(score: Res<Score>) {
 
 Change detection works differently for removed components, since the component (and possibly the entity) no longer exists!
 
-To detect when components are removed, you can use the [`RemovedComponents`] param:
+To detect when components are removed, you can use the [`RemovedComponents`] parameter:
 
 ```rust
 fn detect_removed_position(mut removed: RemovedComponents<Position>) {
-    for entity in removed.iter() {
+    for entity in removed.read() {
         println!("Entity {:?} just lost its Position component", entity);
     }
 }
@@ -121,7 +121,7 @@ fn detect_removed_position(mut removed: RemovedComponents<Position>) {
 
 {% callout(type="warning") %}
 It's generally better to use an [`OnRemove`] observer or a component hook to detect removals.
-This has a number of advantages over using [`RemovedComponents`]:
+Using this has a number of advantages over [`RemovedComponents`]:
 
 - You get access to the component values being removed.
 - [`RemovedComponents`] can miss component removals when used in [`FixedUpdate`].
@@ -198,7 +198,7 @@ You may need to pay attention to how you [run schedules] or use [explicit system
 [states]: @/learn/book/control-flow/states.md
 [run conditions]: @/learn/book/control-flow/run-conditions.md#run-conditions
 [run schedules]: @/learn/book/the-game-loop/schedules.md
-[explicit system ordering]: @/learn/book/control-flow/run-conditions.md
+[explicit system ordering]: @/learn/book/the-game-loop/schedules.md
 
 [`set_if_neq()`]: https://docs.rs/bevy/latest/bevy/ecs/change_detection/trait.DetectChangesMut.html#method.set_if_neq
 [`ResMut`]: https://docs.rs/bevy/latest/bevy/ecs/system/struct.ResMut.html

--- a/content/learn/book/control-flow/commands.md
+++ b/content/learn/book/control-flow/commands.md
@@ -52,7 +52,7 @@ commands.trigger(event);
 ```
 
 To use `Commands` in your systems, it is easiest to pass it in as a system parameter.
-This ensures that every system that needs access to `Commands` gets it and that all of the `Commands` that are called are placed into the `Command` queue.
+This ensures that every system that needs access to `Commands` gets it and that all `Commands` that are called are placed into the `Command` queue.
 
 ```rust
 fn my_system(mut commands: Commands) {
@@ -64,7 +64,7 @@ fn my_system(mut commands: Commands) {
 }
 ```
 
-While Bevy offers a number of different pre-defined `Commands` to use, it also offers the [`queue`] method to make changes that aren't provided by default.
+While Bevy offers a number of different predefined `Commands` to use, it also offers the [`queue`] method to make changes that aren't provided by default.
 `queue` gives us mutable access to the `World`, which we can use however we want.
 The most straightforward approach is to construct our modifications within the method itself, as can be seen in the example below.
 You can also go one step further and create *custom* commands by implementing the `Command` trait on a struct you create, or even extend the `Commands` struct with traits and methods that you define and implement yourself.
@@ -103,7 +103,7 @@ struct UpdateEvent;
 
 // Add our Systems to their Schedules.
 app.add_systems(Startup, insert_observer_system);
-app.add_system(Update, update_system);
+app.add_systems(Update, update_system);
 
 // This System will run in the `Startup` schedule.
 fn insert_observer_system(mut commands: Commands) {
@@ -120,12 +120,12 @@ fn update_system(mut commands: Commands) {
 
 In the above example, we have two systems: `insert_observer_system` running in the `Startup` schedule, and `update_system` running in the `Update` schedule.
 Since the `Startup` schedule only runs once, the `add_observer()` command is only run when our application is launched.
-However a `trigger()` command is queued everytime the `Update` schedule runs, meaning that a `trigger()` command is run every time the `Update` schedule completes.
+However, a `trigger()` command is queued every time the `Update` schedule runs, meaning that a `trigger()` command is run every time the `Update` schedule completes.
 
 We mentioned above that by default `Commands` are applied at the *end* of a `Schedule`.
-While correct, what really happens is that all of the `Commands` we queue are placed into a special `System` known as [`ApplyDeferred`].
+While correct, what really happens is that all the `Commands` we queue are placed into a special `System` known as [`ApplyDeferred`].
 This system will run at the end of every `Schedule` that has a system which uses `Commands` as a `SystemParameter`.
-Since `ApplyDeferred` is run after all of systems in a given schedule, all of the changes made by the `ApplyDeferred` system are able to be seen by the systems in other schedules.
+Since `ApplyDeferred` is run after all of systems in a given schedule, all the changes made by the `ApplyDeferred` system are able to be seen by the systems in other schedules.
 
 In addition, if a system accessing `Commands` is ordered before another system also accessing `Commands` in the same `Schedule`, the second system will always see the effects of `Commands` run in the first system.
 Bevy ensures this occurs by dynamically inserting synchronization points, during which all `Commands` are applied.
@@ -145,7 +145,7 @@ app.add_systems(
 );
 
 // This System will add the TargetComponent to the `player` Entity.
-fn add_the_component(mut commands: Commands, mut player: Single<Entity, Without<TargetComponent>) {
+fn add_the_component(mut commands: Commands, mut player: Single<Entity, Without<TargetComponent>>) {
     commands.entity(player).insert_if_new((TargetComponent));
     println!("TargetComponent added!");
 }
@@ -266,7 +266,7 @@ In the above example we took that same premise and extended it into a full custo
 Creating custom commands can help reduce the amount of boilerplate code you write, especially if you know that you need to repeat that code at multiple points.
 
 You can make this pattern even more ergonomic by writing an extension trait for the `Commands` type, allowing you to call new methods as long as the extension trait is imported.
-Calling `commands.custom_command(my_data)` is shorter and plays nicer with auto-complete, however this approach has no functional benefit or cost; it's simply a matter of style.
+Calling `commands.custom_command(my_data)` is shorter and plays nicer with autocomplete, however this approach has no functional benefit or cost; it's simply a matter of style.
 These same strategies can also be applied for the `EntityCommand` trait and the `EntityCommands` struct.
 
 ```rust
@@ -276,7 +276,7 @@ struct Counter(u64);
 
 // A custom Trait to add a value to the Counter Resource.
 pub trait CounterAdd {
-    fn add_to_counter(&mut self, value: u64)
+    fn add_to_counter(&mut self, value: u64);
 }
 
 // Implement our custom Trait on Commands.

--- a/content/learn/book/control-flow/events.md
+++ b/content/learn/book/control-flow/events.md
@@ -105,7 +105,7 @@ world.add_observer(|event: On<DespawnEnemyUnits>, commands: Commands, enemy_unit
 
 In the above example, we've created an `Observer` that will run its `ObserverSystem` when a `DespawnEnemyUnits` event is triggered. Additionally, we've accessed `Commands` and `Query` as parameters to gain access to the data we need. Within the `ObserverSystem`, we use a `for` loop to despawn every `Enemy` entity that is given in the `enemy_units` query.
 
-It is also worth noting that we can trigger an `Event` within an `ObserverSystem`. Instead of triggering immediately (as is the case when using `World::trigger`), triggering an `Event` inside an `Observer` with `Commands::trigger` will run the newly triggered `ObserverSystem` at the end of the `Command` queue. Once all of the other `Observer` commands that are currently in the queue are run, then the new `ObserverSystem` will be run. Be aware that these events are evaluated _recursively_, and will exit once there are no more events left.
+It is also worth noting that we can trigger an `Event` within an `ObserverSystem`. Instead of triggering immediately (as is the case when using `World::trigger`), triggering an `Event` inside an `Observer` with `Commands::trigger` will run the newly triggered `ObserverSystem` at the end of the `Command` queue. Once all other `Observer` commands that are currently in the queue are run, then the new `ObserverSystem` will be run. Be aware that these events are evaluated _recursively_, and will exit once there are no more events left.
 
 ```rust
 // When Event `A` is triggered, it in turn will trigger Event `B`.
@@ -128,19 +128,19 @@ struct GameActive(bool);
 
 // Global Observer
 app.add_observer(
-    on_damage.run_if(|paused: Res<GamePaused>| !paused.0)
+    on_damage.run_if(|paused: Res<GameActive>| !paused.0)
 );
 
 // Entity Observer
 commands.spawn(Enemy).observe(
-    on_hit.run_if(|paused: Res<GamePaused>| !paused.0)
+    on_hit.run_if(|paused: Res<GameActive>| !paused.0)
 );
 
 // Builder Pattern
 world.spawn(
     Observer::new(DamageEvent)
         .with_entity(Enemy)
-        .run_if(|paused: Res<GamePaused>| !paused.0)
+        .run_if(|paused: Res<GameActive>| !paused.0)
 );
 ```
 
@@ -150,7 +150,7 @@ We also have the ability to chain multiple `.run_if` conditions together, althou
 // Multiple conditions can be chained (AND semantics)
 world.add_observer(
     on_damage
-        .run_if(|paused: Res<GamePaused>| !paused.0)
+        .run_if(|paused: Res<GameActive>| !paused.0)
         .run_if(resource_exists::<Player>)
 );
 ```
@@ -180,7 +180,7 @@ fn setup(mut commands: Commands) {
         // Dereference out of the `player` Single query.
         let (player_entity, mut player_health): (Entity, &mut Health) = *player;
         // Subtract the damage value from player_health.
-        player_health -= player_damage.amount;
+        player_health -= damage_event.amount;
     });
 }
 
@@ -227,7 +227,7 @@ struct Explode {
 }
 ```
 
-With [`EntityEvent`], we are selecting a single `Entity` that will be the target of our event. To determine the selected `Entity`, we need to provide the `EventEntity` with an `event_target` entity. By default, `event_target` will be set to the value inside an `entity` field in a struct (if it exists). Otherwise we can manually specify the `event_target` by using the `#[event_target]` field attribute.
+With [`EntityEvent`], we are selecting a single `Entity` that will be the target of our event. To determine the selected `Entity`, we need to provide the `EntityEvent` with an `event_target` entity. By default, `event_target` will be set to the value inside an `entity` field in a struct (if it exists). Otherwise, we can manually specify the `event_target` by using the `#[event_target]` field attribute.
 
 ```rust
 // A simple EntityEvent:
@@ -289,7 +289,7 @@ world.entity_mut(some_entity).observe(|explode: On<Explode>| {}); // Entity obse
 
 Since [`EntityEvent`] is triggered for individual entities themselves and not for all independent observer entities, we can leverage any [Relations] present on an `Entity` when an `EntityEvent` is activated. This is known as Propagation, or "Event Bubbling", and allows an `EntityEvent` to traverse a hierarchy chain while triggering on each `Entity` in that hierarchy chain.
 
-Propagation has to be explicitly enabled on an `EntityEvent`, and any `Observer` has to opt-in. This is done by setting the `#[entity_event(propagate)]` attribute on an `EntityEvent` and also by allowing the desired `Observer` to allow propagation:
+Propagation has to be explicitly enabled on an `EntityEvent`, and any `Observer` has to opt-in. This is done by setting the `#[entity_event(propagate)]` attribute on an `EntityEvent` and by allowing the desired `Observer` to allow propagation:
 
 ```rust
 // Set the `entity_event(propagate)` attribute.

--- a/content/learn/book/control-flow/handling-errors.md
+++ b/content/learn/book/control-flow/handling-errors.md
@@ -7,7 +7,9 @@ weight = 6
 
 Failures happen all the time in production software, from recoverable failures like not finding a user's save file on first run to unrecoverable errors which are symptoms of critical bugs.
 Dealing with that failure in a productive way means games and applications become more reliable.
-In Bevy, with data such as Entities, Components, and Resources being inserted and manipulated at runtime, handling cases when a Resource doesn't exist yet, an index needs to be updated, or a Component doesn't have the data you're looking for is routine work.
+In Bevy, data such as Entities, Components, and Resources are being inserted and manipulated at runtime.
+This means it's common to encounter cases where a Resource might not exist when you access it, or an index needs to be updated, or a Component doesn't have the data you're looking for.
+We need to handle these cases, and hopefully recover from them gracefully.
 
 ## To Recover or Not
 
@@ -21,7 +23,7 @@ They happen immediately, and provide us no opportunity for clean up or a gracefu
 
 So panics are bad? Well, kind of. Using panicking macros like [`todo!`](https://doc.rust-lang.org/std/macro.todo.html) can be extremely useful during prototyping. Just try to remove them before you let anyone run your code.
 
-## Avoiding crashes
+## Avoiding Crashes
 
 In Rust, unrecoverable failures are explicitly written in the source code.
 Some functions that will signal a potential crash include:
@@ -61,7 +63,7 @@ todo = "warn"
 
 {% end %}
 
-## Recoverable failures
+## Recoverable Failures
 
 The [`Result`](https://doc.rust-lang.org/std/result/enum.Result.html) and [`Option`](https://doc.rust-lang.org/std/option/enum.Option.html) types are regular enums commonly used to represent different kinds of failure.
 An `Option`'s variants, `None` and `Some`, indicate whether a value exists or not while a `Result`'s variants, `Ok` and `Err` store a successful value or an error value respectively.
@@ -178,7 +180,7 @@ Once you have a `Result`, `Option`, or other enum, there are a number of options
 ### `match`
 
 Here we have a Bevy application with a single system that runs every frame.
-The system queries for all of the `Camera` components that have been spawned and uses [`Query::single`](https://docs.rs/bevy/latest/bevy/prelude/struct.Query.html#method.single) to test if there is only a single `Entity` matching the `Query`.
+The system queries for all `Camera` components that have been spawned and uses [`Query::single`](https://docs.rs/bevy/latest/bevy/prelude/struct.Query.html#method.single) to test if there is only a single `Entity` matching the `Query`.
 In the case of 0 or 2+ matching entities, the returned value is the `Err` variant of the `Result`, which itself contains [an enum](https://docs.rs/bevy/latest/bevy/ecs/query/enum.QuerySingleError.html) indicating the reason for the error.
 Using `match` allows running different branches of logic based on matching patterns.
 
@@ -239,10 +241,10 @@ fn update(query: Query<&Camera>, mut commands: Commands) {
 }
 ```
 
-### if let
+### If Let
 
-if-let is a similar concept to let-else that doesn't require the else block to diverge, and can have multiple additional conditions.
-In turn, this means that _if_ an arm doesn't diverge, then each arm of the if-let must return the same type.
+`if let` is a similar concept to `let else` that doesn't require the else block to diverge, and can have multiple additional conditions.
+In turn, this means that _if_ an arm doesn't diverge, then each arm of the `if let` must return the same type.
 
 In this example, the first else block checks to make sure there are no other cameras spawned before spawning in a new camera instead of returning a value from the `if let`.
 Values that _are_ returned from the `if let` are stored in the `computed_target_info` variable and can be used in the rest of the program.
@@ -273,16 +275,16 @@ fn update(query: Query<&Camera>, mut commands: Commands) {
 }
 ```
 
-if-let enables using a concept called "let chaining".
-In the example program, a series of lets are chained together using `&&`, using and matching on values that were previously matched.
-If all of the let patterns match successfully, the relevant branch is executed.
+`if-let` enables using a concept called "let chaining".
+In the example program, a series of `let`s are chained together using `&&`, using and matching on values that were previously matched.
+If all `let` patterns match successfully, the relevant branch is executed.
 
 ## System Requirements
 
 We've been using `Query::single` to validate query data and dispatch logic accordingly.
 Since systems require certain data to be available to function, there are two ways to validate that data before a system runs:
 
-- SystemParam validation
+- `SystemParam` validation
 - Run conditions
 
 Run conditions and fallible system parameters are covered in [run conditions](@/learn/book/control-flow/run-conditions.md)
@@ -297,7 +299,7 @@ While Rust loosely buckets errors into "recoverable" and "unrecoverable", Bevy t
 
 This works because Bevy contains a global, configurable error handler.
 
-### Returning errors from Systems
+### Returning Errors from Systems
 
 Bevy's prelude contains a custom [`Result`](https://docs.rs/bevy/latest/bevy/ecs/error/type.Result.html) type alias that amounts to `Result<(), BevyError>` in the default case.
 This can be used as the return type from systems.
@@ -367,13 +369,13 @@ fn update_map_severity(query: Query<&Camera>) -> Result {
 }
 ```
 
-This is a common and useful pattern: quickly allowing you to downgrade errors based on the local context about how big of a problem they actually pose.
+This is a common and useful pattern: quickly allowing you to downgrade errors based on the local context about how big a problem they actually pose.
 
 [`Severity`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Severity.html
 [`with_severity`]: https://docs.rs/bevy/latest/bevy/prelude/trait.ResultSeverityExt.html#tymethod.with_severity
 [`map_severity`]: https://docs.rs/bevy/latest/bevy/prelude/trait.ResultSeverityExt.html#tymethod.map_severity
 
-#### Configuring the global error handler
+#### Configuring the Global Error Handler
 
 This policy of aggressive panicking can help raise issues quickly in development, but you may prefer a different approach to handling errors globally, especially in production.
 The job of the global error handler is to decide how to log a global error, so Bevy provides [a series of preset handlers](https://docs.rs/bevy/latest/bevy/ecs/error/index.html) ranging from panicking to completely ignoring errors and all log levels in between.
@@ -418,7 +420,7 @@ This is particularly true if you are writing a library: you should *never* overr
 Instead, we recommend you change the global error handler when preparing a game for production, turning unhandled crashes into errors.
 Use a feature flag for this, so you can decide on error policies for development and production separately.
 
-### Per-system error handling
+### Per-System Error Handling
 
 If you want to handle errors returned from a system in more complex ways, system piping can pass the return value of one system to another.
 More details on system piping can be found in [systems](@/learn/book/control-flow/systems.md).
@@ -450,7 +452,7 @@ fn handle_error(In(input): In<Result>) {
 }
 ```
 
-The input type can be any type, which means we don't need to use the generic `BevyError`, and can instead use a custom error type or a pre-existing type like `QuerySingleError` that is returned by the operations the program uses.
+The input type can be any type, which means we don't need to use the generic `BevyError`, and can instead use a custom error type or a preexisting type like `QuerySingleError` that is returned by the operations the program uses.
 
 This allows specific matching of those errors in the piped system.
 

--- a/content/learn/book/control-flow/lifecycle-events.md
+++ b/content/learn/book/control-flow/lifecycle-events.md
@@ -37,7 +37,7 @@ When both `Add` and `Insert` occur, `Add` hooks are evaluated before `Insert` ho
 ## Component Hooks
 
 The most common way of interacting with lifecycle events is by using [`ComponentHooks`].
-We have a couple ways to use `ComponentHooks`, the first of which is through the [`World::register_component_hook`] method.
+We have a couple of ways to use `ComponentHooks`, the first of which is through the [`World::register_component_hooks`] method.
 
 ```rust
 // Create a ComponentHook with the `World` method:
@@ -105,7 +105,7 @@ impl MyComponent {
 ```
 
 [`ComponentHooks`]: https://docs.rs/bevy/latest/bevy/ecs/lifecycle/struct.ComponentHooks.html
-[`World::register_component_hook`]: https://docs.rs/bevy/latest/bevy/prelude/struct.World.html#method.register_component_hooks
+[`World::register_component_hooks`]: https://docs.rs/bevy/latest/bevy/prelude/struct.World.html#method.register_component_hooks
 
 ## Lifecycle Observers
 
@@ -140,7 +140,7 @@ Using `Observers`, we'd have to structure our code like such:
 struct PlayerName(pub String);
 
 // Then we add an Observer that will watch for `PlayerName` being added.
-commands.add_observer(|print_name: On<Add, PlayerName>, player_query: <&PlayerName>| {
+commands.add_observer(|print_name: On<Add, PlayerName>, player_query: Query<&PlayerName>| {
     let new_name = player_query.get(print_name.entity).unwrap().0;
     println!("Spawned: {}", new_name);
 });
@@ -200,7 +200,7 @@ world.register_component_hooks::<PlayerName>().on_add(|mut world, context| {
 
 In earlier chapters, we went over several lifecycle event interactions without specifically naming them as lifecycle events.
 This is because they aren't used in the same manner as we've been using them so far.
-However they are still lifecycle event interactions, so we will briefly return to them to show the differences between them and the tools introduced in this chapter.
+However, they are still lifecycle event interactions, so we will briefly return to them to show the differences between them and the tools introduced in this chapter.
 
 ### Removed Components Parameter
 
@@ -222,7 +222,7 @@ fn react_on_removal(mut removed: RemovedComponents<MyComponent>) {
 // runs *before* `MyComponent` is actually removed from the `Entity`. 
 world.register_component_hooks::<MyComponent>().on_remove(|mut world, remove| {
     // Access the value within `MyComponent` before it's removed.
-    let value = world.get::<MyComponent>(remove.entity).unwrap()
+    let value = world.get::<MyComponent>(remove.entity).unwrap();
     println!("MyComponent with value {} removed from {}", value, remove.entity);
 });
 ```
@@ -238,14 +238,14 @@ We can also manually clear `RemovedComponents` by using the [`World::clear_track
 
 The [`Added`] query filter can be used to see `Entities` that have had a new instance of a specific `Component` added to them for the first time.
 Much like `RemovedComponents` though, `Added` can only be accessed after the lifecycle event occurs.
-Additionally `Added` is less precise, returning `Entities` that had a target `Component` added for the first time and `Entities` that had a target `Component` reinserted, even if the component already existed.
+Additionally, `Added` is less precise, returning `Entities` that had a target `Component` added for the first time and `Entities` that had a target `Component` reinserted, even if the component already existed.
 In effect, this combines both the `Add` and `Insert` lifecycle events, which can be an important distinction depending on the functionality you want to run.
 
-To show the differences, lets imagine we are building a networked multiplayer game where we want to track the following:
+To show the differences, let's imagine we are building a networked multiplayer game where we want to track the following:
 
 - Create a new `Entity` for each player when a new match starts.
-- Have a way for players to reconnect to a match with an existing `Entity` if they happen to leave for some reason.
-- Keep a general log of everytime a Player connects or reconnects to the match.
+- Have a way for players to reconnect to a match with some existing `Entity` if they happen to leave for some reason.
+- Keep a general log of every time a Player connects or reconnects to the match.
 
 We can use both the `Added` query filter and `ComponentHooks` to achieve each use case.
 

--- a/content/learn/book/control-flow/messages.md
+++ b/content/learn/book/control-flow/messages.md
@@ -14,7 +14,7 @@ These are the situations where **Messages** are the preferred tool.
 They can be created and read from using system parameters and are stored in a [`Messages<M>`] resource.
 
 You can use `Messages` for a variety of different functionalities.
-Some messages might re-occur over a longer period of time, like continuously applying damage effects or regularly updating a leaderboard.
+Some messages might reoccur over a longer period of time, like continuously applying damage effects or regularly updating a leaderboard.
 Others can be short-lived, such as checking for whether a player can interact with an object or if a UI element should appear.
 The key concept to remember is that a `Message` is best used for logic that can be _deferred_ rather than requiring immediate action.
 
@@ -60,7 +60,7 @@ fn main() {
 }
 ```
 
-If you would prefer to implement `Message` handling yourself, you are free to omit `App::add_message` and handle all of the functionality manually.
+If you would prefer to implement `Message` handling yourself, you are free to omit `App::add_message` and handle all the functionality manually.
 Setting up `Message` handling manually follows the same process used by `App::add_message<M>`, however we are able to choose when `Messages::update` gets called.
 
 ```rust
@@ -105,7 +105,7 @@ fn main() {
 Messages function based on _writing_ them in response to something happening and _reading_ them at a later point to perform some functionality.
 Let's work through an example to showcase how and why messages should be used in your application.
 To do this we'll be creating a very basic scoreboard update mechanic for a king-of-the-hill style gamemode.
-Before we jump into the code, lets assess our objectives for the scoreboard update:
+Before we jump into the code, let's assess our objectives for the scoreboard update:
 
 - Update each player's score based on if they control the hill.
 - End the game when a player's score reaches 500.
@@ -129,7 +129,7 @@ fn main() {
 }
 ```
 
-Now lets _write_ our message which will update the scoreboard.
+Now let's _write_ our message which will update the scoreboard.
 We'll do this by creating a `Single` query for the hill objective that our players are fighting for control of.
 Specifically we'll be looking for the player `Entity` value stored in a `CurrentHillKing` component, which is a part of an `Entity` with a `HillObjective` marker component.
 Once we have our player `Entity`, we'll write a new `ScoreboardUpdate` message containing the player and the value to update their score by (5 in our case).
@@ -164,7 +164,7 @@ fn read_scoreboard_update(
 ) {
     // Read all of the ScoreboardUpdate messages in `update_reader`.
     for score_update in update_reader.read() {
-        scoreboard_res.update_score(score_update.player, score_update.value);
+        scoreboard_res.update_score(score_update.0, score_update.1);
     }
 
     if scoreboard_res.highest_player_score() >= 500 {
@@ -221,7 +221,7 @@ fn my_system(mut mutator: MessageMutator<MyMessage>) {
 ```
 
 One thing to note is that `MessageMutator` does not run in parallel.
-This is because `MessageMutator` mutably accesses the `Messages<M>` resource that contains all of the messages of a given type.
+This is because `MessageMutator` mutably accesses the `Messages<M>` resource that contains all messages of a given type.
 The same applies for `MessageWriter` as well.
 Systems accessing either will only run sequentially with each other.
 On the other hand, `MessageReader` _can_ be accessed by multiple systems concurrently if they only access `MessageReader`.
@@ -238,7 +238,7 @@ pub struct MyMessage(pub u32);
 fn message_resource(mut messages: ResMut<Messages<MyMessage>>) {
     // Drain all of the messages out of the resource,
     // and remove any message with a value of 2.
-    let filtered_messages = messages.drain().filter(|message| message.0 != 2);
+    let filtered_messages = messages.drain().filter(|message| message.0 != 2).collect();
 
     // Add the filtered messages back into the resource.
     messages.write_batch(filtered_messages);
@@ -267,23 +267,23 @@ pub struct TickDamage {
 }
 
 fn deal_tick_damage(mut tick_damage_reader: MessageReader<TickDamage>, mut health_query: Query<&mut Health>) {
-    for tick_damage in tick_damage_reader.par_read() {
-        if let Some(mut health) = health_query.get_mut(tick_damage.entity) {
-            health.value -= tick_damage.damage;
+    tick_damage_reader.par_read().for_each(|damage_message| {
+        if let Ok(mut health) = health_query.get_mut(damage_message.entity) {
+            health.value -= damage_message.damage;
         }
-    }
+    });
     tick_damage_reader.clear();
 }
 ```
 
 In the above example, we have a `TickDamage` message that tracks an `Entity` and a damage amount (`i32`).
 Throughout our schedules we can use a `MessageWriter` to accumulate `TickDamage` messages.
-When `Messages<TickDamage>` gets updated, we can then apply all of the `TickDamage` messages at once, benefitting from the parallel access that `MessageReader` gives us.
+When `Messages<TickDamage>` gets updated, we can then apply all `TickDamage` messages at once, benefiting from the parallel access that `MessageReader` gives us.
 
 Reproducing the same behavior using `Events` would involve several more steps.
 First we would have to first track all of our entities separately, since we only want to apply `TickDamage` to our entities at a single point.
 Then we would have to queue each `Event` to be evaluated sequentially.
-As the number of entities we're applying `TickDamage` to grows larger and larger, the more time it will take to execute those `Events`.
+As the number of entities we're applying `TickDamage` to grow larger and larger, the more time it will take to execute those `Events`.
 
 By using messages, we avoid the headache of making sure entities are tracked separately and gain stability by avoiding sequential `Event` execution.
 
@@ -310,7 +310,7 @@ If `Messages::update` is never called, these buffers will continue to grow in si
 
 Using `App:add_message<M>()` to register your `Message` will run `Messages::update` _every frame_.
 Like we mentioned at the top, this is because the `message_update_system` is placed in the `First` schedule, meaning it will be the first thing updated every frame.
-However we aren't locked into this behaviour.
+However, we aren't locked into this behavior.
 If we instead want our `Messages` to be updated within the [`FixedUpdate`] schedule rather than being frame-dependent, we can do so by several means.
 
 The first would be to manually place `message_update_system` in the `FixedUpdate` schedule (or some other schedule within the [`FixedMain`] set).
@@ -324,7 +324,7 @@ fn main() {
 }
 ```
 
-However, this is indiscriminant and will update _every_ `Message` type in your application.
+However, this is indiscriminate and will update _every_ `Message` type in your application.
 Instead, it's likely that you'll want more fine-grained control over which `Messages` update in `FixedUpdate` versus those that update every frame.
 We'll have to access each individual `Messages<M>` resource to accomplish this.
 
@@ -350,9 +350,9 @@ fn deal_tick_damage_update(mut tick_damage_messages: ResMut<Messages<TickDamage>
 // This system will read from the Message<TickDamage> resource
 // and apply damage to entities.
 fn deal_tick_damage(mut tick_damage_reader: MessageReader<TickDamage>, mut health_query: Query<&mut Health>) {
-    for tick_damage in tick_damage_reader.par_read() {
-        if let Some(mut health) = health_query.get_mut(tick_damage.entity) {
-            health.value -= tick_damage.damage;
+    tick_damage_reader.par_read().for_each(|damage_message| {
+        if let Ok(mut health) = health_query.get_mut(damage_message.entity) {
+            health.value -= damage_message.damage;
         }
     }
     tick_damage_reader.clear();
@@ -360,15 +360,15 @@ fn deal_tick_damage(mut tick_damage_reader: MessageReader<TickDamage>, mut healt
 
 // This system will update the Message<WarnTickDamage> resource.
 fn warn_tick_damage_update(mut warn_messages: ResMut<Messages<WarnTickDamage>>) {
-    warn_message.update();
+    warn_messages.update();
 }
 
 // This system will read from the Message<WarnTickDamage> resource
 // and print a warning message.
 fn warn_tick_damage(warn_tick_damage_reader: MessageReader<WarnTickDamage>) {
-    for message in warn_tick_damage_reader.par_read() {
+    warn_tick_damage_reader.par_read().for_each(|message| {
         println!("{} will take Tick Damage!", message.entity);
-    }
+    });
 }
 
 // This system will add the Message<TickDamage> and Message<WarnTickDamage>

--- a/content/learn/book/control-flow/messages.md
+++ b/content/learn/book/control-flow/messages.md
@@ -354,7 +354,7 @@ fn deal_tick_damage(mut tick_damage_reader: MessageReader<TickDamage>, mut healt
         if let Ok(mut health) = health_query.get_mut(damage_message.entity) {
             health.value -= damage_message.damage;
         }
-    }
+    });
     tick_damage_reader.clear();
 }
 

--- a/content/learn/book/control-flow/run-conditions.md
+++ b/content/learn/book/control-flow/run-conditions.md
@@ -8,7 +8,7 @@ status = 'hidden'
 
 Instead of returning early from a system, you could choose to skip it entirely.
 This can reduce the complexity of using your systems by separating concerns of _"what a system does"_ from _"should it run"_.
-Skipping a system entirely can also reduce the overhead involved since it would be cancelled before being dispatched.
+Skipping a system entirely can also reduce the overhead involved since it would be canceled before being dispatched.
 Systems are run in parallel by default, so skipping a system means your application would do less work overall if a system is skipped.
 
 Bevy offers two complementary ways to skip systems: **run conditions** and **fallible system parameters**.
@@ -19,12 +19,12 @@ Run conditions are functions that can be attached to systems via the [`.run_if()
 More specifically, any read-only system which returns `bool` can be used as a run condition.
 This allows you to access information about the [`World`] and even store local state when determining if a system should be run.
 
-For your convenience, Bevy comes with a set of premade run conditions, which can be found by searching for [common conditions] in the Bevy docs.
-These run conditions are domain-specific, thus they are defined as needed by various Bevy subcrates.
+For your convenience, Bevy comes with a set of pre-made run conditions, which can be found by searching for [common conditions] in the Bevy docs.
+These run conditions are domain-specific, thus they are defined as needed by various Bevy sub-crates.
 They might allow you to [only run a system based on input being received], [run a system on a timer], or [run a system when in a certain game state].
 
-Most of these premade run conditions won't run on their own.
-Instead you'll have to provide them with a value which will then return a function that can be then be used as a run condition.
+Most of these pre-made run conditions won't run on their own.
+Instead, you'll have to provide them with a value which will then return a function that can be then be used as a run condition.
 
 Run conditions can also be composed.
 You can chain multiple `.run_if()` calls using AND logic, but there are also various boolean operations provided by the [`SystemCondition`] trait.
@@ -54,10 +54,10 @@ If that data is not found, [`SystemParam`] authors can choose how to proceed:
 - Or the system can be gracefully skipped.
 
 You aren't locked into either panicking or skipping though.
-When system params fail the resulting behavior can be configured (as detailed in the [handling errors] section), but by default failed system parameters will cause a panic.
+When system parameters fail the resulting behavior can be configured (as detailed in the [handling errors] section), but by default failed system parameters will cause a panic.
 
-Alternatively, system params can cause the system that they are part of to be skipped when validation fails.
-This represents an unusual but expected state of the application, which should be handled silently without issue.
+Alternatively, system parameters can cause the system that they are part of to be skipped when validation fails.
+This represents an unusual (but expected) application state, which should be handled silently without issue.
 
 For example, the [`Single`] system parameter works like [`Query`] except that it only succeeds if the query matches exactly one entity.
 If only a single entity matches, the returned value is provided and conveniently unwrapped.

--- a/content/learn/book/control-flow/states.md
+++ b/content/learn/book/control-flow/states.md
@@ -26,7 +26,7 @@ For example, you might have a HUD (heads-up display) entity which only exists du
 
 [`States`]: https://docs.rs/bevy/latest/bevy/state/state/trait.States.html
 
-## Setting Up States
+## Setting up States
 
 Let's say that we're building a retro arcade game like [Galaga](https://en.wikipedia.org/wiki/Galaga).
 We'll want at least three states:
@@ -113,7 +113,7 @@ The `StateTransition` schedule itself runs at two points:
 2. **Each tick of the game loop**, after [`PreUpdate`] but before the fixed update loop and [`Update`].
 
 When you set a new state with [`NextState<T>`], the transition doesn't happen immediately.
-Instead the change is queued and applied the next time `StateTransition` runs.
+Instead, the change is queued and applied the next time `StateTransition` runs.
 This means that systems which will run later in the _same_ tick will still see the _old_ state.
 
 When a transition does occur, the schedules run in this order:
@@ -136,7 +136,7 @@ For more details on where `StateTransition` fits into the broader game loop, see
 [`Update`]: https://docs.rs/bevy/latest/bevy/app/struct.Update.html
 [schedules]: @/learn/book/the-game-loop/schedules.md
 
-## Cleaning Up Between States
+## Cleaning up Between States
 
 One of the most common patterns when working with states is to run some setup logic upon entering a state, and some tear-down or clean-up logic when exiting a state.
 The most common form of clean-up is despawning entities when the state they're associated with ends. 
@@ -157,7 +157,7 @@ fn spawn_enemy(mut commands: Commands) {
 
 The same pattern can be very helpful for UI as well.
 We can automatically close menus by despawning them when their associated state ends.
-This allows us to automatically couple the "remember to clean this up" logic with the creation of our objects, rather than needing to remember all of the things we might have spawned in a single monolithic cleanup system.
+This allows us to automatically couple the "remember to clean this up" logic with the creation of our objects, rather than needing to remember all the things we might have spawned in a single monolithic cleanup system.
 
 Similar helper components exist: [`DespawnOnEnter`], for when you want to clean up when entering a specific state, and [`DespawnWhen`], for when you want to perform more complex state-matching logic.
 
@@ -165,7 +165,7 @@ Similar helper components exist: [`DespawnOnEnter`], for when you want to clean 
 [`DespawnOnEnter`]: https://docs.rs/bevy/latest/bevy/prelude/struct.DespawnOnEnter.html
 [`DespawnWhen`]: https://docs.rs/bevy/latest/bevy/prelude/struct.DespawnWhen.html
 
-## SubStates: States Within States
+## Substates: States Within States
 
 For our arcade game, the `GameState::Playing` state is actually more complex than it appears.
 When a level starts, the action doesn't begin immediately - instead there is a brief interval where we display an animation of the ship arriving, or "warping in".
@@ -193,12 +193,12 @@ pub enum ActionState {
 }
 ```
 
-Sub-states are initialized just like top-level states:
+Sub-states are initialized alongside top-level states, but with their own method call:
 
 ```rust
 app
     .init_state::<GameState>()
-    .init_state::<ActionState>();
+    .add_sub_state::<ActionState>();
 ```
 
 When state transitions occur, sub-states and computed states are recomputed accordingly, causing these transitions to cascade.

--- a/content/learn/book/control-flow/systems.md
+++ b/content/learn/book/control-flow/systems.md
@@ -88,7 +88,7 @@ If you're interested, you can check the [`SystemParam`] page for more details.
 [`Local`]: https://docs.rs/bevy/latest/bevy/ecs/prelude/struct.Local.html
 [`Commands`]: https://docs.rs/bevy/latest/bevy/ecs/prelude/struct.Commands.html
 
-## Accessing Data In Systems
+## Accessing Data in Systems
 
 One of the major benefits of Bevy's system abstraction is that it easily and efficiently ["splits the borrow"] of a `World`.
 When a system is run, the requested data is automatically fetched from the `World`.
@@ -116,7 +116,7 @@ fn access_resource(custom_resource: Res<CustomResource>) {
 }
 ```
 
-Systems can run in parallel, as long as one system isn't *mutably* accessing the same data as the other system.
+Systems can run in parallel, as long as one system isn't *mutably* accessing the same component data as the other system.
 Both systems in the example below access the same data, but neither changes the data.
 These systems can run in parallel.
 
@@ -130,9 +130,8 @@ fn print_player_and_enemy_locations(
     println!("Enemy Location: {:?}", enemy_query.translation);
 }
 
-// While this System also immutably accesses the same Transform components,
-// meaning it can run alongside `print_player_and_enemy_locations`
-// even though they both access the same data.
+// Even though `Stats` is mutably accessed in this system, `Transform` isn't.
+// This means `damage_player` can run alongside `print_player_and_enemy_locations`.
 fn damage_player(
     mut player_query: Single<(&Transform, &mut Stats), With<Player>>,
     enemy_query: Single<&Transform, With<Enemy>>,
@@ -182,7 +181,7 @@ See the section on [local system state] for more details.
 [local system state]: @/learn/book/storing-data/local-system-param.md
 [Queries book section]: @/learn/book/storing-data/queries.md
 
-## Running Systems In Schedules
+## Running Systems in Schedules
 
 Systems are usually repeatedly run throughout the life of your application.
 We are able to control when systems run and how systems are ordered by placing them into a [`Schedule`].
@@ -198,7 +197,7 @@ fn main() {
 In the above example, we're running the `my_system` system in the [`Update`] schedule.
 `Update` is one of the *standard* schedules that Bevy provides, but there are many more to choose from.
 Each standard schedule provides access to a different point of time for a single frame, allowing you to place your systems in relation to the state of the frame.
-You can read more about schedules in the dedicated [Schedules section], but for now you just need to know a couple things:
+You can read more about schedules in the dedicated [Schedules section], but for now you just need to know a couple of things:
 
 - By default, systems within a single schedule run in parallel.
 - Systems within a single schedule can also be explicitly ordered to run relative to each other.
@@ -212,18 +211,18 @@ You can read more about schedules in the dedicated [Schedules section], but for 
 [`Update`]: https://docs.rs/bevy/latest/bevy/app/struct.Update.html
 [`Fixed`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Fixed.html
 
-## One-shot Systems
+## One-Shot Systems
 
 Systems can also be run on demand, via a "one-shot" pattern.
 This is an extremely flexible tool, allowing you to execute arbitrary logic on the world in an ergonomic way whenever you please.
 One-shot systems are particularly useful for testing, handling callbacks in UI, or creating scripted events.
 
-We have two means of running one-shot systems:
+We have two ways of running one-shot systems:
 
 - Register and invoke a system's [`SystemId`].
 - Access a System by name, caching it in a [`CachedSystemId`].
 
-Both means involve accessing the *state* of a particular system.
+Both ways involve accessing the *state* of a particular system.
 When working with one-shot systems, entities are spawned to store this information.
 The [`Entity`] identifier for each system are stored in a `SystemId` (or `CachedSystemId`).
 
@@ -232,7 +231,7 @@ After the system is registered, we can use [`World::run_system`] and pass in the
 
 ```rust
 // This System will register and then run two One-shot Systems.
-fn register_one_shot_systems(mut world: &mut World) {
+fn register_one_shot_systems(world: &mut World) {
     // Register two One-shot Systems.
     let some_system_id = world.register_system(one_shot_system);
     let another_system_id = world.register_system(one_shot_system_with_input);
@@ -256,11 +255,11 @@ fn one_shot_system_with_input(In(input): In<usize>) {
 
 Alternatively, if we don't want to handle the `SystemId` ourselves, we can use [`World::run_system_cached`].
 This will automatically cache the system and will retrieve its `SystemId` based on its [`TypeId`].
-However this approach can be harder to abstract, and limits you to one copy of each system.
+However, this approach can be harder to abstract, and limits you to one copy of each system.
 Any internal state (such as [locals] or [change detection] information) will be shared.
 
 ```rust
-fn run_one_shot_systems(mut world: &mut World) {
+fn run_one_shot_systems(world: &mut World) {
     // This will print a `local_value: 1` since this is the first time
     // the system is run.
     world.run_system_cached(one_shot_system);
@@ -271,7 +270,7 @@ fn run_one_shot_systems(mut world: &mut World) {
 }
 
 fn one_shot_system(mut local_value: Local<usize>) {
-    local_value += 1;
+    *local_value += 1;
     println!("local_value: {}", local_value);
 }
 ```
@@ -344,14 +343,21 @@ Exclusive Systems:
 
 ```rust
 // This system exclusively accesses `World` in a mutable way.
-fn exclusive_system(mut world: &mut World) {
+fn exclusive_system(world: &mut World) {
     // This registers a System.
-    world.register_system(SystemdId);
+    world.register_system(my_system);
     // This removes all entities from the World.
     world.clear_entities();
     // This adds a custom schedule to be run in the World.
     world.add_schedule(MySchedule);
 }
+
+// A system we want to register.
+fn my_system(mut commands: Commands) {...}
+
+// A custom schedule to use.
+#[derive(ScheduleLabel)]
+struct MySchedule;
 ```
 
 Exclusive systems are useful for operations that require making large or unique changes to your `World`.
@@ -367,7 +373,7 @@ such as [`System`].
 The application of this is simplest to understand in the context of one-shot systems.
 
 ```rust
-fn call_system(mut world: &mut World) {
+fn call_system(world: &mut World) {
     // Call the one-shot system with an input value of 42.
     let system_value: Result<usize, _> = world.run_system_once_with(one_shot_system_with_input, 42);
     // After going through the one-shot system, system_value will equal `Ok<44>`.

--- a/content/learn/book/control-flow/time-controls.md
+++ b/content/learn/book/control-flow/time-controls.md
@@ -107,9 +107,6 @@ The length of time tracks how long the `Timer` will be active for, while the `Ti
 // A new timer that will expire after 5 seconds
 Timer::new(Duration::from_secs(5), TimerMode::Once);
 
-// A new timer that will repeat every 2 minutes
-Timer::new(Duration::from_mins(2), TimerMode::Repeating);
-
 // A new timer specifying a duration in seconds
 Timer::from_seconds(3.0, TimerMode::Once);
 ```
@@ -181,7 +178,7 @@ Instead of having to create a separate ability timer, just change the `TimerMode
 
 ```rust
 fn on_ability_upgrade(
-    mut ability_upgrade: Single<&mut AbilityTimer, With<AbilityUpgrade>
+    mut ability_upgrade: Single<&mut AbilityTimer, With<AbilityUpgrade>>
 ) {
     *ability_upgrade.timer.set_mode(TimerMode::Repeating);
 }
@@ -194,9 +191,9 @@ These can be helpful for giving buffs or debuffs to players or enemies based on 
 ```rust
 fn alter_ability(mut ability_timer: Single<&mut AbilityTimer, With<Ability>>) {
     // Reward the player with nearly unlimited ability use!
-    *ability_timer.set_duration(Duration::from_secs(0.1));
+    *ability_timer.timer.set_duration(Duration::from_secs(1));
     // Or punish them by effectively taking the ability away.
-    *ability_timer.set_duration(Duration::from_secs(10000.0));
+    *ability_timer.timer.set_duration(Duration::from_secs(10000));
 }
 ```
 
@@ -305,9 +302,9 @@ fn automatically_click_cookies(
     for mut cookie_clicker in query.iter_mut() {
         if boost.0 {
             let cookie_boost = 10;
-            cookie_clicker.timer.tick(Duration::from_secs(cookie_boost));
+            cookie_clicker.timer.tick(Duration::from_secs(cookie_boost) * delta_time);
             if cookie_clicker.timer.just_finished() {
-                cookies.0 += cookie_clicker.resources_gained;
+                cookies.0 += cookie_clicker.resources_gained * cookie_clicker.timer.times_finished_this_tick();
                 println!(
                     "Cookie Explosion! {}x Multiplier!",
                     cookie_clicker.timer.times_finished_this_tick()

--- a/content/learn/book/development-practices/_index.md
+++ b/content/learn/book/development-practices/_index.md
@@ -6,4 +6,4 @@ insert_anchor_links = "right"
 weight = 18
 +++
 
-This section offers suggestions on getting the most out of Bevy as a developer, highlighting the tools, practices and settings needed for a fast and productive experience.
+This section offers suggestions on getting the most out of Bevy as a developer, highlighting the tools, practices, and settings needed for a fast and productive experience.

--- a/content/learn/book/development-practices/fast-compiles.md
+++ b/content/learn/book/development-practices/fast-compiles.md
@@ -83,7 +83,7 @@ Create a `rust-toolchain.toml` file in the root of your project, next to `Cargo.
 channel = "nightly"
 ```
 
-For more information, see [The rustup book: Overrides](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file).
+For more information, see [The Rustup book: Overrides](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file).
 
 ## Cranelift
 
@@ -109,20 +109,20 @@ codegen-backend = "cranelift"
 codegen-backend = "llvm"
 ```
 
-This enables faster compiles for your binary, but builds Bevy and other dependencies with the more-optimized LLVM backend. See the [cranelift setup guide](https://github.com/rust-lang/rustc_codegen_cranelift#download-using-rustup) for
+This enables faster compiles for your binary, but builds Bevy and other dependencies with the more-optimized LLVM backend. See the [Cranelift setup guide](https://github.com/rust-lang/rustc_codegen_cranelift#download-using-rustup) for
 details on other ways in which Cranelift can be enabled. The installation process for Windows is a bit more involved. Consult the linked documentation for help.
-MacOS builds can currently crash on Bevy applications, so you should still wait a bit before using cranelift on that system.
+MacOS builds can currently crash on Bevy applications, so you should still wait a bit before using Cranelift on that system.
 
 While Cranelift is very fast to compile, the generated binaries are not optimized for speed. Additionally, it is generally still immature, so you may run into issues with it.
-Notably, Wasm builds do not work yet.
+Notably, WASM builds do not work yet.
 
 When shipping your game, you should still compile it with LLVM.
 
 {% callout(type="caution") %}
-Enabling cranelift is known to break local variable inspection while debugging.
+Enabling Cranelift is known to break local variable inspection while debugging.
 You can only inspect statics.
 This is caused by the fact that `rustc_codegen_cranelift` is missing DWARF support.
-See [`cranelift #166`](https://github.com/rust-lang/rustc_codegen_cranelift/issues/166) for more information.
+See [`Cranelift #166`](https://github.com/rust-lang/rustc_codegen_cranelift/issues/166) for more information.
 {% end %}
 
 ## Generic Sharing
@@ -131,7 +131,7 @@ Allows crates to share monomorphized generic code instead of duplicating it.
 In some cases this allows us to "precompile" generic code so it doesn't affect iterative compiles.
 This is currently only available on nightly Rust ([see above](#nightly-rust-compiler)).
 
-### Generic sharing setup
+### Generic Sharing Setup
 
 See [this file](https://github.com/bevyengine/bevy/blob/latest/.cargo/config_fast_builds.toml) for a more comprehensive, cross-platform example.
 

--- a/content/learn/book/development-practices/hot-reloading.md
+++ b/content/learn/book/development-practices/hot-reloading.md
@@ -37,7 +37,7 @@ If you are also using embedded assets (through the [`load_embedded_asset!`] macr
 [`AssetEvent::Modified`]: https://docs.rs/bevy/latest/bevy/asset/enum.AssetEvent.html
 [`AssetChanged`]: https://docs.rs/bevy/latest/bevy/asset/prelude/struct.AssetChanged.html
 
-## Asset-driven gameplay logic
+## Asset-Driven Gameplay Logic
 
 Asset hot-reloading is so useful and powerful that some projects choose to lean into it,
 and deliberately architect their games to drive important gameplay parameters via assets to ease development and modding.
@@ -96,7 +96,7 @@ use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
 
 /// A strongly typed identifier for an object that can be stored in a manifest
-#[derive(Component, Reflect, Serialize, Deserialize)]
+#[derive(Component, Hash, PartialEq, Eq, Reflect, Serialize, Deserialize)]
 pub struct Id<T> {
     value: u64,
     #[reflect(ignore)]
@@ -118,7 +118,7 @@ Because our manifests are asset files, you can take advantage of hot-reloading t
 As your data becomes more complex, your approach should become more sophisticated: break the process into multiple steps to resolve cross-object references, add error handling, and so on.
 
 While this workflow can be powerful and convenient, this pattern is not right for every project.
-There's non-trivial setup work, significant indirection, and you cannot capture arbitrarily complex gameplay logic in data.
+There's nontrivial setup work, significant indirection, and you cannot capture arbitrarily complex gameplay logic in data.
 This pattern is best suited to games that have a large amount of structured gameplay data that needs tuning:
 it would work well for something like an ARPG, but poorly for a walking simulator.
 

--- a/content/learn/book/development-practices/testing.md
+++ b/content/learn/book/development-practices/testing.md
@@ -135,7 +135,7 @@ To test that our game logic is working, we need to set up some world state and t
 The tools below are presented in order of increasing realism and complexity.
 You can mix-and-match, but you should prefer simpler methods wherever possible.
 
-### The Best ECS Is no ECS
+### The Best ECS Is No ECS
 
 Just because your data lives inside of the ECS doesn't mean that you need to use the ECS in your tests.
 This is an obvious insight, but surprisingly easy to overlook.

--- a/content/learn/book/development-practices/testing.md
+++ b/content/learn/book/development-practices/testing.md
@@ -72,7 +72,7 @@ Simply compiling the code is often good enough.
 Doc tests serve three purposes:
 
 1. Teaching the reader about the intended usage of the API.
-2. Serving as a canary for when code changes cause your documentation to go out of date.
+2. Serving as a canary for when code changes cause your documentation to go out-of-date.
 3. Acting as quick unit tests to assert invariants.
 
 Unsurprisingly, these are extremely useful for teaching users about libraries!
@@ -89,7 +89,7 @@ Save doc tests for teaching about usage and important invariants, and use unit t
 
 ## Integration Tests
 
-Integration tests are used to ensure that all of the parts of your project fit together and produce a desired end result.
+Integration tests are used to ensure that all parts of your project fit together and produce a desired end result.
 
 In Rust, integration tests are conventionally written by creating a `.rs` file with `#[test]` functions inside of your project's `tests` folder.
 Unlike unit tests, these tests can only access your crate's public API.
@@ -98,18 +98,18 @@ For games specifically, integration tests present some serious problems:
 
 1. Most games require graphics to run, and will simply panic uninformatively if this fails. Most CI providers do not offer GPUs or monitors.
 2. Most games require user input to advance.
-3. Failure conditions can be subtle, often involving human judgement or visual processing, and rigidly encoding desired states can lead to fragile tests that need to be constantly rewritten.
+3. Failure conditions can be subtle, often involving human judgment or visual processing, and rigidly encoding desired states can lead to fragile tests that need to be constantly rewritten.
 
 On small teams, these hurdles often aren't worth overcoming — unit tests and manual testing may be all you need.
 
-## Speeding Up Manual Testing
+## Speeding up Manual Testing
 
 Regardless of the complexity of your automated testing, you should be regularly testing your project by hand to catch unexpected bugs and judge it as a whole.
 
 You will be doing this a *lot*, so you should take the time to make this process both fast and painless.
 Take advantage of existing developer tools, make your own, and make it easy to jump to problematic game states.
 
-You should create a dedicated `devtools` feature flag for your application (and enable it by default) which will turn on all of the testing and debugging utilities that your project might need.
+You should create a dedicated `devtools` feature flag for your application (and enable it by default) which will turn on all testing and debugging utilities that your project might need.
 Reproducing tricky bugs can be incredibly time-consuming; you don't want to have to recompile your game to turn on these tools.
 Then when you are [building for release](@/learn/book/releasing-projects/release-builds.md), turn your `devtools` feature flag off.
 
@@ -127,7 +127,7 @@ Save games don't have nice compiler errors, and automatically upgrading them is 
 
 [`run_once`]: https://docs.rs/bevy/latest/bevy/ecs/schedule/common_conditions/fn.run_once.html
 
-## Testing With The ECS
+## Testing with the ECS
 
 When testing Bevy applications in a more integrated way, most of what we care about lives in the ECS.
 To test that our game logic is working, we need to set up some world state and then assert something about it.
@@ -135,7 +135,7 @@ To test that our game logic is working, we need to set up some world state and t
 The tools below are presented in order of increasing realism and complexity.
 You can mix-and-match, but you should prefer simpler methods wherever possible.
 
-### The Best ECS Is No ECS
+### The Best ECS Is no ECS
 
 Just because your data lives inside of the ECS doesn't mean that you need to use the ECS in your tests.
 This is an obvious insight, but surprisingly easy to overlook.
@@ -178,7 +178,7 @@ If the function you are testing doesn't need a `World`, neither does your test.
 [`World`]: https://docs.rs/bevy/latest/bevy/ecs/world/struct.World.html
 [`App`]: https://docs.rs/bevy/latest/bevy/app/struct.App.html
 
-### Testing Using A Raw `World`
+### Testing Using a Raw `World`
 
 When you need to test helper functions that set up entities or resources, you can create a [`World`] directly and make assertions against it.
 
@@ -347,7 +347,7 @@ Failures can be caused by completely unrelated code, and refactors commonly move
 Treat this approach like lightweight integration testing; it can ensure that everything fits together as expected, but it will also be a hassle to maintain.
 Save them for critical game logic, and think carefully about your assertions to avoid breakage due to irrelevant changes.
 
-#### Running To Completion
+#### Running to Completion
 
 Sometimes you don't care *when* something happens, only *that* it happens.
 A level loads, an animation finishes, a character dies, etc.
@@ -396,7 +396,7 @@ These problems are tightly coupled: operating at the level of pixels, coordinate
 You should prefer:
 
 1. Sending the highest level user input possible. Prefer actions over inputs, manipulate state rather than going through intermediates.
-2. Locating objects to interact with by querying for them, rather than using hot keys or simulated positional mouse clicks.
+2. Locating objects to interact with by querying for them, rather than using hot-keys or simulated positional mouse clicks.
 3. Determining application state by polling the underlying data directly.
 4. Deciding on whether or not to proceed by polling to see if the state has changed (with a timeout).
 
@@ -571,10 +571,10 @@ sudo apt-get install xvfb
 xvfb-run cargo run --example my_example --features bevy_ci_testing
 ```
 
-#### Self-hosted Runners
+#### Self-Hosted Runners
 
 Software renderers work, but they're slow and don't behave identically to real GPUs.
-Hosting your own CI runners on machines with actual graphics hardware is more common in gamedev than in other parts of software development.
+Hosting your own CI runners on machines with actual graphics hardware is more common in game dev than in other parts of software development.
 A desktop with a mid-range GPU under a desk is enough to run graphical tests on real hardware, and the results will be far more representative of what your players actually see.
 
 Both [GitHub Actions] and [GitLab CI] support self-hosted runners.
@@ -653,12 +653,12 @@ Simply calling public APIs has three problems:
 2. They are not trained on these tasks, and may struggle to identify the objects you care about or cope with your artistic style.
 3. They may change out from underneath you, as a new version of the model rolls out.
 
-Training your own model to do this (probably via finetuning) may seem appealing, but is not for the faint of heart.
+Training your own model to do this (probably via fine-tuning) may seem appealing, but is not for the faint of heart.
 There are a huge number of potential failure modes: your style and features are a moving target, false positives are frustrating time-sinks, the investment in both expertise and hardware needed to do this well is quite large, etc.
 
 Like always, keep your testing as simple as possible.
 
-#### Know When To Test Logic Instead
+#### Know When to Test Logic Instead
 
 Before investing in graphical testing infrastructure, ask yourself: **can this be tested without looking at pixels?**
 

--- a/content/learn/book/intro/apps-worlds.md
+++ b/content/learn/book/intro/apps-worlds.md
@@ -42,4 +42,4 @@ Apps can be used to combine code that's been broken down into modular, reusable 
 With that, you should have everything you need to start [exploring our examples](https://github.com/bevyengine/bevy/tree/latest/examples#examples),
 or diving into the rest of the book.
 
-The remaining chapters of this book are non-linear: you can read or reference them in any order.
+The remaining chapters of this book are nonlinear: you can read or reference them in any order.

--- a/content/learn/book/intro/the-next-three-letters.md
+++ b/content/learn/book/intro/the-next-three-letters.md
@@ -6,7 +6,7 @@ weight = 4
 status = 'hidden'
 +++
 
-If Entities, Components and Systems are the first three concepts, then **Resources**, **Queries**, and **Commands** are the next three.
+If Entities, Components, and Systems are the first three concepts, then **Resources**, **Queries**, and **Commands** are the next three.
 These concepts are core to Bevy's ECS (so much so that they're used in the previous section!), but they aren't inherent to the architecture.
 
 ## Resources
@@ -72,7 +72,7 @@ Then, when systems are run as part of a Bevy [app](@/learn/book/the-game-loop/ap
 ```rs
 fn main() {
     App::new()
-        .add_systems(Update, (my_system, my_other_system))
+        .add_systems(Update, (apply_poison, tick_down_poison))
         .run();
 }
 ```

--- a/content/learn/book/intro/the-three-letters.md
+++ b/content/learn/book/intro/the-three-letters.md
@@ -97,7 +97,7 @@ These can fetch data from the ECS, make updates, call external APIs, and anythin
 
 ```rs
 // No derive macro needed!
-fn my_system(entities: Query<&mut Location>) {
+fn my_system(mut entities: Query<&mut Location>) {
     for location in entities.iter_mut() {
         location.x += 1;
     }

--- a/content/learn/book/is-bevy-right-for-your-project/_index.md
+++ b/content/learn/book/is-bevy-right-for-your-project/_index.md
@@ -44,7 +44,7 @@ We love Bevy, but it's not the right tool for every project. You should not use 
   - Bevy does not currently have a graphical editor.
 - _You want scripting language support out-of-the-box:_
   - Unlike other game engines, gameplay logic is written in the same language (and style) as engine logic.
-  - That said, it is possible. Bevy and Rust provide the tools needed to integrate Lua, Python and more.
+  - That said, it is possible. Bevy and Rust provide the tools needed to integrate Lua, Python, and more.
   - Take a look at [Bevy Assets](https://bevy.org/assets) to see the options that the community has provided.
 - _You want to ship to consoles:_
   - Rust (and therefore Bevy) is currently not supported on Sony or Nintendo consoles.

--- a/content/learn/book/modular-architecture/plugins.md
+++ b/content/learn/book/modular-architecture/plugins.md
@@ -12,7 +12,7 @@ and reuse functionality between projects.
 Plugins are best used to organize your code into functional units:
 `WorldGenPlugin`, `InventoryPlugin` or `AudioPlugin` are all plausible.
 Inside of each plugin, you can initialize resources,
-add systems, setup observers, register types and generally handle the setup needed
+add systems, set up observers, register types and generally handle the setup needed
 to make your subsystem function.
 Once all of this setup is complete, a plugin's job is done:
 vanishing into thin air as the systems and resources it added live on to carry out its job.
@@ -28,12 +28,12 @@ trait Plugin {
 
 Let's break that down:
 
-- this is a trait, so we need to implement it for a user-defined type
+- This is a trait, so we need to implement it for a user-defined type.
 - `build` takes `&self`, allowing you to change the behavior based on the value.
-- it takes a `&mut App` reference, allowing you to mutate the [`App`] state freely
-  - adding systems via [`App::add_systems`] is the most common and important method
-  - as discussed in our section on [apps], [`App`] holds a [`World`], allowing you to add resources, make queries, spawn entities and more
-- because of how simple this is, we can just cut-and-paste code from our `main.rs` into plugins when we're ready to clean up
+- It takes a `&mut App` reference, allowing you to mutate the [`App`] state freely.
+  - Adding systems via [`App::add_systems`] is the most common and important method.
+  - As discussed in our section on [apps], [`App`] holds a [`World`], allowing you to add resources, make queries, spawn entities and more.
+- Because of how simple this is, we can just cut-and-paste code from our `main.rs` into plugins when we're ready to clean up
 
 Let's see how this works in practice:
 
@@ -75,7 +75,7 @@ extra features in the future.
 
 [`Plugin`]: https://docs.rs/bevy/latest/bevy/app/trait.Plugin.html
 
-## Configuring plugins
+## Configuring Plugins
 
 As alluded to above, you can use the `&self` argument in [`Plugin::build`] to change
 the behavior of the plugin based on the passed in configuration.
@@ -99,7 +99,7 @@ is the best and only option.
 
 [`Plugin::build`]: https://docs.rs/bevy/latest/bevy/app/trait.Plugin.html#tymethod.build
 
-## Plugin groups
+## Plugin Groups
 
 You may have noticed that [`App::add_plugins`] is a method that takes `&mut App`.
 Does that mean you can add plugins via other plugins?
@@ -121,7 +121,7 @@ You've likely already encountered these: [`DefaultPlugins`] is a [`PluginGroup`]
 2. You can overwrite the values of contained plugins via [`PluginGroup::set`], changing the default config.
 3. With the help of [`PluginGroupBuilder`] you can enable and disable contained plugins cleanly.
 
-## Plugin ordering and dependencies
+## Plugin Ordering and Dependencies
 
 When working with multiple plugins, be mindful that they're effectively just functions that immediately mutate the [`App`].
 As a result, plugins are [evaluated in the order that they are added to the `App`].
@@ -137,12 +137,12 @@ This behavior can be overridden by overwriting the default [`Plugin::is_unique`]
 The same duck-typing solution can be used to check if the plugin already exists,
 and avoid re-adding it if another dependency has already pulled it in.
 
-## The `Plugin` lifecycle
+## The `Plugin` Life Cycle
 
 When a plugin is added though [`App::add_plugins`], the app calls `Plugin::build`, and the plugin typically accesses and configures the world.  
 Then, when the app is run, a few other plugin life-cycle functions are called, and finally we enter the run loop:
 
-- The app polls `Plugin::finished` until all the added plugins return `true`.
+- The app polls `Plugin::ready` until all the added plugins return `true`.
 - The app calls `Plugin::finish` on all plugins.
 - The app calls `Plugin::cleanup` an all plugins.
 - The app calls the run loop function on itself.

--- a/content/learn/book/modular-architecture/project-organization.md
+++ b/content/learn/book/modular-architecture/project-organization.md
@@ -10,18 +10,18 @@ But how should you split it apart, and what are your tools for doing so?
 
 Thankfully, the Bevy community has answers to these questions:
 
-- split your code based on the "domain" it covers
-  - think about where you might want to reuse, or selectively disable bits of functionality
-  - code that changes together should live together
-  - don't try to group together objects by "kind", like "components" and "systems"
-- don't try to get it right from the very start
-  - split things up gradually, as areas become complex and unwieldy
-  - you'll have a much better idea of the shape of your program then
-  - and it stops you from wasting time at the start of your project
-- take advantage of Rust's modules, crates and visibility to organize your code
-  - be mindful of [orphan rules] when architecting multi-crate projects
-- one [plugin] per module, and one plugin per crate (which may nest multiple plugins) is a good default
-  - placing these at the top of your files can act as a simple, consistent "table of contents"
+- Split your code based on the "domain" it covers.
+  - Think about where you might want to reuse, or selectively disable bits of functionality.
+  - Code that changes together should live together.
+  - Don't try to group together objects by "kind", like "components" and "systems".
+- Don't try to get it right from the very start.
+  - Split things up gradually, as areas become complex and unwieldy.
+  - You'll have a much better idea of the shape of your program then.
+  - And it stops you from wasting time at the start of your project.
+- Take advantage of Rust's modules, crates, and visibility to organize your code.
+  - Be mindful of [orphan rules] when architecting multi-crate projects.
+- One [plugin] per module, and one plugin per crate (which may nest multiple plugins) is a good default.
+  - Placing these at the top of your files can act as a simple, consistent "table of contents".
 
 [orphan rules]: https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules
 [plugin]: @/learn/book/modular-architecture/plugins.md
@@ -83,16 +83,16 @@ You might even be the only person on your team!
 And that's largely right: game programming often warrants a more fluid, permissive approach.
 But there's still a few good reasons to take advantage of Rust's visibility system:
 
-- carefully maintaining invariants
-  - simple validated getter/setter patterns are very effective
-  - more complex patterns can often benefit from custom commands or system params to ensure a single blessed workflow
-  - clean encapsulation ensures that you can update how something works in a single place
-- dead code detection
-  - if your types/methods/functions are `pub`, Rust won't know if they're dead code
-  - dead code slows down compile times, confuses the reader and slowly rots
-- keeping your code *reasonably* untangled
-  - iterating quickly is important, and Rust will help you refactor, so you should be careful not to get too tangled up
-  - forcing consumers to do things the right way makes it easier to change the internals later
+- Carefully maintaining invariants.
+  - Simple validated getter/setter patterns are very effective.
+  - More complex patterns can often benefit from custom commands or system parameters to ensure a single blessed workflow.
+  - Clean encapsulation ensures that you can update how something works in a single place.
+- Dead code detection.
+  - If your types/methods/functions are `pub`, Rust won't know if they're dead code.
+  - Dead code slows down compile times, confuses the reader and slowly rots.
+- Keeping your code *reasonably* untangled.
+  - Iterating quickly is important, and Rust will help you refactor, so you should be careful not to get too tangled up.
+  - Forcing consumers to do things the right way makes it easier to change the internals later.
 
 At the end of the day, `pub(crate)` is a good default visibility level for items in larger projects.
 Internal methods, invariants, and implementation details should be private, which is the Rust language default behavior.
@@ -105,7 +105,7 @@ skip the getter/setter methods unless you're performing validation.
 
 [visibility]: https://doc.rust-lang.org/reference/visibility-and-privacy.html
 
-## Project organization by example
+## Project Organization by Example
 
 Now that we have a handle on the tools available, let's talk over how a hypothetical project might change and grow.
 Our small studio is building a Wild West single player first-person shooter!
@@ -138,7 +138,7 @@ Our project now looks like this:
 
 With a bit of basic gameplay working, it's time to tackle some infrastructure that we know we'll need: menus and loading screens.
 We look at what we've done in previous projects and copy-paste liberally into a new `ui` folder, with multiple sub-files.
-We setup a basic `GameState` here, to allow us to pause and restart the game and handle opening and closing menus,
+We set up a basic `GameState` here, to allow us to pause and restart the game and handle opening and closing menus,
 sticking it in our `main.rs` because it's used throughout the project.
 Now, our project looks like this:
 
@@ -250,7 +250,7 @@ Now:
 
 Ugh, the compile times are really starting to slow down, and things are getting complicated.
 Let's refactor this to be a workspace.
-One step at a time though: get the simple setup right first, then we'll spin out subcrates.
+One step at a time though: get the simple setup right first, then we'll spin out sub-crates.
 We're just going to create a binary application and a single library,
 and dump everything but our main.rs contents into the library, which we'll depend on in our binary.
 

--- a/content/learn/book/releasing-projects/compiling-less-code.md
+++ b/content/learn/book/releasing-projects/compiling-less-code.md
@@ -6,7 +6,7 @@ weight = 2
 +++
 
 As a game engine, Bevy offers a wide variety of functionality out-of-the-box.
-It's unlikely that your project will take advantage of all of the features at the same time though.
+It's unlikely that your project will take advantage of every feature at the same time though.
 Keeping every feature enabled will result in increased compilation times and a bloated project binary size.
 However, each project might require a different combination of features.
 
@@ -102,7 +102,7 @@ Features in Rust are _additive_.
 This means that if any crate in your tree enables a feature,
 it will be enabled for all users of the crate.
 
-Be warned that ecosystem crates, or `bevy`'s own subcrates, may enable various features of subcrates.
+Be warned that ecosystem crates, or `bevy`'s own sub-crates, may enable various features of subcrates.
 Simply not enabling them yourself is insufficient.
 
 You can check which features are enabled using `cargo tree -f {p} {f}`.
@@ -114,7 +114,7 @@ or by gating some of their functionality behind feature flags of their own.
 
 {% end %}
 
-## Looking For Duplicate Crates
+## Looking for Duplicate Crates
 
 Unlike in other languages, Rust projects can have multiple different versions of the same dependency.
 This makes it much easier to have complex dependency trees, but can pointlessly bloat both binary size and compilation time.
@@ -158,7 +158,7 @@ These costs scale substantially the more you diverge from upstream, especially i
 As a result, we recommend:
 
 1. Only forking during the final stages of a project's lifecycle, once you are no longer updating Bevy versions.
-2. Only maintaining forks for particularly heavy dependencies, or for critical bug fixes.
+2. Only maintaining forks for particularly heavy dependencies, or for critical bugfixes.
 3. Minimizing divergence from upstream unless there is a good reason to do so.
 4. Committing your `Cargo.lock` file, and carefully testing any updates or upstream changes.
 

--- a/content/learn/book/releasing-projects/libraries-for-bevy.md
+++ b/content/learn/book/releasing-projects/libraries-for-bevy.md
@@ -13,9 +13,9 @@ but can also pay dividends as contributors help you refine and polish the crate 
 This chapter covers some best practices for creating open source libraries with Bevy.
 Most of these sections will *also* apply if you're splitting your work apart for reuse between projects!
 
-## Setting up your crate
+## Setting up Your Crate
 
-### Naming your crate
+### Naming Your Crate
 
 Names are famously one of the hardest problems in computer science,
 and crates are no exception to this.
@@ -23,7 +23,7 @@ and crates are no exception to this.
 When considering a name for your crate, we recommend that you:
 
 - **Always use `_` rather than `-`.** This keeps the crate name consistent with how users import it.
-- **Pick a name which communicates what your crate does** in a somewhat unique way.
+- **Pick a name which communicates what your crate does** in a somewhat special way.
 - **Avoid confusion with potential official Bevy crates.** `crates.io` does not have namespaces currently, and `bevy_color` and `bevy_colour` are easy to confuse.
 - **Consider choosing a "branding" name** for your family of crates (e.g. `leafwing`). This can unify your projects without cluttering the main crate namespace.
 
@@ -62,15 +62,15 @@ as this will seriously hinder the adoption of your work and the contributions ma
 When making a crate that relies on Bevy, there are two strategies:
 
 - **Rely on `bevy` directly.** Simple to set up and update, and easy to patch if the user wants to point to their own fork or `bevy/main`.
-- **Rely on Bevy subcrates**, like `bevy_ecs` and `bevy_input`. Works for projects that don't rely on `bevy` itself, and enables faster compilation: your crate can compile before `bevy` itself finishes.
+- **Rely on Bevy sub-crates**, like `bevy_ecs` and `bevy_input`. Works for projects that don't rely on `bevy` itself, and enables faster compilation: your crate can compile before `bevy` itself finishes.
 
-We recommend subcrates, primarily for the compile-time benefits.
+We recommend sub-crates, primarily for the compile-time benefits.
 
 Regardless of your choice, you should *always* specify `default-features = false` in your `Cargo.toml`.
 This ensures that your crate does not pull in unneeded code.
 Remember: features can only be enabled, not disabled in Rust.
 
-## Polishing your crate
+## Polishing Your Crate
 
 ### Idiomatic Bevy and Rust
 
@@ -78,7 +78,7 @@ Users of your crate will expect it to feel like a natural extension of Bevy.
 A few conventions go a long way:
 
 - **Expose a plugin.** The standard entry point for a Bevy library is a [`Plugin`](https://docs.rs/bevy/latest/bevy/app/trait.Plugin.html). Even if your crate is simple, wrapping your setup logic in a plugin gives users a consistent, predictable way to integrate it: `app.add_plugins(YourPlugin)`.
-- **Use the ECS where it makes sense.** Bevy users expect their crates to use components, resources, events and messages. Structuring your crate to use them makes it easier to extend, modify and inspect.
+- **Use the ECS where it makes sense.** Bevy users expect their crates to use components, resources, events, and messages. Structuring your crate to use them makes it easier to extend, modify and inspect.
 - **Don't panic.** Library code should almost never crash. Program defensively, and return `Result` when something goes wrong. Log an error or warning if there's nowhere to return. Reserve panics exclusively for upholding soundness invariants. Read more about [handling errors here](@/learn/book/control-flow/handling-errors.md).
 - **Follow Rust API guidelines.** The [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/) are a great reference for naming, documentation, and API design.
 - **Use feature flags to make expensive or niche functionality opt-in.** If your crate has optional integrations (e.g. serialization, debug tooling, support for specific Bevy subsystems), gate them behind [Cargo features](https://doc.rust-lang.org/cargo/reference/features.html) rather than pulling everything in by default. This keeps compile times down and avoids forcing unwanted dependencies on your users. A few guidelines:
@@ -86,7 +86,7 @@ A few conventions go a long way:
   - Keep your default features minimal.
   - Document your features in your `Cargo.toml` using comments above each feature.
 - **Consider `no_std` support.** If your crate is primarily logic — math, data structures, ECS patterns — it may not need the standard library at all. This makes your crate usable in more environments, including embedded platforms and WebAssembly without a full runtime.
-  - This is easiest to set up at the start of a project; retrofitting it later is harder but not impossible.
+  - This is easiest to set up at the start of a project; retrofitting it later is harder but isn't impossible.
   - Add `#![no_std]` to your `lib.rs`, with a `std` feature flag to enable anything that requires it
   - In the majority of cases, you can just use `core` or `alloc` directly instead
   - Confirm that your dependencies work without `std` by compiling to a target that does not have `std` (such as `wasm32v1-none`).
@@ -94,7 +94,7 @@ A few conventions go a long way:
 
 [`no_std` example]: https://github.com/bevyengine/bevy/tree/latest/examples/no_std/library
 
-### Minimizing dependencies
+### Minimizing Dependencies
 
 You should try to keep your dependency tree lean.
 Every dependency you add is a dependency your users inherit, and one that you need to regularly update.
@@ -144,12 +144,12 @@ name = "basic_usage"
 path = "examples/basic_usage.rs"
 ```
 
-While you should always rely on Bevy or its subcrates using `default-features=false`,
+While you should always rely on Bevy or its sub-crates using `default-features=false`,
 it's common to need access to more features to create an interactive example.
 You can depend on `bevy` as a `dev-dependency` using whatever features you need,
 and get the best of both worlds.
 
-### Automated quality control
+### Automated Quality Control
 
 Set up CI early. A basic GitHub Actions workflow can catch issues before they reach your users and makes accepting contributions much easier.
 
@@ -195,14 +195,14 @@ We have a few additional setup suggestions:
 Take a look at our chapter on [Testing](@/learn/book/development-practices/testing.md):
 this advice is particularly useful for library authors.
 
-### Configuring Github repo settings
+### Configuring GitHub Repo Settings
 
 There are a few things we recommend configuring for every new public open source project:
 
 - **Protect your main branch.** Require PRs to pass CI before merging. This keeps contributors from accidentally breaking things, and lets you review changes before they land. On GitHub, configure this under Settings → Branches → Branch protection rules.
 - **Use squash-and-merge.** Squashing PR commits into a single commit keeps your main branch history clean and readable. Each merge becomes one self-contained entry in `git log`, which makes changelogs, bisecting, and reverts much simpler. You can set this as the default (or only) merge strategy in your GitHub repository settings.
 
-## Sharing your crate
+## Sharing Your Crate
 
 ### Publishing
 
@@ -231,7 +231,7 @@ cargo publish
 
 Use [semantic versioning](https://semver.org/) for your releases. For pre-1.0 crates (which most Bevy ecosystem crates are), a bump to the minor version (`0.1.0` → `0.2.0`) signals breaking changes, while a patch bump (`0.1.0` → `0.1.1`) signals backwards-compatible fixes.
 
-### Promoting your crate
+### Promoting Your Crate
 
 If you went to the effort of making and publishing a crate, you probably want people to use it.
 Getting your crate in front of users:
@@ -244,9 +244,9 @@ Getting your crate in front of users:
 Make sure that your README, crate docs and your posts on social media clearly explain what your work is and why someone might want to use it.
 Don't underestimate the value of a pretty screenshot or GIF — polish is a strong indicator of a maintainer who's put the time in to make something worth using.
 
-## Maintaining your crate
+## Maintaining Your Crate
 
-### Keeping up with Bevy versions
+### Keeping up with Bevy Versions
 
 The major version of Bevy that your crate uses must match the Bevy version that your users are on.
 As a result, users expect ecosystem crates to track Bevy releases actively.
@@ -268,7 +268,7 @@ This can be a fair bit of work, but there are a few practices that help:
 - **Work with your community to update.** Active crates often get PRs from users eager to update versions. Work with them to polish the migration and spread the load.
 - **Use the [Bevy migration guides](https://bevy.org/learn/migration-guides/).** These are the primary resource for updating your code.
 
-### Managing contributions
+### Managing Contributions
 
 If your crate gains traction, people will want to contribute.
 You want to empower users to scratch their own itch, not stand in their way.
@@ -289,7 +289,7 @@ Here are our most important tips on being a good open source maintainer:
 - **Encourage reviews from the community.** Your users and contributors have useful perspectives on potential changes. You should welcome their interest and expertise. Bevy does this to great effect!
 - **Ask for help when you need it.** Maintaining an open source crate can be overwhelming, especially alone. The Bevy community is friendly and experienced — don't hesitate to ask for advice, reviews, or help in the [Bevy Discord](https://discord.gg/bevy). If you're struggling with maintainer burnout, it's okay to say so and ask for volunteers to step up.
 
-### Keeping a changelog
+### Keeping a Changelog
 
 As your crate evolves, help your users keep up.
 
@@ -308,7 +308,7 @@ As your crate evolves, help your users keep up.
 
 - **Tag releases in git** and use GitHub Releases (or your host's equivalent) to publish release notes alongside the tag. This gives users a natural place to find what changed.
 
-### Offering support
+### Offering Support
 
 As your user base grows, people will ask for help using your crate.
 You should not feel compelled to do so (you're almost certainly not getting paid for this),

--- a/content/learn/book/releasing-projects/profiling.md
+++ b/content/learn/book/releasing-projects/profiling.md
@@ -27,7 +27,7 @@ Bevy has built-in [tracing](https://github.com/tokio-rs/tracing) spans to make i
 Enable the `trace` cargo feature to enable Bevy's built-in spans.
 
 If you want to include `wgpu` tracing spans when profiling, they are emitted at the `tracing` `info` level.
-You will need to make sure they are not filtered out by the `LogSettings` resource's `filter` member which defaults to `wgpu=error`.
+You will need to make sure they are not filtered out by the [`LogPlugin`]'s `filter` member which defaults to `wgpu=error`.
 This can be done by setting the `RUST_LOG=info` environment variable when running your application.
 
 You also need to select a `tracing` backend using one of the cargo features described in the below sections.
@@ -41,6 +41,8 @@ You can find more details in the docs for [`prepare_windows`](https://docs.rs/be
 {% end %}
 
 ![prepare_windows span bug](https://github.com/bevyengine/bevy/assets/2771466/15c0819b-0e07-4665-aa1e-579caa24fece)
+
+[`LogPlugin`]: https://docs.rs/bevy/latest/bevy/log/struct.LogPlugin.html
 
 ### Adding Your Own Spans
 
@@ -98,7 +100,7 @@ If you also want to track memory allocations, at the cost of increased runtime o
 After running your app, you can open the captured profile file (`my_capture.tracy` in the example above) in the Tracy GUI application to see a timeline of the executed spans.
 
 Alternatively, directly run the tracy GUI and then run your application, for live capture.
-However, beware that running the live capture on the same machine will be a competing graphical application, which may impact results. Pre-recording the profile data through the CLI tool is recommended for more accurate traces.
+However, beware that running the live capture on the same machine will be a competing graphical application, which may impact results. Prerecording the profile data through the CLI tool is recommended for more accurate traces.
 
 In any case, you'll see your trace in the GUI window:
 
@@ -139,7 +141,7 @@ It will look something like this:
 
 This approach requires no extra instrumentation and shows finer-grained flame graphs of actual code call trees.
 This is useful when you want to identify the specific function of a "hot spot".
-The downside is that it has higher overhead, so your app will run slower than it normally does.
+The downside is that it will have a higher overhead, so your app will run slower than it normally does.
 
 Install [cargo-flamegraph](https://github.com/flamegraph-rs/flamegraph), [enable debug symbols in your release build](https://github.com/flamegraph-rs/flamegraph#improving-output-when-running-with---release), then run your app using one of the following commands.
 Note that `cargo-flamegraph` forwards arguments to cargo.
@@ -182,7 +184,7 @@ Note that while RenderDoc is a great debugging tool, it is _not_ a profiler, and
 #### Xcode's Metal Debugger
 
 Follow the steps below to start GPU debugging on macOS.
-There is no need to create an Xcode project.
+There is no need to create a Xcode project.
 
 1. In the menu bar click on Debug > Debug Executable…
 

--- a/content/learn/book/releasing-projects/profiling.md
+++ b/content/learn/book/releasing-projects/profiling.md
@@ -184,7 +184,7 @@ Note that while RenderDoc is a great debugging tool, it is _not_ a profiler, and
 #### Xcode's Metal Debugger
 
 Follow the steps below to start GPU debugging on macOS.
-There is no need to create a Xcode project.
+There is no need to create an Xcode project.
 
 1. In the menu bar click on Debug > Debug Executable…
 

--- a/content/learn/book/releasing-projects/release-builds.md
+++ b/content/learn/book/releasing-projects/release-builds.md
@@ -6,7 +6,7 @@ weight = 0
 +++
 
 During compilation, the Rust compiler can make a number of different choices,
-trading off debuggability and compile times against final binary size and performance.
+trading off debugging capabilities and compile times against final binary size and performance.
 
 There are a number of important settings we can experiment with here.
 Compilation settings are recorded in your root `Cargo.toml` file, and should be grouped into [profiles](https://doc.rust-lang.org/cargo/reference/profiles.html) designed for different tasks.
@@ -87,7 +87,7 @@ Modifying this setting will slow down compilation.
 
 Similarly, we can eliminate intra-crate parallelism during compilation by setting `codegen-units = 1`.
 Spreading crate compilation across multiple codegen units speeds up compilation at the cost of increased
-build size and lost optimisation opportunities.
+build size and lost optimization opportunities.
 
 Modifying this setting will slow down compilation.
 

--- a/content/learn/book/storing-data/entities-components.md
+++ b/content/learn/book/storing-data/entities-components.md
@@ -6,7 +6,7 @@ weight = 1
 status = 'hidden'
 +++
 
-**Entities** are the fundamental objects of your game world, whizing around, storing cameras, being controlled by the player or tracking the state of a button.
+**Entities** are the fundamental objects of your game world, whizzing around, storing cameras, being controlled by the player or tracking the state of a button.
 On its own, the [`Entity`] type is a simple identifier: it has neither behavior nor data.
 Components store this data, and define the overlapping categories that the entity belongs to.
 

--- a/content/learn/book/storing-data/entities-components.md
+++ b/content/learn/book/storing-data/entities-components.md
@@ -6,7 +6,7 @@ weight = 1
 status = 'hidden'
 +++
 
-**Entities** are the fundamental objects of your game world, moving around, storing cameras, being controlled by the player or tracking the state of a button.
+**Entities** are the fundamental objects of your game world, whizing around, storing cameras, being controlled by the player or tracking the state of a button.
 On its own, the [`Entity`] type is a simple identifier: it has neither behavior nor data.
 Components store this data, and define the overlapping categories that the entity belongs to.
 

--- a/content/learn/book/storing-data/entities-components.md
+++ b/content/learn/book/storing-data/entities-components.md
@@ -6,12 +6,12 @@ weight = 1
 status = 'hidden'
 +++
 
-**Entities** are the fundamental objects of your game world, whizzing around, storing cameras, being controlled by the player or tracking the state of a button.
+**Entities** are the fundamental objects of your game world, moving around, storing cameras, being controlled by the player or tracking the state of a button.
 On its own, the [`Entity`] type is a simple identifier: it has neither behavior nor data.
 Components store this data, and define the overlapping categories that the entity belongs to.
 
 Informally, we use the term "entity" to refer to a single conceptual entry in our [world].
-An "entity" is made up of all component data with the correct identifier, although it's very rare to use all of the data for a single entity at once.
+An "entity" is made up of all component data with the correct identifier, although it's very rare to use all the data for a single entity at once.
 If you're an experienced programmer, you can reason about the [world] as something like a (very fast) [`HashMap`] that links an [`Entity`] identifier to a collection of components.
 
 Internally, [`Entity`] is roughly shaped like a `u64`, with arbitrary (unique) bits.
@@ -34,7 +34,7 @@ However, the advantage of this approach is the ability to perform massive bulk o
 ## Spawning and Despawning Entities
 
 Before you can do much of anything in Bevy, you'll need to **spawn** your first entity by adding it to the app's [`World`].
-Once entities exist, they can likewise be despawned, deleting all of the data stored in their components and removing it from the world.
+Once entities exist, they can likewise be despawned, deleting all data stored in their components and removing it from the world.
 
 Spawning and despawning entities can have far-reaching effects, and so cannot be done immediately (unless you are using an [exclusive system]).
 As a result, we must use [`Commands`], which queue up work to do later.
@@ -57,7 +57,7 @@ fn spawning_system(mut commands: Commands){
 [`World`]: https://docs.rs/bevy/latest/bevy/ecs/world/struct.World.html
 [`Commands`]: https://docs.rs/bevy/latest/bevy/ecs/system/struct.Commands.html
 
-## Working With Components
+## Working with Components
 
 As mentioned in the [introduction section on components], a **Component** is a small, modular, reusable piece of data that can be attached to an entity.
 Components are necessary to make individual entities useful.
@@ -113,7 +113,7 @@ enum Allegiance {
 
 [`Component`]: https://docs.rs/bevy/latest/bevy/ecs/component/trait.Component.html
 
-### Spawning Entities With Components
+### Spawning Entities with Components
 
 Now that we have some components defined, let's try adding them to our entities using [`Commands`].
 
@@ -186,7 +186,7 @@ struct InCombat;
 // that have the `Combatant` component but do not yet have the `InCombat` component
 fn start_combat_system(query: Query<Entity, (With<Combatant>, Without<InCombat>)>, mut commands: Commands){
     for entity in query.iter() {
-        // The component will be inserted at the end of the current stage
+        // The component will be inserted once the command is run.
         commands.entity(entity).insert(InCombat);
     }
 }
@@ -194,7 +194,7 @@ fn start_combat_system(query: Query<Entity, (With<Combatant>, Without<InCombat>)
 // Now to undo our hard work
 fn end_combat_system(query: Query<Entity, (With<Combatant>, With<InCombat>)>, mut commands: Commands){
     for entity in query.iter() {
-        // The component will be removed at the end of the current stage
+        // The component will be removed once the command is run.
         // It is provided as a type parameter,
         // as we do not need to know a specific value in order to remove a component of the correct type
         commands.entity(entity).remove::<InCombat>();

--- a/content/learn/book/storing-data/local-system-param.md
+++ b/content/learn/book/storing-data/local-system-param.md
@@ -16,14 +16,14 @@ However, from time to time, you might want to:
 - Maintain a cache of intermediate results to improve efficiency of computation.
 - Avoid allocating a new large data structure each frame.
 
-Bevy itself uses `Local` system params in two prominent places:
+Bevy itself uses `Local` system parameters in two prominent places:
 
 1. As part of the [`MessageReader`] abstraction, keeping track of which events each system has read.
 2. In run conditions like [`on_timer`], to track how much time has run.
 
-## Starting values
+## Starting Values
 
-`Local` system params are always initialized with a default value.
+`Local` system parameters are always initialized with a default value.
 This value is set by either the [`FromWorld`] trait or the [`Default`] trait.
 The [`FromWorld`] trait allows you to access arbitrary data from the world, allowing more complex initialization.
 

--- a/content/learn/book/storing-data/queries.md
+++ b/content/learn/book/storing-data/queries.md
@@ -22,10 +22,10 @@ The [`Query<D, F>`] type has two [generic type parameters]:
 - `F`, which must implement the [`QueryFilter`] trait.
 
 `D` describes _"which data should I access"_, while `F` describes _"how should I restrict the returned entities"_.
-Only entities which match _all_ of the terms in `D` _and_ `F` will be included in your query.
+Only entities which match _all_ the terms in `D` _and_ `F` will be included in your query.
 
 When we write `Query<&Life, With<Player>>`, we're supplying these generics, setting `D` to `&Life` and `F` to `With<Player>`, separated by a comma.
-Bevy uses the information in the [`QueryData`] and [`QueryFilter`] traits (along with the [`WorldQuery`] supertrait) to look up components of the correct type in the world and supply them to your system via [dependency injection].
+Bevy uses the information in the [`QueryData`] and [`QueryFilter`] traits (along with the [`WorldQuery`] super-trait) to look up components of the correct type in the world and supply them to your system via [dependency injection].
 
 If we don't want to fetch any data, or perform any filtering, we can use `()`, Rust's ["unit type"] in place of `D` or `F`.
 
@@ -44,7 +44,7 @@ To access more than one component at once (or add multiple filters at the same t
 [`QueryFilter`]: https://docs.rs/bevy/latest/bevy/ecs/query/trait.QueryFilter.html
 [`WorldQuery`]: https://docs.rs/bevy/latest/bevy/ecs/query/trait.WorldQuery.html
 
-### Accessing Multiple Components At Once
+### Accessing Multiple Components at Once
 
 Let's say we have three components: `Energy`, `Life`, and `Mana`.
 
@@ -52,7 +52,7 @@ As shown above, we can grab a list of all entities with the `Life` component wit
 But what if we wanted to see the `Life` and `Mana` of our entities at the same time?
 
 We need to somehow communicate that the `D` generic of our `Query` should cover both `&Life` and `&Mana`.
-Bevy uses tuples as the syntax for this, wrapping all of the types that we want to combine in parentheses.
+Bevy uses tuples as the syntax for this, wrapping all the types that we want to combine in parentheses.
 `&Life` becomes `(&Life, &Mana)`, which we slot into the `D` generic to become `Query<(&Life, &Mana)>`.
 
 We can iterate over this query like so:
@@ -96,7 +96,7 @@ Combining multiple terms in your queries like this should be the first tool you 
 
 ### Optional Components
 
-Sometimes, you want to swap from the default "and" logic, where all of the components must be present, to "or" logic, where any of the components can be present. To do so, you can use [`Option`] and a few special types:
+Sometimes, you want to swap from the default "and" logic, where all the components must be present, to "or" logic, where any of the components can be present. To do so, you can use [`Option`] and a few special types:
 
 - `Query<Option<&Life>>`, for an `Option` that contains the component value if present and nothing if it is absent.
 - `Query<AnyOf<(&Life, &Mana)>>` which acts as a wrapper for multiple `Option` `QueryData` types.
@@ -132,7 +132,7 @@ struct Life {
     value: u32,
 }
 
-fn apply_poison(poisoned: Query<&mut Life, With<Poisoned>>) {
+fn apply_poison(mut poisoned: Query<&mut Life, With<Poisoned>>) {
     // The `mut life` tells Rust that we want to mutate the Rust variable
     // and `.iter_mut` tells Bevy that we want to access the query data mutably,
     // rather than downgrading it to a read-only `&Life`
@@ -148,9 +148,9 @@ fn apply_poison(poisoned: Query<&mut Life, With<Poisoned>>) {
 You can include multiple queries within a single system, allowing you to access component data in more flexible ways.
 But, if Bevy is handing out mutable references to component data in safe Rust, how does it ensure that users don't invoke undefined behavior due to the forbidden [mutable aliasing]?
 
-Bevy protects against this by examining the [`Access`] of each of the system params in each systems, then panicking if they could conflict.
+Bevy protects against this by examining the [`Access`] of each of the system parameters in each systems, then panicking if they could conflict.
 
-System params conflict if the data they are accessing overlaps and at least one of the accesses are mutable.
+System parameters conflict if the data they are accessing overlaps and at least one of the accesses are mutable.
 You can avoid this by ensuring that your access is provably disjoint: [`Without`] can be very helpful.
 
 If you run into this you'll be pointed to the [B0002] error page, which has advice on how to fix and avoid this problem.
@@ -179,7 +179,7 @@ While this is talked about in more depth in the chapter on [change detection], i
 
 ## Accessing Data on Specific Entities
 
-While many systems will operate by simply iterating over all of the entities in a query, it is often helpful to look up (and possibly mutate) the data of a specific entity.
+While many systems will operate by simply iterating over every entity in a query, it is often helpful to look up (and possibly mutate) the data of a specific entity.
 
 This is fast and easy to do, using [`Query::get`] and its mutable sibling [`Query::get_mut`].
 These respect the query data and query filters of the query they are called on, making them an extremely powerful tool.
@@ -236,13 +236,13 @@ fn despawn_all_enemies(enemies: Query<Entity, With<Enemy>>, mut commands: Comman
 [`Query::get_mut`]: https://docs.rs/bevy/latest/bevy/ecs/system/struct.Query.html#method.get_mut
 [`Entity`]: https://docs.rs/bevy/latest/bevy/ecs/entity/struct.Entity.html
 
-## Working With Singleton Entities
+## Working with Singleton Entities
 
 From time-to-time, you may find yourself needing queries that only match a single entity.
 This might be a player, the sun, or something more abstract like your camera.
 
 While you could iterate over a query of length one, this can be confusing to read and feel a bit silly.
-To make working with these patterns more comfortable, Bevy provides two tools: [`Query::single`] and the [`Single`] system param.
+To make working with these patterns more comfortable, Bevy provides two tools: [`Query::single`] and the [`Single`] system parameter.
 Let's try writing the same simple system in each of the three ways.
 
 ```rust,hide_lines=1-2
@@ -262,7 +262,7 @@ fn kill_player_when_dead_query_iter(player_query: Query<(Entity, &Life), With<Pl
 }
 
 fn kill_player_when_dead_query_single(player_query: Query<(Entity, &Life), With<Player>>, mut commands: Commands) {
-    let Ok((player_entity, player_life)) = player.single() else {
+    let Ok((player_entity, player_life)) = player_query.single() else {
         // We could instead use the ? operator and return an error;
         // see the error handling chapter        
         return;
@@ -297,7 +297,7 @@ Similarly, see the [resources] chapter of this book for a discussion on the choi
 [`QuerySingleError`]: https://docs.rs/bevy/latest/bevy/ecs/query/enum.QuerySingleError.html
 [`Single`]: https://docs.rs/bevy/latest/bevy/ecs/system/struct.Single.html
 
-## Accessing Multiple Items From The Same Query
+## Accessing Multiple Items from the Same Query
 
 By contrast, you may have a query and need to access multiple items from it at once.
 The obvious method is to simply call [`Query::get`] multiple times on it.
@@ -308,7 +308,7 @@ To help with this, Bevy offers two particularly helpful methods on [`Query`]:
 
 - [`Query::get_many_mut`]: Fetch multiple entities by their [`Entity`] ids, which must be unique.
   - Helpful for things like collisions.
-- [`Query::iter_combinations_mut`]: Iterate over all pairs, triples or so on of query items.
+- [`Query::iter_combinations_mut`]: Iterate over every pair, triple, or so on of query items.
   - Great for gravity simulations!
 
 [`Query::get_many_mut`]: https://docs.rs/bevy/latest/bevy/ecs/system/struct.Query.html#method.get_many_mut
@@ -322,7 +322,7 @@ While simply setting its [`Visibility`] can work well, it won't stop any gamepla
 
 Bevy offers a [`Disabled`] component which works by hiding entities with this component from queries unless the [`Disabled`] component is explicitly permitted (such as via [`With`], [`Has`] or [`Allow`]).
 
-This acts as a [default query filter], adding an overridable filter to each query.
+This acts as a [default query filter], adding an override-able filter to each query.
 You can even add your own disabling components, which can be helpful if you want to assign a specific meaning for _why_ entities are disabled.
 
 [default query filter]: https://docs.rs/bevy/latest/bevy/ecs/entity_disabling/struct.DefaultQueryFilters.html
@@ -332,7 +332,7 @@ You can even add your own disabling components, which can be helpful if you want
 [`Has`]: https://docs.rs/bevy/latest/bevy/ecs/query/struct.Has.html
 [`Allow`]: https://docs.rs/bevy/latest/bevy/ecs/query/struct.Allow.html
 
-## Working With Complex Queries
+## Working with Complex Queries
 
 In real projects, queries can get quite complex!
 As a result, Bevy users tend to disable [`clippy`'s `type_complexity` lint] altogether.

--- a/content/learn/book/storing-data/relations.md
+++ b/content/learn/book/storing-data/relations.md
@@ -17,7 +17,7 @@ This has numerous potential uses:
 
 There is one particular type of relation that gets used a lot in Bevy: the [`ChildOf`] relation.
 This is a [`Component`] which is inserted into a child entity, holding a reference to the child's parent entity.
-The parent has a corresponding [`Children`] component which contains a reference to all of the parent's children.
+The parent has a linked [`Children`] component which contains a reference to all the parent's children.
 
 Like all relations, the `ChildOf` / `Children` relation is dual-ended and directed, with separate components maintaining each end of the relationship.
 It represents a "one-to-many" relationship, with the parent being the one, and the children being the many.
@@ -34,13 +34,15 @@ It represents a "one-to-many" relationship, with the parent being the one, and t
 fn spawn_entity_with_children(mut commands: Commands) {
     // Spawn a car
     let vehicle = commands.spawn((Camaro, Color::Red)).id();
+    
     // Spawn 4 wheels and attach to the car
-    commands.entity(vehicle).add_children(&[
+    let wheels: Vec<Entity> = [
         commands.spawn((Wheel, Color::Black)).id(),
         commands.spawn((Wheel, Color::Black)).id(),
         commands.spawn((Wheel, Color::Black)).id(),
         commands.spawn((Wheel, Color::Black)).id(),
-    ]);
+    ];
+    commands.entity(vehicle).add_children(&wheels);
 
     // You can also use `with_children`:
     commands.entity(vehicle).with_children(|parent| {
@@ -52,7 +54,7 @@ fn spawn_entity_with_children(mut commands: Commands) {
 Note that `add_children` and `with_children` only set up the `ChildOf` and `Children` components, and nothing else.
 If you want any other components, you'll need to add them yourself.
 
-The `ChildOf` relation uses the [`linked_spawn`] option, which means that when a parent is despawned, it's children (and their children, and so on) are also despawned automatically.
+The `ChildOf` relation uses the [`linked_spawn`] option, which means that when a parent is despawned, its children (and their children, and so on) are also despawned automatically.
 
 ```rs
 fn despawn_vehicle(mut commands: Commands, vehicle: Entity) {
@@ -211,7 +213,7 @@ Similarly, `ContainedBy` makes it clear that this is an item in a container, not
 {% end %}
 
 Now that we've defined our new relation, we can start using it!
-Remember in the previous sections all of the various methods for adding children?
+Remember the various methods for adding children in the previous sections?
 Well, those methods are just special cases of more general ones.
 Instead of `add_children()`, you could use `add_related::<ContainedBy>()`, and instead of `Children::spawn()` you can call `Contents::spawn()`.
 
@@ -219,7 +221,7 @@ Instead of `add_children()`, you could use `add_related::<ContainedBy>()`, and i
 
 As your game develops further, you might find that there are cases where you want a relationship between an `Entity` and _itself_.
 Maybe your game is inspired by JRPGs and you want to include the player's character in a custom `Party` relationship collection, or perhaps the enemy boss should include themselves in a `EnemyCombatants` relationship collection.
-However you wish to implement it, including an `Entity` in a relationship collection that the same `Entity` owns can potentially help simplify the logic required to build your game.
+However, you wish to implement it, including an `Entity` in a relationship collection that the same `Entity` owns can potentially help simplify the logic required to build your game.
 
 However, Bevy does not allow this by default: attempting to create a relationship between an `Entity` and itself will simply remove the relationship component from the `Entity` and a warning will be logged.
 To get around the default behavior, we have to include the `allow_self_referential` attribute when defining our relationship struct:

--- a/content/learn/book/storing-data/resources.md
+++ b/content/learn/book/storing-data/resources.md
@@ -121,7 +121,7 @@ fn setup_audio_settings(world: &mut World) {
 **Caution**
 
 Use care when accessing resources which may not exist.
-Attempting to inject a non-existent resource using [`Res`] or [`ResMut`] will cause a panic.
+Attempting to inject a nonexistent resource using [`Res`] or [`ResMut`] will cause a panic.
 You can avoid this by wrapping the resource in `Option`:
 
 ```rs
@@ -137,14 +137,14 @@ fn audio_settings_system(settings_res: Option<Res<AudioSettings>>) {
 
 {% end %}
 
-## Resources vs Singleton Entities
+## Resources Vs Singleton Entities
 
 Not every singleton object has to be stored as a resource, and in some cases you may not want to.
 Any data that is storable in a resource could instead be stored as a component on a singleton entity.
 Which approach is better is a design question that depends on a number of tradeoffs.
 
 The advantages of resources is simplicity and ease of use: it requires very little code to read or write data stored in a resource.
-Accessing data within a component is more involved, and entails a multi-step process where you first have to get access to the entity, and then its components.
+Accessing data within a component is more involved, and entails a multistep process where you first have to get access to the entity, and then its components.
 Often this will involve writing a query.
 
 Resources make sense when the data is _truly_ singular and _always will be_ singular.
@@ -157,7 +157,7 @@ Your single-player game only supports one game controller _now_, but what if you
 Then you'll need more than one gamepad.
 
 An object also can't be a resource if it is going to be a part of a bigger collection at any point.
-For example, lets say a game has a `PlayerAvatar` struct representing the object that the player controls and moves.
+For example, let's say a game has a `PlayerAvatar` struct representing the object that the player controls and moves.
 If `PlayerAvatar` needs to be rendered and simulated using common ECS systems, it can't be a resource as it's a part of a larger collection and therefore isn't unique.
 
 Finally, a resource can only be a single `struct` or `enum`.

--- a/content/learn/book/storing-data/world.md
+++ b/content/learn/book/storing-data/world.md
@@ -6,7 +6,7 @@ weight = 3
 +++
 
 The [`World`] is a catch-all container for *stuff*.
-Entities, components, resources, assets -- all of these exist within a world.
+Entities, components, resources, assets – all of these exist within a world.
 It's where your data lives.
 
 ## The World as a Database

--- a/content/learn/book/the-game-loop/app.md
+++ b/content/learn/book/the-game-loop/app.md
@@ -16,7 +16,7 @@ You can think of an `App` as containing three things:
 + A run-loop function, to execute [schedules].
 + A set of [plugins], which are important enough to deserve their own section.
 
-Most app configuration -- registering systems, etc. -- boils down to modifying the world.
+Most app configuration (registering systems, etc.) boils down to modifying the world.
 To simplify this, [`App`] proxies most of the [`World`] API.
 The world can also be accessed directly via [`App::world_mut`].
 

--- a/content/learn/book/the-game-loop/game-time.md
+++ b/content/learn/book/the-game-loop/game-time.md
@@ -5,7 +5,7 @@ insert_anchor_links = "right"
 weight = 5
 +++
 
-Responding to the passage of time is essential for gameplay, animations and audio.
+Responding to the passage of time is essential for gameplay, animations, and audio.
 But doing so correctly is surprisingly subtle.
 
 The [`Time`] resource in Bevy is the source of truth
@@ -17,7 +17,7 @@ set at the start of the frame based on the time supplied by the renderer
 during the [`TimeSystem`] system set in the [`First`] schedule.
 
 This is helpful for performance reasons, but more critically,
-it ensures consistency of behavior across all of the various bits of game logic.
+it ensures consistency of behavior across all the various bits of game logic.
 
 {% callout(type="info") %}
 
@@ -38,7 +38,7 @@ If you'd like to read about these tools, please see the [Time Controls page] loc
 [`TimeSystem`]: https://docs.rs/bevy/latest/bevy/time/struct.TimeSystem.html
 [`First`]: https://docs.rs/bevy/latest/bevy/app/struct.First.html
 
-## Frame-rate independence and delta time
+## Frame-Rate Independence and Delta Time
 
 Suppose we want to move our player to the right:
 
@@ -61,7 +61,7 @@ fn move_player(mut player_transform: Single<&mut Transform, With<Player>>){
 Every frame, our player will move 1 unit to the right. Great!
 But what happens when our game stutters, and the frame rate drops?
 Suddenly, rather than moving 60 units per second at our target 60 frames per second,
-our player is moving at an unsteady 20-30 units per second. Oh no!
+our player is moving at an unsteady 20–30 units per second. Oh no!
 
 Instead, we can compensate for this effect by fixing our _speed_ (or other rates of change per second),
 and then multiplying by the elapsed time.
@@ -84,7 +84,7 @@ This technique is commonly known as ["delta time"] among game devs, because phys
 
 ["delta time"]: https://en.wikipedia.org/wiki/Delta_timing
 
-## Pausing and time control
+## Pausing and Time Control
 
 With all of our time-dependent logic driven by the delta time,
 we can start playing tricks with the value of [`Time`] to implement features like pausing and slowing down the game.
@@ -110,13 +110,13 @@ fn set_game_speed(new_speed: On<SetGameSpeed>, mut time: ResMut<Time<Virtual>>) 
 ```
 
 If your systems uniformly rely on [`Time`], this will affect your entire game:
-halting, slowing or speeding up animations, movement, projectiles, physics and so on.
+halting, slowing, or speeding up animations, movement, projectiles, physics, and so on.
 Alternatively, [states] and [run conditions] can be used to skip systems while the game is paused.
 
 [states]: @/learn/book/control-flow/states.md
 [run conditions]: @/learn/book/control-flow/run-conditions.md
 
-## Fixing your timestep
+## Fixing Your Timestep
 
 Compensating for fluctuating frame times using delta time is a great start.
 But as the timeless [*Fix Your Timestep!*] article by Glenn Fiedler explains, for projects that require a higher level of stability and reproducibility,
@@ -126,13 +126,13 @@ This is particularly important for physics and networking.
 To understand how to work with fixed time in Bevy, we need to first learn a little bit about how [`Time`] actually works under the hood.
 As the docs on [`Time`] explain, there's actually _three_ distinct types of time being measured:
 
-- real time: the actual wall clock time
-  - use this for things like UI animations that you don't want to be affected by pausing
-- virtual time: the "in-game time"
-  - if you're using fixed time, this is useful for graphical effects
-  - otherwise, this is used for all of your gameplay logic as well
-- fixed time
-  - all of your gameplay logic should go here if you're using a fixed timestep approach
+- Real time: the actual wall clock time.
+  - Use this for things like UI animations that you don't want to be affected by pausing.
+- Virtual time: the "in-game time".
+  - If you're using fixed time, this is useful for graphical effects.
+  - Otherwise, this is used for all of your gameplay logic as well.
+- Fixed time
+  - All of your gameplay logic should go here if you're using a fixed timestep approach.
 
 When thinking about fixed time, it's important to clearly distinguish **frames** and **ticks**.
 A "frame" is one pass of the [`Main`] schedule, and corresponds to a single rendered frames.
@@ -157,11 +157,11 @@ to [`Real`], [`Virtual`] or [`Fixed`].
 
 Now that we have the required vocabulary, let's go over exactly how the fixed timestep logic works in Bevy:
 
-- each frame, during the [`RunFixedMainLoop`] schedule, we determine how many times we should run the [`FixedMain`] schedule
-  - we add the the elapsed virtual time for the frame to a running time buffer
-  - if that time buffer is greater than or equal to [`Time<Fixed>::timestep`], we run the [`FixedMain`] schedule once, and subtract that timestep from our buffer
-- when the [`FixedMain`] schedule is evaluated, the various subschedules are iterated through, running [`FixedPreUpdate`], [`FixedUpdate`] and so on in order
-- within your fixed time systems, use the exact same delta time techniques to properly account for changes in your desired timestep during development
+- Each frame, during the [`RunFixedMainLoop`] schedule, we determine how many times we should run the [`FixedMain`] schedule.
+  - We add the elapsed virtual time for the frame to a running time buffer.
+  - If that time buffer is greater than or equal to [`Time<Fixed>::timestep`], we run the [`FixedMain`] schedule once, and subtract that timestep from our buffer.
+- When the [`FixedMain`] schedule is evaluated, the various sub-schedules are iterated through, running [`FixedPreUpdate`], [`FixedUpdate`] and so on in order.
+- Within your fixed time systems, use the exact same delta time techniques to properly account for changes in your desired timestep during development.
 
 This means that we may have 0, 1, 2 or more ticks per frame,
 with our fixed timestep logic running repeatedly until it's caught back up.
@@ -187,11 +187,11 @@ Please see the [Time Controls page] for the tools available to model this type o
 [*Fix Your Timestep!*]: https://gafferongames.com/post/fix_your_timestep/
 [`RunFixedMainLoop`]: https://docs.rs/bevy/latest/bevy/app/struct.RunFixedMainLoop.html
 
-### Interpolation between ticks
+### Interpolation Between Ticks
 
 One key problem with using a fixed timestep is that your game logic (including physics!) will have an uneven
 number of updates between each frame.
-This will lead to visible jittering, lagginess and tiny speedups.
+This will lead to visible jittering, lag, and tiny speedups.
 
 To account for this, we need to distinguish between the logical and rendered position (and rotation, and sometimes scale) of
 game objects.

--- a/content/learn/book/the-game-loop/schedules.md
+++ b/content/learn/book/the-game-loop/schedules.md
@@ -22,7 +22,7 @@ Now, whenever Bevy runs the `Update` schedule, `move_players` will execute.
 The `Update` schedule is one of many built-in schedules provided by Bevy, each of which runs at a different point.
 Each schedule runs at a different point during the life-cycle of a Bevy app, so by controlling where your system is registered you can also control how it's run.
 
-## The standard Bevy schedules
+## The Standard Bevy Schedules
 
 Let's look at the other schedules provided by Bevy by default.
 When a Bevy [app] starts, it typically executes several schedules in order:
@@ -42,7 +42,7 @@ After the [`PostStartup`] schedule completes, the app shifts into the main game 
 The following schedules are then executed in order each "tick":
 
 1. [`First`]: Logic that needs to run before everything else each tick.
-2. [`PreUpdate`]: Library updates that must proceed application updates.
+2. [`PreUpdate`]: Library updates that must precede application updates.
 3. [`StateTransition`]: Part of Bevy's [state machine abstraction].
 4. The [fixed update loop] may run multiple schedules before progressing.
 5. [`Update`]: Updates for the application itself.
@@ -53,7 +53,7 @@ The following schedules are then executed in order each "tick":
 [`First`] and [`Last`] extend this further, allowing running before and after the majority of other logic.
 Libraries should generally prefer the update schedules unless they have a very good reason to use `First` or `Last`.
 
-## Adding your own schedules
+## Adding Your Own Schedules
 
 This repeating game loop is set up by the [`ScheduleRunnerPlugin`],
 which is included as part of both [`MinimalPlugins`] and [`DefaultPlugins`].


### PR DESCRIPTION
A long, varied list of fixes for content in the book. This covers code syntax, grammar, spelling, and link fixes. There are no major structural or content changes.

The syntax and link fixes were brought up by @viridia and documented in [this hack.md doc](https://hackmd.io/CGhAv1HQToexPBi8zdDS4Q?view#4-Code-samples-that-dont-compile-%E2%AC%9C-largest-remaining-item), which was generated by Claude. The implementation and fixes were done by hand by myself while referencing the docs.rs and other examples in the engine repo.

The spelling and grammar fixes were done by hand by me as well, however I used [Harper](https://writewithharper.com/) to view and correct them.