### PR TITLE
Update "Manufact" to "Design Once" (we just did a rebrand)

### DIFF
--- a/content/news/2026-08-10-bevys-sixth-birthday/index.md
+++ b/content/news/2026-08-10-bevys-sixth-birthday/index.md
@@ -213,7 +213,7 @@ This year we had a ton of new Bevy usage, with some exciting Steam releases, dem
 - [Willcaster](https://store.steampowered.com/app/4953880/Willcaster/): a game where you guide an ordinary frog on your magical game board, helping him with your spells, was announced on Steam.
 - [Unhaunter](https://www.unhaunter.com/): the paranormal investigation simulator, made a lot of progress this year.
 - [One Planet](https://store.steampowered.com/app/2348960/One_Planet/): a political strategy game where you take on climate change, was announced on Steam.
-- [Manufact](https://manufact.au/): a "design for manufacture" and simulation platform, was released. It uses Bevy as the renderer!
+- [Design Once](https://www.designonce.ai/): a "design for manufacture" and simulation platform, was released. It uses Bevy as the renderer!
 
 [bevy_awesome_prod](https://github.com/Vrixyz/bevy_awesome_prod/) has even more cool projects!
 


### PR DESCRIPTION
Hey guys, thanks for including us your birthday post :heart:

Tiny PR here, we've just this week done a rebrand to "Design Once" (you'll find [manufact.au](https://manufact.au) redirects to [designonce.ai](https://designonce.ai)), we noticed some referrals from bevy.org in our analytics so figure we should probably update the name/link here.

### BTW

Anyone can create an account and take a look at our demo projects if they want to try out what we've done with bevy first-hand. (go straight to [app.designonce.ai](https://app.designonce.ai) and create an account) 

Let me know if you'd like me to update the copy to mention that as part of this PR (since it's not obvious from our landing page)