### PR TITLE
Fix syntax theme's "orange everywhere" and highlight "self" keyword

### DIFF
--- a/themes/bevy-syntax-theme-dark.json
+++ b/themes/bevy-syntax-theme-dark.json
@@ -82,7 +82,7 @@
 		{
 			"scope": "variable.language.self.rust",
 			"settings": {
-				"foreground": "#c594c5"
+				"foreground": "#C594C5"
 			}
 		},
 		{
@@ -2003,7 +2003,7 @@
 		{
 			"scope": "punctuation.brackets.round.rust",
 			"settings": {
-				"foreground": "#abb2bf"
+				"foreground": "#ABB2BF"
 			}
 		},
 		{

--- a/themes/bevy-syntax-theme-dark.json
+++ b/themes/bevy-syntax-theme-dark.json
@@ -80,6 +80,12 @@
 			}
 		},
 		{
+			"scope": "variable.language.self.rust",
+			"settings": {
+				"foreground": "#c594c5"
+			}
+		},
+		{
 			"scope": "support.constant.edge",
 			"settings": {
 				"foreground": "#C678DD"
@@ -1869,7 +1875,7 @@
 			}
 		},
 		{
-			"scope": "meta.attribute.rust, meta.interpolation.rust",
+			"scope": "meta.attribute.rust punctuation.brackets.round.rust",
 			"settings": {
 				"foreground": "#D19A66"
 			}
@@ -1935,19 +1941,13 @@
 			}
 		},
 		{
-			"scope": "variable.language.self.rust",
-			"settings": {
-				"foreground": "#C0C5CE"
-			}
-		},
-		{
 			"scope": "punctuation.brackets.angle.rust,  punctuation.comma.rust, punctuation.semi.rust",
 			"settings": {
 				"foreground": "#C0C5CE"
 			}
 		},
 		{
-			"scope": "punctuation.brackets.attribute.rust, punctuation.brackets.round.rust, punctuation.definition.interpolation.rust",
+			"scope": "punctuation.brackets.attribute.rust, punctuation.definition.interpolation.rust",
 			"settings": {
 				"foreground": "#D19A66"
 			}
@@ -1998,6 +1998,18 @@
 			"scope": "support.type.property-name.toml",
 			"settings": {
 				"foreground": "#E06C75"
+			}
+		},
+		{
+			"scope": "punctuation.brackets.round.rust",
+			"settings": {
+				"foreground": "#abb2bf"
+			}
+		},
+		{
+			"scope": "meta.attribute.rust, meta.interpolation.rust",
+			"settings": {
+				"foreground": "#D19A66"
 			}
 		}
 	]

--- a/themes/bevy-syntax-theme-dark.json
+++ b/themes/bevy-syntax-theme-dark.json
@@ -1875,7 +1875,7 @@
 			}
 		},
 		{
-			"scope": "meta.attribute.rust punctuation.brackets.round.rust",
+			"scope": "meta.attribute.rust, meta.interpolation.rust, meta.attribute.rust punctuation.brackets.round.rust",
 			"settings": {
 				"foreground": "#D19A66"
 			}
@@ -2004,12 +2004,6 @@
 			"scope": "punctuation.brackets.round.rust",
 			"settings": {
 				"foreground": "#ABB2BF"
-			}
-		},
-		{
-			"scope": "meta.attribute.rust, meta.interpolation.rust",
-			"settings": {
-				"foreground": "#D19A66"
 			}
 		}
 	]


### PR DESCRIPTION
This was really bothering me :)

## Before

<img width="688" height="877" alt="image" src="https://github.com/user-attachments/assets/617a2484-b9c9-42db-8282-05eab106a271" />

## After

<img width="688" height="877" alt="after" src="https://github.com/user-attachments/assets/916a7d5f-79a5-4708-928c-06a087f14436" />
